### PR TITLE
Add Nimble web intelligence for URL extraction and topic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ Install with the `nimble` extra to power web extraction and topic-based ingestio
 
 ```bash
 pip install graphifyy[nimble]
+export NIMBLE_API_KEY=YOUR_API_KEY_HERE
 ```
+
+Get your API credentials from [Nimble's dashboard](https://online.nimbleway.com/account-settings/api-keys) (free trial available) and set as an environment variable.
 
 **Nimble Extract** — `/graphify add <url>` gets clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. No scraping hassle.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ When the user types `/graphify`, invoke the Skill tool with `skill: "graphify"` 
 /graphify add https://x.com/karpathy/status/...       # fetch a tweet
 /graphify add https://... --author "Name"             # tag the original author
 /graphify add https://... --contributor "Name"        # tag who added it to the corpus
+/graphify ingest-topic "transformer architectures"    # search web, save results, update graph
+/graphify ingest-topic "attention mechanisms" --max-results 5  # limit results (default 10)
 
 /graphify query "what connects attention to the optimizer?"
 /graphify query "what connects attention to the optimizer?" --dfs   # trace a specific path
@@ -152,6 +154,24 @@ Works with any mix of file types:
 | Docs | `.md .txt .rst` | Concepts + relationships + design rationale via Claude |
 | Papers | `.pdf` | Citation mining + concept extraction |
 | Images | `.png .jpg .webp .gif` | Claude vision - screenshots, diagrams, any language |
+
+## Web ingestion (optional)
+
+Install with the `nimble` extra to power web extraction and topic-based ingestion with [Nimble](https://nimbleway.com) — real-time web intelligence that turns any public webpage into clean, structured data:
+
+```bash
+pip install graphifyy[nimble]
+```
+
+**Nimble Extract** — `/graphify add <url>` gets clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. No scraping hassle.
+
+**Nimble Search** — `/graphify ingest-topic "transformer architectures"` searches the live web to retrieve precise information, saves the results as markdown files in your corpus, and updates the graph. Uses deep extraction for full page content, not just snippets.
+
+```
+/graphify ingest-topic "attention mechanisms" --max-results 5
+```
+
+Without the `nimble` extra, `/graphify add` uses the built-in urllib path. `/graphify ingest-topic` requires Nimble.
 
 ## What you get
 

--- a/graphify/ingest.py
+++ b/graphify/ingest.py
@@ -1,4 +1,7 @@
 # fetch URLs (tweet/arxiv/pdf/web) and save as annotated markdown
+# When nimble_python is installed, powered by Nimble (nimbleway.com) for
+# real-time web intelligence with stealth unblocking and JS rendering.
+# Uses built-in urllib as an alternative path.
 from __future__ import annotations
 import json
 import re
@@ -8,6 +11,33 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from graphify.security import safe_fetch, safe_fetch_text, validate_url
+
+# ---------------------------------------------------------------------------
+# Nimble availability
+# ---------------------------------------------------------------------------
+
+try:
+    from nimble_python import Nimble
+
+    _HAS_NIMBLE = True
+except ImportError:
+    _HAS_NIMBLE = False
+
+
+_nimble_cached: "Nimble | None" = None
+
+
+def _nimble_client() -> "Nimble":
+    """Return a cached Nimble client. Requires NIMBLE_API_KEY env var."""
+    global _nimble_cached
+    if _nimble_cached is None:
+        _nimble_cached = Nimble()
+    return _nimble_cached
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _yaml_str(s: str) -> str:
@@ -44,11 +74,40 @@ def _detect_url_type(url: str) -> str:
     return "webpage"
 
 
+def _write_unique(target_dir: Path, filename: str, content: str) -> Path:
+    """Write content to target_dir/filename, appending a counter if it exists."""
+    out_path = target_dir / filename
+    counter = 1
+    while out_path.exists():
+        stem = Path(filename).stem
+        out_path = target_dir / f"{stem}_{counter}.md"
+        counter += 1
+    out_path.write_text(content, encoding="utf-8")
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Nimble-powered extraction
+# ---------------------------------------------------------------------------
+
+
+def _nimble_extract_markdown(url: str) -> str:
+    """Use Nimble Extract to fetch a URL and return markdown content."""
+    client = _nimble_client()
+    response = client.extract(url=url, render=True, formats=["markdown"])
+    return response.data.markdown or ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in urllib fetching
+# ---------------------------------------------------------------------------
+
+
 def _fetch_html(url: str) -> str:
     return safe_fetch_text(url)
 
 
-def _html_to_markdown(html: str, url: str) -> str:
+def _html_to_markdown(html_str: str, url: str) -> str:
     """Convert HTML to clean markdown. Uses html2text if available, else basic strip."""
     try:
         import html2text
@@ -56,29 +115,46 @@ def _html_to_markdown(html: str, url: str) -> str:
         h.ignore_links = False
         h.ignore_images = True
         h.body_width = 0
-        return h.handle(html)
+        return h.handle(html_str)
     except ImportError:
         # Fallback: strip tags
-        text = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r"<script[^>]*>.*?</script>", "", html_str, flags=re.DOTALL | re.IGNORECASE)
         text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL | re.IGNORECASE)
         text = re.sub(r"<[^>]+>", " ", text)
         text = re.sub(r"\s+", " ", text).strip()
         return text[:8000]
 
 
+# ---------------------------------------------------------------------------
+# Fetchers (Nimble when available, urllib as alternative)
+# ---------------------------------------------------------------------------
+
+
 def _fetch_tweet(url: str, author: str | None, contributor: str | None) -> tuple[str, str]:
     """Fetch a tweet URL. Returns (content, filename)."""
-    # Normalize to twitter.com for oEmbed
-    oembed_url = url.replace("x.com", "twitter.com")
-    oembed_api = f"https://publish.twitter.com/oembed?url={urllib.parse.quote(oembed_url)}&omit_script=true"
-    try:
-        data = json.loads(safe_fetch_text(oembed_api))
-        tweet_text = re.sub(r"<[^>]+>", "", data.get("html", "")).strip()
-        tweet_author = data.get("author_name", "unknown")
-    except Exception:
-        # oEmbed failed - save URL stub
-        tweet_text = f"Tweet at {url} (could not fetch content)"
-        tweet_author = "unknown"
+    if _HAS_NIMBLE:
+        try:
+            markdown = _nimble_extract_markdown(url)
+            tweet_text = markdown.strip() or f"Tweet at {url} (could not fetch content)"
+            tweet_author = "unknown"
+            # Try to extract author from the markdown
+            author_match = re.search(r"@(\w+)", markdown)
+            if author_match:
+                tweet_author = author_match.group(1)
+        except Exception:
+            tweet_text = f"Tweet at {url} (could not fetch content)"
+            tweet_author = "unknown"
+    else:
+        # Alternative: oEmbed
+        oembed_url = url.replace("x.com", "twitter.com")
+        oembed_api = f"https://publish.twitter.com/oembed?url={urllib.parse.quote(oembed_url)}&omit_script=true"
+        try:
+            data = json.loads(safe_fetch_text(oembed_api))
+            tweet_text = re.sub(r"<[^>]+>", "", data.get("html", "")).strip()
+            tweet_author = data.get("author_name", "unknown")
+        except Exception:
+            tweet_text = f"Tweet at {url} (could not fetch content)"
+            tweet_author = "unknown"
 
     now = datetime.now(timezone.utc).isoformat()
     content = f"""---
@@ -99,14 +175,27 @@ Source: {url}
     return content, filename
 
 
+def _fetch_webpage_urllib(url: str) -> tuple[str, str]:
+    """Fetch webpage via urllib and return (title, markdown)."""
+    html_str = _fetch_html(url)
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", html_str, re.IGNORECASE | re.DOTALL)
+    title = re.sub(r"\s+", " ", title_match.group(1)).strip() if title_match else url
+    markdown = _html_to_markdown(html_str, url)
+    return title, markdown
+
+
 def _fetch_webpage(url: str, author: str | None, contributor: str | None) -> tuple[str, str]:
     """Fetch a generic webpage and convert to markdown."""
-    html = _fetch_html(url)
-    # Extract title
-    title_match = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
-    title = re.sub(r"\s+", " ", title_match.group(1)).strip() if title_match else url
+    if _HAS_NIMBLE:
+        try:
+            markdown = _nimble_extract_markdown(url)
+            title_match = re.search(r"^#\s+(.+)$", markdown, re.MULTILINE)
+            title = title_match.group(1).strip() if title_match else url
+        except Exception:
+            title, markdown = _fetch_webpage_urllib(url)
+    else:
+        title, markdown = _fetch_webpage_urllib(url)
 
-    markdown = _html_to_markdown(html, url)
     now = datetime.now(timezone.utc).isoformat()
     content = f"""---
 source_url: {url}
@@ -130,27 +219,43 @@ Source: {url}
 
 def _fetch_arxiv(url: str, author: str | None, contributor: str | None) -> tuple[str, str]:
     """Fetch arXiv abstract page."""
-    # Convert /abs/ or /pdf/ to abs for the API
     arxiv_id = re.search(r"(\d{4}\.\d{4,5})", url)
-    if arxiv_id:
-        api_url = f"https://export.arxiv.org/abs/{arxiv_id.group(1)}"
+    if not arxiv_id:
+        return _fetch_webpage(url, author, contributor)
+
+    if _HAS_NIMBLE:
         try:
-            html = _fetch_html(api_url)
-            abstract_match = re.search(r'class="abstract[^"]*"[^>]*>(.*?)</blockquote>', html, re.DOTALL | re.IGNORECASE)
-            abstract = re.sub(r"<[^>]+>", "", abstract_match.group(1)).strip() if abstract_match else ""
-            title_match = re.search(r'class="title[^"]*"[^>]*>(.*?)</h1>', html, re.DOTALL | re.IGNORECASE)
-            title = re.sub(r"<[^>]+>", " ", title_match.group(1)).strip() if title_match else arxiv_id.group(1)
-            authors_match = re.search(r'class="authors"[^>]*>(.*?)</div>', html, re.DOTALL | re.IGNORECASE)
-            paper_authors = re.sub(r"<[^>]+>", "", authors_match.group(1)).strip() if authors_match else ""
+            abs_url = f"https://arxiv.org/abs/{arxiv_id.group(1)}"
+            markdown = _nimble_extract_markdown(abs_url)
+            # Try to extract structured info from markdown
+            title_match = re.search(r"^#\s+(.+)$", markdown, re.MULTILINE)
+            title = title_match.group(1).strip() if title_match else arxiv_id.group(1)
+            # Look for abstract section
+            abstract_match = re.search(r"(?:Abstract|abstract)[:\s]*\n(.*?)(?:\n#|\n\n\n|\Z)", markdown, re.DOTALL)
+            abstract = abstract_match.group(1).strip() if abstract_match else ""
+            paper_authors = ""
+            authors_match = re.search(r"(?:Authors?|By)[:\s]*(.+?)(?:\n#|\n\n)", markdown, re.DOTALL)
+            if authors_match:
+                paper_authors = authors_match.group(1).strip()
         except Exception:
             title, abstract, paper_authors = arxiv_id.group(1), "", ""
     else:
-        return _fetch_webpage(url, author, contributor)
+        api_url = f"https://export.arxiv.org/abs/{arxiv_id.group(1)}"
+        try:
+            html_str = _fetch_html(api_url)
+            abstract_match = re.search(r'class="abstract[^"]*"[^>]*>(.*?)</blockquote>', html_str, re.DOTALL | re.IGNORECASE)
+            abstract = re.sub(r"<[^>]+>", "", abstract_match.group(1)).strip() if abstract_match else ""
+            title_match = re.search(r'class="title[^"]*"[^>]*>(.*?)</h1>', html_str, re.DOTALL | re.IGNORECASE)
+            title = re.sub(r"<[^>]+>", " ", title_match.group(1)).strip() if title_match else arxiv_id.group(1)
+            authors_match = re.search(r'class="authors"[^>]*>(.*?)</div>', html_str, re.DOTALL | re.IGNORECASE)
+            paper_authors = re.sub(r"<[^>]+>", "", authors_match.group(1)).strip() if authors_match else ""
+        except Exception:
+            title, abstract, paper_authors = arxiv_id.group(1), "", ""
 
     now = datetime.now(timezone.utc).isoformat()
     content = f"""---
 source_url: {url}
-arxiv_id: {arxiv_id.group(1) if arxiv_id else ''}
+arxiv_id: {arxiv_id.group(1)}
 type: paper
 title: "{title}"
 paper_authors: "{paper_authors}"
@@ -161,7 +266,7 @@ contributor: {contributor or author or 'unknown'}
 # {title}
 
 **Authors:** {paper_authors}
-**arXiv:** {arxiv_id.group(1) if arxiv_id else url}
+**arXiv:** {arxiv_id.group(1)}
 
 ## Abstract
 
@@ -169,7 +274,7 @@ contributor: {contributor or author or 'unknown'}
 
 Source: {url}
 """
-    filename = f"arxiv_{arxiv_id.group(1).replace('.', '_')}.md" if arxiv_id else _safe_filename(url, ".md")
+    filename = f"arxiv_{arxiv_id.group(1).replace('.', '_')}.md"
     return content, filename
 
 
@@ -181,19 +286,28 @@ def _download_binary(url: str, suffix: str, target_dir: Path) -> Path:
     return out_path
 
 
+# ---------------------------------------------------------------------------
+# Main entry points
+# ---------------------------------------------------------------------------
+
+
 def ingest(url: str, target_dir: Path, author: str | None = None, contributor: str | None = None) -> Path:
     """
     Fetch a URL and save it into target_dir as a graphify-ready file.
 
+    When nimble_python is installed, uses Nimble Extract for JS rendering,
+    anti-bot handling, and clean markdown. Uses urllib as an alternative otherwise.
+
     Returns the path of the saved file.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    url_type = _detect_url_type(url)
 
     try:
         validate_url(url)
     except ValueError as exc:
         raise ValueError(f"ingest: {exc}") from exc
+
+    url_type = _detect_url_type(url)
 
     try:
         if url_type == "pdf":
@@ -216,17 +330,85 @@ def ingest(url: str, target_dir: Path, author: str | None = None, contributor: s
     except (urllib.error.HTTPError, urllib.error.URLError, OSError) as exc:
         raise RuntimeError(f"ingest: failed to fetch {url!r}: {exc}") from exc
 
-    out_path = target_dir / filename
-    # Avoid overwriting - append counter if needed
-    counter = 1
-    while out_path.exists():
-        stem = Path(filename).stem
-        out_path = target_dir / f"{stem}_{counter}.md"
-        counter += 1
-
-    out_path.write_text(content, encoding="utf-8")
-    print(f"Saved {url_type}: {out_path.name}")
+    backend = "nimble" if _HAS_NIMBLE else "urllib"
+    out_path = _write_unique(target_dir, filename, content)
+    print(f"Saved {url_type}: {out_path.name} (via {backend})")
     return out_path
+
+
+def search_ingest(
+    query: str,
+    target_dir: Path,
+    max_results: int = 10,
+    author: str | None = None,
+    contributor: str | None = None,
+) -> list[Path]:
+    """
+    Search the web for *query* using Nimble Search (general focus, deep mode),
+    then ingest each result into target_dir as graphify-ready markdown.
+
+    Requires nimble_python to be installed. Raises ImportError otherwise.
+
+    Returns list of saved file paths.
+    """
+    if not _HAS_NIMBLE:
+        raise ImportError(
+            "search_ingest requires nimble_python. "
+            "Install it with: pip install graphifyy[nimble]"
+        )
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    client = _nimble_client()
+
+    response = client.search(
+        query=query,
+        max_results=max_results,
+        focus="general",
+        search_depth="deep",
+    )
+
+    saved: list[Path] = []
+    results = response.results or []
+
+    now = datetime.now(timezone.utc).isoformat()
+    for item in results:
+        title = getattr(item, "title", "")
+        url = getattr(item, "url", "")
+        description = getattr(item, "description", "")
+        content_text = getattr(item, "content", "")
+
+        if not url:
+            continue
+
+        content = f"""---
+source_url: {url}
+type: search_result
+query: "{_yaml_str(query)}"
+title: "{_yaml_str(title)}"
+captured_at: {now}
+contributor: {contributor or author or 'unknown'}
+---
+
+# {title}
+
+Source: {url}
+Search query: {query}
+
+---
+
+{content_text or description}
+"""
+        filename = _safe_filename(url, ".md")
+        out_path = _write_unique(target_dir, filename, content)
+        saved.append(out_path)
+
+    print(f"Search '{query}': saved {len(saved)} results (via nimble)")
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# Q&A memory (unchanged)
+# ---------------------------------------------------------------------------
 
 
 def save_query_result(
@@ -282,10 +464,21 @@ def save_query_result(
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Fetch a URL into a graphify /raw folder")
-    parser.add_argument("url", help="URL to fetch")
+    parser.add_argument("url", help="URL to fetch (or use --search for topic search)")
     parser.add_argument("target_dir", nargs="?", default="./raw", help="Target directory (default: ./raw)")
     parser.add_argument("--author", help="Your name (stored as node metadata)")
     parser.add_argument("--contributor", help="Contributor name for team graphs")
+    parser.add_argument("--search", action="store_true", help="Treat 'url' as a search query (requires nimble)")
+    parser.add_argument("--max-results", type=int, default=10, help="Max search results (default: 10)")
     args = parser.parse_args()
-    out = ingest(args.url, Path(args.target_dir), author=args.author, contributor=args.contributor)
-    print(f"Ready for graphify: {out}")
+
+    if args.search:
+        results = search_ingest(
+            args.url, Path(args.target_dir),
+            max_results=args.max_results,
+            author=args.author, contributor=args.contributor,
+        )
+        print(f"Ready for graphify: {len(results)} files in {args.target_dir}")
+    else:
+        out = ingest(args.url, Path(args.target_dir), author=args.author, contributor=args.contributor)
+        print(f"Ready for graphify: {out}")

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -27,6 +27,8 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
+/graphify ingest-topic "<topic>"                      # search web, save results to ./raw, update graph
+/graphify ingest-topic "<topic>" --max-results 5      # limit number of results (default 10)
 /graphify query "<question>"                          # BFS traversal - broad context
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
@@ -1093,12 +1095,44 @@ except RuntimeError as e:
 
 Replace `URL` with the actual URL, `AUTHOR` with the user's name if provided, `CONTRIBUTOR` likewise. If the command exits with an error, tell the user what went wrong - do not silently continue. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new file into the existing graph.
 
+When `nimble_python` is installed (`pip install graphifyy[nimble]`), URL extraction is powered by [Nimble](https://nimbleway.com) — get clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. Otherwise uses the built-in urllib path.
+
 Supported URL types (auto-detected):
-- Twitter/X → fetched via oEmbed, saved as `.md` with tweet text and author
+- Twitter/X → saved as `.md` with tweet text and author
 - arXiv → abstract + metadata saved as `.md`  
 - PDF → downloaded as `.pdf`
 - Images (.png/.jpg/.webp) → downloaded, Claude vision extracts on next run
-- Any webpage → converted to markdown via html2text
+- Any webpage → converted to markdown
+
+---
+
+## For /graphify ingest-topic
+
+Search the web for a topic and ingest the results into the corpus, then update the graph. Requires `nimble_python` (`pip install graphifyy[nimble]`).
+
+```bash
+$(cat .graphify_python) -c "
+import sys
+from graphify.ingest import search_ingest
+from pathlib import Path
+
+try:
+    paths = search_ingest('QUERY', Path('./raw'), max_results=MAX_RESULTS, author='AUTHOR', contributor='CONTRIBUTOR')
+    print(f'Saved {len(paths)} results to ./raw')
+    for p in paths:
+        print(f'  {p.name}')
+except ImportError as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+"
+```
+
+Replace `QUERY` with the user's search topic, `MAX_RESULTS` with the requested count (default 10), `AUTHOR` and `CONTRIBUTOR` if provided. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new files into the existing graph.
+
+Each result is saved as a `.md` file with YAML frontmatter (`type: search_result`, query, title, URL) and full page content. Nimble Search agents search the live web to retrieve precise information — deep mode extracts the full page text, not just snippets.
 
 ---
 

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -27,6 +27,8 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
+/graphify ingest-topic "<topic>"                      # search web, save results to ./raw, update graph
+/graphify ingest-topic "<topic>" --max-results 5      # limit number of results (default 10)
 /graphify query "<question>"                          # BFS traversal - broad context
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
@@ -1150,12 +1152,44 @@ except RuntimeError as e:
 
 Replace `URL` with the actual URL, `AUTHOR` with the user's name if provided, `CONTRIBUTOR` likewise. If the command exits with an error, tell the user what went wrong - do not silently continue. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new file into the existing graph.
 
+When `nimble_python` is installed (`pip install graphifyy[nimble]`), URL extraction is powered by [Nimble](https://nimbleway.com) — get clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. Otherwise uses the built-in urllib path.
+
 Supported URL types (auto-detected):
-- Twitter/X → fetched via oEmbed, saved as `.md` with tweet text and author
+- Twitter/X → saved as `.md` with tweet text and author
 - arXiv → abstract + metadata saved as `.md`  
 - PDF → downloaded as `.pdf`
 - Images (.png/.jpg/.webp) → downloaded, Claude vision extracts on next run
-- Any webpage → converted to markdown via html2text
+- Any webpage → converted to markdown
+
+---
+
+## For /graphify ingest-topic
+
+Search the web for a topic and ingest the results into the corpus, then update the graph. Requires `nimble_python` (`pip install graphifyy[nimble]`).
+
+```bash
+$(cat .graphify_python) -c "
+import sys
+from graphify.ingest import search_ingest
+from pathlib import Path
+
+try:
+    paths = search_ingest('QUERY', Path('./raw'), max_results=MAX_RESULTS, author='AUTHOR', contributor='CONTRIBUTOR')
+    print(f'Saved {len(paths)} results to ./raw')
+    for p in paths:
+        print(f'  {p.name}')
+except ImportError as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+"
+```
+
+Replace `QUERY` with the user's search topic, `MAX_RESULTS` with the requested count (default 10), `AUTHOR` and `CONTRIBUTOR` if provided. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new files into the existing graph.
+
+Each result is saved as a `.md` file with YAML frontmatter (`type: search_result`, query, title, URL) and full page content. Nimble Search agents search the live web to retrieve precise information — deep mode extracts the full page text, not just snippets.
 
 ---
 

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -27,6 +27,8 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
+/graphify ingest-topic "<topic>"                      # search web, save results to ./raw, update graph
+/graphify ingest-topic "<topic>" --max-results 5      # limit number of results (default 10)
 /graphify query "<question>"                          # BFS traversal - broad context
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
@@ -1145,12 +1147,44 @@ except RuntimeError as e:
 
 Replace `URL` with the actual URL, `AUTHOR` with the user's name if provided, `CONTRIBUTOR` likewise. If the command exits with an error, tell the user what went wrong - do not silently continue. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new file into the existing graph.
 
+When `nimble_python` is installed (`pip install graphifyy[nimble]`), URL extraction is powered by [Nimble](https://nimbleway.com) — get clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. Otherwise uses the built-in urllib path.
+
 Supported URL types (auto-detected):
-- Twitter/X → fetched via oEmbed, saved as `.md` with tweet text and author
+- Twitter/X → saved as `.md` with tweet text and author
 - arXiv → abstract + metadata saved as `.md`  
 - PDF → downloaded as `.pdf`
 - Images (.png/.jpg/.webp) → downloaded, Claude vision extracts on next run
-- Any webpage → converted to markdown via html2text
+- Any webpage → converted to markdown
+
+---
+
+## For /graphify ingest-topic
+
+Search the web for a topic and ingest the results into the corpus, then update the graph. Requires `nimble_python` (`pip install graphifyy[nimble]`).
+
+```bash
+$(cat .graphify_python) -c "
+import sys
+from graphify.ingest import search_ingest
+from pathlib import Path
+
+try:
+    paths = search_ingest('QUERY', Path('./raw'), max_results=MAX_RESULTS, author='AUTHOR', contributor='CONTRIBUTOR')
+    print(f'Saved {len(paths)} results to ./raw')
+    for p in paths:
+        print(f'  {p.name}')
+except ImportError as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+"
+```
+
+Replace `QUERY` with the user's search topic, `MAX_RESULTS` with the requested count (default 10), `AUTHOR` and `CONTRIBUTOR` if provided. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new files into the existing graph.
+
+Each result is saved as a `.md` file with YAML frontmatter (`type: search_result`, query, title, URL) and full page content. Nimble Search agents search the live web to retrieve precise information — deep mode extracts the full page text, not just snippets.
 
 ---
 

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -27,6 +27,8 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
+/graphify ingest-topic "<topic>"                      # search web, save results to ./raw, update graph
+/graphify ingest-topic "<topic>" --max-results 5      # limit number of results (default 10)
 /graphify query "<question>"                          # BFS traversal - broad context
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
@@ -1143,12 +1145,44 @@ except RuntimeError as e:
 
 Replace `URL` with the actual URL, `AUTHOR` with the user's name if provided, `CONTRIBUTOR` likewise. If the command exits with an error, tell the user what went wrong - do not silently continue. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new file into the existing graph.
 
+When `nimble_python` is installed (`pip install graphifyy[nimble]`), URL extraction is powered by [Nimble](https://nimbleway.com) — get clean, real-time HTML and markdown from any URL with stealth unblocking and JS rendering. Otherwise uses the built-in urllib path.
+
 Supported URL types (auto-detected):
-- Twitter/X → fetched via oEmbed, saved as `.md` with tweet text and author
+- Twitter/X → saved as `.md` with tweet text and author
 - arXiv → abstract + metadata saved as `.md`  
 - PDF → downloaded as `.pdf`
 - Images (.png/.jpg/.webp) → downloaded, Claude vision extracts on next run
-- Any webpage → converted to markdown via html2text
+- Any webpage → converted to markdown
+
+---
+
+## For /graphify ingest-topic
+
+Search the web for a topic and ingest the results into the corpus, then update the graph. Requires `nimble_python` (`pip install graphifyy[nimble]`).
+
+```bash
+$(cat .graphify_python) -c "
+import sys
+from graphify.ingest import search_ingest
+from pathlib import Path
+
+try:
+    paths = search_ingest('QUERY', Path('./raw'), max_results=MAX_RESULTS, author='AUTHOR', contributor='CONTRIBUTOR')
+    print(f'Saved {len(paths)} results to ./raw')
+    for p in paths:
+        print(f'  {p.name}')
+except ImportError as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f'error: {e}', file=sys.stderr)
+    sys.exit(1)
+"
+```
+
+Replace `QUERY` with the user's search topic, `MAX_RESULTS` with the requested count (default 10), `AUTHOR` and `CONTRIBUTOR` if provided. After a successful save, automatically run the `--update` pipeline on `./raw` to merge the new files into the existing graph.
+
+Each result is saved as a `.md` file with YAML frontmatter (`type: search_result`, query, title, URL) and full page content. Nimble Search agents search the live web to retrieve precise information — deep mode extracts the full page text, not just snippets.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ Issues = "https://github.com/safishamsi/graphify/issues"
 [project.optional-dependencies]
 mcp = ["mcp"]
 neo4j = ["neo4j"]
+nimble = ["nimble_python"]
 pdf = ["pypdf", "html2text"]
 watch = ["watchdog"]
 leiden = ["graspologic"]
-all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic"]
+all = ["mcp", "neo4j", "nimble_python", "pypdf", "html2text", "watchdog", "graspologic"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/test_nimble_ingest.py
+++ b/tests/test_nimble_ingest.py
@@ -1,0 +1,212 @@
+"""Tests for Nimble integration in graphify.ingest."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphify.ingest import ingest, search_ingest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class _FakeExtractData:
+    def __init__(self, markdown: str):
+        self.markdown = markdown
+
+class _FakeExtractResponse:
+    def __init__(self, markdown: str):
+        self.data = _FakeExtractData(markdown)
+
+class _FakeSearchResultItem:
+    def __init__(self, title="", url="", description="", content=""):
+        self.title = title
+        self.url = url
+        self.description = description
+        self.content = content
+
+class _FakeSearchResponse:
+    def __init__(self, results):
+        self.results = results
+
+
+def _make_client(extract_md="# Page Title\n\nSome content.", search_results=None):
+    client = MagicMock()
+    client.extract.return_value = _FakeExtractResponse(extract_md)
+    if search_results is not None:
+        items = [_FakeSearchResultItem(**r) if isinstance(r, dict) else r for r in search_results]
+        client.search.return_value = _FakeSearchResponse(items)
+    return client
+
+
+@pytest.fixture
+def nimble(request):
+    """Patch Nimble as available with a fake client. Use `indirect` to pass extract_md."""
+    md = getattr(request, "param", "# Page Title\n\nSome content.")
+    client = _make_client(extract_md=md)
+    with patch("graphify.ingest._HAS_NIMBLE", True), \
+         patch("graphify.ingest._nimble_client", return_value=client), \
+         patch("graphify.ingest.validate_url", side_effect=lambda u: u):
+        yield client
+
+
+@pytest.fixture
+def nimble_search(request):
+    """Patch Nimble as available with search results."""
+    results = getattr(request, "param", [])
+    client = _make_client(search_results=results)
+    with patch("graphify.ingest._HAS_NIMBLE", True), \
+         patch("graphify.ingest._nimble_client", return_value=client):
+        yield client
+
+
+@pytest.fixture
+def no_nimble():
+    with patch("graphify.ingest._HAS_NIMBLE", False), \
+         patch("graphify.ingest.validate_url", side_effect=lambda u: u):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Nimble Extract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("nimble", ["# Hello World\n\nContent from Nimble."], indirect=True)
+def test_webpage_via_nimble(nimble, tmp_path):
+    out = ingest("https://example.com", tmp_path)
+    content = out.read_text()
+    assert "Content from Nimble" in content
+    assert "type: webpage" in content
+    nimble.extract.assert_called_once_with(url="https://example.com", render=True, formats=["markdown"])
+
+
+@pytest.mark.parametrize("nimble", ["# My Great Page\n\nBody."], indirect=True)
+def test_title_from_markdown_heading(nimble, tmp_path):
+    out = ingest("https://example.com/page", tmp_path)
+    assert 'title: "My Great Page"' in out.read_text()
+
+
+def test_nimble_error_uses_urllib(tmp_path):
+    client = _make_client()
+    client.extract.side_effect = Exception("connection timeout")
+    html = "<html><head><title>Alternative</title></head><body>Hello</body></html>"
+    with patch("graphify.ingest._HAS_NIMBLE", True), \
+         patch("graphify.ingest._nimble_client", return_value=client), \
+         patch("graphify.ingest.validate_url", side_effect=lambda u: u), \
+         patch("graphify.ingest._fetch_html", return_value=html):
+        out = ingest("https://example.com", tmp_path)
+    assert "Alternative" in out.read_text()
+
+
+@pytest.mark.parametrize("nimble", ["Tweet by @testuser\n\nHello world!"], indirect=True)
+def test_tweet_via_nimble(nimble, tmp_path):
+    out = ingest("https://x.com/testuser/status/123", tmp_path)
+    content = out.read_text()
+    assert "type: tweet" in content
+    assert "testuser" in content
+
+
+@pytest.mark.parametrize("nimble", ["# Attention Is All You Need\n\nAuthors: Vaswani et al.\n\nAbstract\nNew architecture."], indirect=True)
+def test_arxiv_via_nimble(nimble, tmp_path):
+    out = ingest("https://arxiv.org/abs/1706.03762", tmp_path)
+    content = out.read_text()
+    assert "type: paper" in content
+    assert "1706.03762" in content
+    assert "Attention Is All You Need" in content
+
+
+def test_pdf_binary_download(nimble, tmp_path):
+    with patch("graphify.ingest.safe_fetch", return_value=b"%PDF-1.4 fake"):
+        out = ingest("https://example.com/paper.pdf", tmp_path)
+    assert out.suffix == ".pdf"
+    assert out.read_bytes() == b"%PDF-1.4 fake"
+
+
+# ---------------------------------------------------------------------------
+# urllib alternative
+# ---------------------------------------------------------------------------
+
+def test_webpage_via_urllib(no_nimble, tmp_path):
+    html = "<html><head><title>Old School</title></head><body>Content</body></html>"
+    with patch("graphify.ingest._fetch_html", return_value=html):
+        out = ingest("https://example.com", tmp_path)
+    assert "Old School" in out.read_text()
+
+
+def test_tweet_via_oembed(no_nimble, tmp_path):
+    resp = json.dumps({"html": "<p>Hello tweet</p>", "author_name": "testuser"})
+    with patch("graphify.ingest.safe_fetch_text", return_value=resp):
+        out = ingest("https://x.com/testuser/status/1", tmp_path)
+    content = out.read_text()
+    assert "testuser" in content
+    assert "Hello tweet" in content
+
+
+# ---------------------------------------------------------------------------
+# Nimble Search
+# ---------------------------------------------------------------------------
+
+_TWO_RESULTS = [
+    {"title": "Result 1", "url": "https://a.com/1", "description": "First", "content": "Full content 1"},
+    {"title": "Result 2", "url": "https://b.com/2", "description": "Second", "content": "Full content 2"},
+]
+
+@pytest.mark.parametrize("nimble_search", [_TWO_RESULTS], indirect=True)
+def test_search_saves_results(nimble_search, tmp_path):
+    paths = search_ingest("test query", tmp_path)
+    assert len(paths) == 2
+    for p in paths:
+        content = p.read_text()
+        assert "type: search_result" in content
+        assert 'query: "test query"' in content
+
+
+@pytest.mark.parametrize("nimble_search", [[]], indirect=True)
+def test_search_params(nimble_search, tmp_path):
+    search_ingest("AI transformers", tmp_path, max_results=5)
+    nimble_search.search.assert_called_once_with(
+        query="AI transformers", max_results=5, focus="general", search_depth="deep",
+    )
+
+
+@pytest.mark.parametrize("nimble_search", [[
+    {"title": "No URL", "description": "Missing"},
+    {"title": "Has URL", "url": "https://c.com/page", "description": "Good"},
+]], indirect=True)
+def test_search_skips_results_without_url(nimble_search, tmp_path):
+    assert len(search_ingest("query", tmp_path)) == 1
+
+
+def test_search_raises_without_nimble(no_nimble, tmp_path):
+    with pytest.raises(ImportError, match="nimble_python"):
+        search_ingest("query", tmp_path)
+
+
+@pytest.mark.parametrize("nimble_search,field,expected", [
+    ([{"title": "Deep", "url": "https://d.com/d", "content": "Full deep content"}], "content", "Full deep content"),
+    ([{"title": "Lite", "url": "https://e.com/e", "description": "Just a description"}], "description", "Just a description"),
+], indirect=["nimble_search"])
+def test_search_content_vs_description(nimble_search, field, expected, tmp_path):
+    paths = search_ingest("query", tmp_path)
+    assert expected in paths[0].read_text()
+
+
+@pytest.mark.parametrize("nimble_search", [[
+    {"title": "A", "url": "https://same.com/a", "description": "A"},
+    {"title": "A", "url": "https://same.com/a", "description": "A dup"},
+]], indirect=True)
+def test_search_no_filename_collision(nimble_search, tmp_path):
+    paths = search_ingest("query", tmp_path)
+    assert len(paths) == 2
+    assert paths[0] != paths[1]
+
+
+@pytest.mark.parametrize("nimble_search", [[
+    {"title": "T", "url": "https://f.com/f", "description": "t"},
+]], indirect=True)
+def test_search_contributor(nimble_search, tmp_path):
+    paths = search_ingest("query", tmp_path, author="Alice", contributor="Bob")
+    assert "contributor: Bob" in paths[0].read_text()

--- a/tests/test_nimble_live.py
+++ b/tests/test_nimble_live.py
@@ -1,0 +1,124 @@
+"""Live integration tests for Nimble — requires NIMBLE_API_KEY env var.
+
+Run with:
+    uv run --with nimble_python --with pytest pytest tests/test_nimble_live.py -v -s
+
+Skipped automatically in CI or when no API key is set.
+"""
+from __future__ import annotations
+import os
+from pathlib import Path
+
+import pytest
+
+try:
+    import nimble_python  # noqa: F401
+    _HAS_NIMBLE = True
+except ImportError:
+    _HAS_NIMBLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_NIMBLE or not os.environ.get("NIMBLE_API_KEY"),
+    reason="nimble_python not installed or NIMBLE_API_KEY not set",
+)
+
+
+@pytest.fixture
+def nimble_client():
+    from nimble_python import Nimble
+    return Nimble()
+
+
+# ---------------------------------------------------------------------------
+# Extract
+# ---------------------------------------------------------------------------
+
+class TestLiveExtract:
+
+    def test_extract_markdown(self, nimble_client):
+        response = nimble_client.extract(url="https://example.com", render=True, formats=["markdown"])
+        md = response.data.markdown
+        assert md is not None
+        assert len(md) > 20
+        # Nimble returns body text as markdown; example.com mentions "domain" and "examples"
+        assert "domain" in md.lower()
+        print(f"\n--- Extract markdown ({len(md)} chars) ---")
+        print(md[:500])
+
+    def test_extract_html(self, nimble_client):
+        response = nimble_client.extract(url="https://example.com")
+        html = response.data.html
+        assert html is not None
+        assert "<html" in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+class TestLiveSearch:
+
+    def test_search_general_deep(self, nimble_client):
+        response = nimble_client.search(
+            query="what is a knowledge graph",
+            max_results=3,
+            focus="general",
+            search_depth="deep",
+        )
+        assert response.results is not None
+        assert len(response.results) > 0
+
+        first = response.results[0]
+        assert first.title
+        assert first.url
+        # deep mode should populate content
+        assert first.content and len(first.content) > 100
+
+        print(f"\n--- Search: {len(response.results)} results ---")
+        for r in response.results:
+            print(f"  {r.title[:60]}  ({r.url[:50]})")
+            print(f"    content: {len(r.content or '')} chars, description: {len(r.description or '')} chars")
+
+    def test_search_lite(self, nimble_client):
+        """Lite mode returns metadata only — content should be empty/minimal."""
+        response = nimble_client.search(
+            query="python programming",
+            max_results=3,
+            focus="general",
+            search_depth="lite",
+        )
+        assert len(response.results) > 0
+        first = response.results[0]
+        assert first.title
+        assert first.url
+        assert first.description
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ingest + search_ingest
+# ---------------------------------------------------------------------------
+
+class TestLiveIngest:
+
+    def test_ingest_webpage(self, tmp_path):
+        from graphify.ingest import ingest
+        out = ingest("https://example.com", tmp_path)
+        assert out.exists()
+        content = out.read_text()
+        assert "domain" in content.lower()
+        assert "type: webpage" in content
+        print(f"\n--- Ingest webpage: {out.name} ({len(content)} chars) ---")
+
+    def test_search_ingest(self, tmp_path):
+        from graphify.ingest import search_ingest
+        paths = search_ingest("knowledge graph AI", tmp_path, max_results=3)
+        assert len(paths) > 0
+        for p in paths:
+            assert p.exists()
+            content = p.read_text()
+            assert "type: search_result" in content
+            assert "source_url:" in content
+            print(f"\n--- Search result: {p.name} ({len(content)} chars) ---")
+            # Print first few lines
+            for line in content.splitlines()[:8]:
+                print(f"  {line}")


### PR DESCRIPTION
## Why

graphify's `/graphify add` command currently uses Python's built-in `urllib` for fetching URLs — no JS rendering, no anti-bot handling, and basic HTML-to-markdown conversion. Modern websites increasingly rely on client-side rendering, which means `urllib` often returns empty or incomplete content.

[Nimble](https://nimbleway.com) is a web intelligence platform that turns any public webpage into clean, structured data. Their Extract API handles JS rendering, stealth unblocking, and returns clean markdown — all in a single API call. Their Search API lets AI agents search the live web and retrieve precise, full-page content in real time.

This PR integrates Nimble as an optional dependency, so graphify users can get significantly better web extraction out of the box.

## What changed

- **Nimble Extract** — `/graphify add <url>` now uses Nimble for real-time HTML/markdown extraction with stealth unblocking and JS rendering when `nimble_python` is installed (`pip install graphifyy[nimble]`). The built-in urllib path is used as an alternative when Nimble is not installed.
- **Nimble Search** — New `/graphify ingest-topic "<topic>"` command. Searches the live web via Nimble Search (general focus, deep mode) and saves results as graphify-ready markdown files with full page content — not just snippets.
- Added `nimble = ["nimble_python"]` optional dependency in `pyproject.toml`
- Updated all 4 skill files (Claude, Codex, OpenCode, OpenClaw) with the new `ingest-topic` command
- Updated README with web ingestion section, usage examples, and API key setup
- Unit tests (mocked) and live integration tests (auto-skipped without API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)