### PR TITLE
feat: add Factory Droid platform support

### DIFF
--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -142,7 +142,7 @@ else:
 
 **Fast path:** If detection found zero docs, papers, and images (code-only corpus), skip Part B entirely and go straight to Part C. AST handles code - there is nothing for semantic subagents to do.
 
-**MANDATORY: You MUST use the Agent tool here. Reading files yourself one-by-one is forbidden - it is 5-10x slower. If you do not use the Agent tool you are doing this wrong.**
+**MANDATORY: You MUST use the Task tool here. Reading files yourself one-by-one is forbidden - it is 5-10x slower. If you do not use the Task tool you are doing this wrong.**
 
 Before dispatching subagents, print a timing estimate:
 - Load `total_words` and file counts from `.graphify_detect.json`
@@ -178,18 +178,24 @@ Only dispatch subagents for files listed in `.graphify_uncached.txt`. If all fil
 
 Load files from `.graphify_uncached.txt`. Split into chunks of 20-25 files each. Each image gets its own chunk (vision needs separate context).
 
-**Step B2 - Dispatch ALL subagents in a single message (Factory Droid)**
+**Step B2 - Dispatch ALL subagents in a single message (Factory Droid Task tool)**
 
-> **Factory Droid platform:** Uses the `Task` tool for parallel subagent dispatch.
-> Call `Task` once per chunk — ALL in the same response so they run in parallel.
+> **Factory Droid platform:** Use the `Task` tool with `subagent_type="worker"` for parallel extraction.
+> Create one Task call per chunk and dispatch all chunk tasks in the same response so they run concurrently.
+> Each task message must include the extraction prompt below (with `FILE_LIST`, `CHUNK_NUM`, `TOTAL_CHUNKS`, and `DEEP_MODE` substituted) and must return **only** structured JSON.
+> After dispatch, collect every task result, parse JSON, and merge valid outputs into `.graphify_semantic_new.json`.
 
-Call `Task` once per chunk — ALL in the same response so they run in parallel. Pass the extraction prompt as the task description:
+Task message template per chunk:
 
 ```
-Task(description="Your task is to perform the following. Follow the instructions below exactly.\n\n<agent-instructions>\n[extraction prompt below, with FILE_LIST, CHUNK_NUM, TOTAL_CHUNKS, DEEP_MODE substituted]\n</agent-instructions>\n\nExecute this now. Output ONLY the structured JSON response.")
+Task(subagent_type="worker", description="Graphify semantic extraction chunk CHUNK_NUM/TOTAL_CHUNKS", prompt="[extraction prompt below with substitutions]. Output ONLY the structured JSON response.")
 ```
 
-Collect results as each Task completes. Parse each result as JSON.
+Then collect all task outputs:
+- Parse each result as JSON.
+- Accumulate `nodes`, `edges`, and `hyperedges` across all successful chunks.
+- Write merged new semantic output to `.graphify_semantic_new.json`.
+- If a task fails or returns invalid JSON, warn and skip that chunk (do not abort the whole run).
 
 Parse each result as JSON. Accumulate nodes/edges/hyperedges across all results and write to `.graphify_semantic_new.json`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ where = ["."]
 include = ["graphify*"]
 
 [tool.setuptools.package-data]
-graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md"]
+graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-droid.md"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,7 @@ PLATFORMS = {
     "codex": (".agents/skills/graphify/SKILL.md",),
     "opencode": (".config/opencode/skills/graphify/SKILL.md",),
     "claw": (".claw/skills/graphify/SKILL.md",),
+    "droid": (".factory/skills/graphify/SKILL.md",),
 }
 
 
@@ -38,6 +39,12 @@ def test_install_claw(tmp_path):
     assert (tmp_path / ".claw" / "skills" / "graphify" / "SKILL.md").exists()
 
 
+
+
+def test_install_droid(tmp_path):
+    _install(tmp_path, "droid")
+    assert (tmp_path / ".factory" / "skills" / "graphify" / "SKILL.md").exists()
+
 def test_install_unknown_platform_exits(tmp_path):
     with pytest.raises(SystemExit):
         _install(tmp_path, "unknown")
@@ -48,6 +55,13 @@ def test_codex_skill_contains_spawn_agent():
     import graphify
     skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
     assert "spawn_agent" in skill
+
+
+def test_droid_skill_contains_task_tool():
+    """Droid skill file must reference Task tool."""
+    import graphify
+    skill = (Path(graphify.__file__).parent / "skill-droid.md").read_text()
+    assert "Task" in skill
 
 
 def test_opencode_skill_contains_mention():
@@ -67,10 +81,10 @@ def test_claw_skill_is_sequential():
 
 
 def test_all_skill_files_exist_in_package():
-    """All four platform skill files must be present in the installed package."""
+    """All five platform skill files must be present in the installed package."""
     import graphify
     pkg = Path(graphify.__file__).parent
-    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md"):
+    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-droid.md"):
         assert (pkg / name).exists(), f"Missing: {name}"
 
 
@@ -115,10 +129,31 @@ def test_claw_agents_install_writes_agents_md(tmp_path):
     assert (tmp_path / "AGENTS.md").exists()
 
 
+
+
+def test_droid_agents_install_writes_agents_md(tmp_path):
+    _agents_install(tmp_path, "droid")
+    agents_md = tmp_path / "AGENTS.md"
+    assert agents_md.exists()
+    assert "graphify" in agents_md.read_text()
+    assert "GRAPH_REPORT.md" in agents_md.read_text()
+
+
+def test_droid_install_does_not_write_claude_md(tmp_path):
+    _install(tmp_path, "droid")
+    assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
 def test_agents_install_idempotent(tmp_path):
     """Installing twice does not duplicate the section."""
     _agents_install(tmp_path, "codex")
     _agents_install(tmp_path, "codex")
+    content = (tmp_path / "AGENTS.md").read_text()
+    assert content.count("## graphify") == 1
+
+
+def test_droid_agents_install_idempotent(tmp_path):
+    _agents_install(tmp_path, "droid")
+    _agents_install(tmp_path, "droid")
     content = (tmp_path / "AGENTS.md").read_text()
     assert content.count("## graphify") == 1
 


### PR DESCRIPTION
## Summary
- add Factory Droid platform support in CLI platform routing and `graphify droid install/uninstall`
- include `graphify/skill-droid.md` for Droid Task-tool workflow
- extend package-data and install tests for Droid paths and behavior

## Validation
- `python -m pytest tests/ -q --tb=short`
- `graphify --help`
- `graphify install --platform droid`

Supersedes #23.
Closes #20
