### PR TITLE
Add Lua language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Works with any mix of file types:
 
 | Type | Extensions | Extraction |
 |------|-----------|------------|
-| Code | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php` | AST via tree-sitter + call-graph + docstring/comment rationale |
+| Code | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php .lua` | AST via tree-sitter + call-graph + docstring/comment rationale |
 | Docs | `.md .txt .rst` | Concepts + relationships + design rationale via Claude |
 | Papers | `.pdf` | Citation mining + concept extraction |
 | Images | `.png .jpg .webp .gif` | Claude vision - screenshots, diagrams, any language |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -16,7 +16,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc'}
 DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -527,6 +527,43 @@ _PHP_CONFIG = LanguageConfig(
 )
 
 
+def _import_lua(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
+    """Extract require('module') from Lua variable_declaration nodes."""
+    text = _read_text(node, source)
+    import re
+    m = re.search(r"""require\s*[\('"]\s*['"]?([^'")\s]+)""", text)
+    if m:
+        module_name = m.group(1).split(".")[-1]
+        if module_name:
+            edges.append({
+                "source": file_nid,
+                "target": module_name,
+                "relation": "imports",
+                "confidence": "EXTRACTED",
+                "confidence_score": 1.0,
+                "source_file": str_path,
+                "source_location": str(node.start_point[0] + 1),
+                "weight": 1.0,
+            })
+
+
+_LUA_CONFIG = LanguageConfig(
+    ts_module="tree_sitter_lua",
+    ts_language_fn="language",
+    class_types=frozenset(),
+    function_types=frozenset({"function_declaration"}),
+    import_types=frozenset({"variable_declaration"}),
+    call_types=frozenset({"function_call"}),
+    call_function_field="name",
+    call_accessor_node_types=frozenset({"method_index_expression"}),
+    call_accessor_field="name",
+    name_fallback_child_types=("identifier", "method_index_expression"),
+    body_fallback_child_types=("block",),
+    function_boundary_types=frozenset({"function_declaration"}),
+    import_handler=_import_lua,
+)
+
+
 # ── Generic extractor ─────────────────────────────────────────────────────────
 
 def _extract_generic(path: Path, config: LanguageConfig) -> dict:
@@ -982,6 +1019,11 @@ def extract_scala(path: Path) -> dict:
 def extract_php(path: Path) -> dict:
     """Extract classes, functions, methods, namespace uses, and calls from a .php file."""
     return _extract_generic(path, _PHP_CONFIG)
+
+
+def extract_lua(path: Path) -> dict:
+    """Extract functions, methods, require() imports, and calls from a .lua file."""
+    return _extract_generic(path, _LUA_CONFIG)
 
 
 # ── Go extractor (custom walk) ────────────────────────────────────────────────
@@ -1523,6 +1565,8 @@ def extract(paths: list[Path]) -> dict:
         ".kts": extract_kotlin,
         ".scala": extract_scala,
         ".php": extract_php,
+        ".lua": extract_lua,
+        ".toc": extract_lua,
     }
 
     for path in paths:

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -702,7 +702,7 @@ import json
 from pathlib import Path
 
 result = json.loads(open('.graphify_incremental.json').read()) if Path('.graphify_incremental.json').exists() else {}
-code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts'}
+code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.lua','.toc','.cc','.cxx','.hpp','.h','.kts'}
 new_files = result.get('new_files', {})
 all_changed = [f for files in new_files.values() for f in files]
 code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tree-sitter-kotlin",
     "tree-sitter-scala",
     "tree-sitter-php",
+    "tree-sitter-lua",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Adds `.lua` and `.toc` to `CODE_EXTENSIONS` in `detect.py`
- Adds `_LUA_CONFIG` LanguageConfig and `extract_lua()` in `extract.py`
- Handles Lua-specific patterns: `local function`, `function Addon:Method()`, `require('module')`
- Adds `tree-sitter-lua` to `pyproject.toml` dependencies
- Updates README language table and skill.md code extensions

## Motivation

Lua is the scripting language for World of Warcraft addons, Roblox, Neovim plugins, and game engines (Love2D, Defold). `tree-sitter-lua` is mature (v0.5.0 on PyPI) and the generic extractor handles Lua well since functions use a `name` field and `block` body consistently.

## Test plan

- [x] Tested on a 27-file WoW addon codebase (mixed local functions, method syntax, require imports)
- [x] Verified function declarations, method patterns (`Addon:Method`), require() imports, and call-graph extraction
- [x] Confirmed `.toc` files (WoW addon manifests) are detected as code