### PR TITLE
Add follow_symlinks support to file discovery

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -293,7 +293,7 @@ def _is_ignored(path: Path, root: Path, patterns: list[str]) -> bool:
     return False
 
 
-def detect(root: Path) -> dict:
+def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
     files: dict[FileType, list[str]] = {
         FileType.CODE: [],
         FileType.DOCUMENT: [],
@@ -316,8 +316,15 @@ def detect(root: Path) -> dict:
 
     for scan_root in scan_paths:
         in_memory_tree = memory_dir.exists() and str(scan_root).startswith(str(memory_dir))
-        for dirpath, dirnames, filenames in os.walk(scan_root, followlinks=False):
+        for dirpath, dirnames, filenames in os.walk(scan_root, followlinks=follow_symlinks):
             dp = Path(dirpath)
+            # Prevent infinite loops from circular symlinks
+            if follow_symlinks and os.path.islink(dirpath):
+                real = os.path.realpath(dirpath)
+                parent_real = os.path.realpath(os.path.dirname(dirpath))
+                if parent_real == real or parent_real.startswith(real + os.sep):
+                    dirnames.clear()
+                    continue
             if not in_memory_tree:
                 # Prune noise dirs in-place so os.walk never descends into them
                 dirnames[:] = [

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2194,21 +2194,42 @@ def extract(paths: list[Path]) -> dict:
     }
 
 
-def collect_files(target: Path) -> list[Path]:
+def collect_files(target: Path, *, follow_symlinks: bool = False) -> list[Path]:
     if target.is_file():
         return [target]
-    _EXTENSIONS = (
-        "*.py", "*.js", "*.ts", "*.tsx", "*.go", "*.rs",
-        "*.java", "*.c", "*.h", "*.cpp", "*.cc", "*.cxx", "*.hpp",
-        "*.rb", "*.cs", "*.kt", "*.kts", "*.scala", "*.php", "*.swift",
-        "*.lua", "*.toc", "*.zig", "*.ps1",
-    )
-    results: list[Path] = []
-    for pattern in _EXTENSIONS:
-        results.extend(
-            p for p in target.rglob(pattern)
-            if not any(part.startswith(".") for part in p.parts)
-        )
+    _EXTENSIONS = {
+        ".py", ".js", ".ts", ".tsx", ".go", ".rs",
+        ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
+        ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
+        ".lua", ".toc", ".zig", ".ps1",
+    }
+    if not follow_symlinks:
+        results: list[Path] = []
+        for ext in sorted(_EXTENSIONS):
+            results.extend(
+                p for p in target.rglob(f"*{ext}")
+                if not any(part.startswith(".") for part in p.parts)
+            )
+        return sorted(results)
+    # Walk with symlink following + cycle detection
+    import os
+    results = []
+    for dirpath, dirnames, filenames in os.walk(target, followlinks=True):
+        # Prevent infinite loops from circular symlinks
+        if os.path.islink(dirpath):
+            real = os.path.realpath(dirpath)
+            parent_real = os.path.realpath(os.path.dirname(dirpath))
+            if parent_real == real or parent_real.startswith(real + os.sep):
+                dirnames.clear()
+                continue
+        dp = Path(dirpath)
+        if any(part.startswith(".") for part in dp.parts):
+            dirnames.clear()
+            continue
+        for fname in filenames:
+            p = dp / fname
+            if p.suffix in _EXTENSIONS and not fname.startswith("."):
+                results.append(p)
     return sorted(results)
 
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -18,7 +18,7 @@ _CODE_EXTENSIONS = {
 }
 
 
-def _rebuild_code(watch_path: Path) -> bool:
+def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
     """Re-run AST extraction + build + cluster + report for code files. No LLM needed.
 
     Returns True on success, False on error.
@@ -31,13 +31,10 @@ def _rebuild_code(watch_path: Path) -> bool:
         from graphify.report import generate
         from graphify.export import to_json
 
-        code_files = []
-        for ext in _CODE_EXTENSIONS:
-            code_files.extend(watch_path.rglob(f"*{ext}"))
+        code_files = collect_files(watch_path, follow_symlinks=follow_symlinks)
         code_files = [
             f for f in code_files
-            if not any(part.startswith(".") for part in f.parts)
-            and "graphify-out" not in f.parts
+            if "graphify-out" not in f.parts
             and "__pycache__" not in f.parts
         ]
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from graphify.detect import classify_file, count_words, detect, FileType, _looks_like_paper, _is_ignored, _load_graphifyignore
 
@@ -103,3 +104,51 @@ def test_graphifyignore_comments_ignored(tmp_path):
     result = detect(tmp_path)
     assert not any("main.py" in f for f in result["files"]["code"])
     assert any("other.py" in f for f in result["files"]["code"])
+
+
+def test_detect_follows_symlinked_directory(tmp_path):
+    """With follow_symlinks=True, files inside symlinked directories are discovered."""
+    real_dir = tmp_path / "real_lib"
+    real_dir.mkdir()
+    (real_dir / "util.py").write_text("x = 1")
+
+    link = tmp_path / "linked_lib"
+    link.symlink_to(real_dir)
+
+    result_no = detect(tmp_path, follow_symlinks=False)
+    result_yes = detect(tmp_path, follow_symlinks=True)
+
+    code_no = result_no["files"]["code"]
+    code_yes = result_yes["files"]["code"]
+
+    # Without follow_symlinks only the real dir is found
+    assert any("real_lib" in f for f in code_no)
+    assert not any("linked_lib" in f for f in code_no)
+
+    # With follow_symlinks both are found
+    assert any("real_lib" in f for f in code_yes)
+    assert any("linked_lib" in f for f in code_yes)
+
+
+def test_detect_follows_symlinked_file(tmp_path):
+    """With follow_symlinks=True, symlinked files are discovered."""
+    (tmp_path / "real.py").write_text("x = 1")
+    (tmp_path / "link.py").symlink_to(tmp_path / "real.py")
+
+    result = detect(tmp_path, follow_symlinks=True)
+    code = result["files"]["code"]
+    assert any("real.py" in f for f in code)
+    assert any("link.py" in f for f in code)
+
+
+def test_detect_handles_circular_symlinks(tmp_path):
+    """Circular symlinks must not cause infinite recursion."""
+    sub = tmp_path / "a"
+    sub.mkdir()
+    (sub / "main.py").write_text("x = 1")
+    # Create a circular symlink: a/loop -> ../ (points back to tmp_path)
+    (sub / "loop").symlink_to(tmp_path)
+
+    result = detect(tmp_path, follow_symlinks=True)
+    # Should complete without hanging and find the file
+    assert any("main.py" in f for f in result["files"]["code"])

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -72,6 +72,39 @@ def test_collect_files_skips_hidden():
         assert not any(part.startswith(".") for part in f.parts)
 
 
+def test_collect_files_follows_symlinked_directory(tmp_path):
+    """With follow_symlinks=True, files inside symlinked directories are discovered."""
+    real_dir = tmp_path / "real_src"
+    real_dir.mkdir()
+    (real_dir / "lib.py").write_text("x = 1")
+
+    link = tmp_path / "linked_src"
+    link.symlink_to(real_dir)
+
+    files_no = collect_files(tmp_path, follow_symlinks=False)
+    files_yes = collect_files(tmp_path, follow_symlinks=True)
+
+    names_no = [f.name for f in files_no]
+    names_yes = [f.name for f in files_yes]
+
+    # Without symlinks: only via real path
+    assert names_no.count("lib.py") == 1
+
+    # With symlinks: found via both real and symlinked paths
+    assert names_yes.count("lib.py") == 2
+
+
+def test_collect_files_handles_circular_symlinks(tmp_path):
+    """Circular symlinks must not cause infinite recursion in collect_files."""
+    sub = tmp_path / "pkg"
+    sub.mkdir()
+    (sub / "mod.py").write_text("x = 1")
+    (sub / "cycle").symlink_to(tmp_path)
+
+    files = collect_files(tmp_path, follow_symlinks=True)
+    assert any(f.name == "mod.py" for f in files)
+
+
 def test_no_dangling_edges_on_extract():
     """After merging multiple files, no internal edges should be dangling."""
     files = list(FIXTURES.glob("*.py"))


### PR DESCRIPTION
## Summary
- Adds opt-in `follow_symlinks` parameter to `detect()` and `collect_files()` so symlinked files and directories are no longer invisible to graphify
- Implements cycle detection that prevents infinite recursion from circular symlinks while still allowing legitimate sibling symlinks (checks if symlink target is an ancestor of current path)
- Updates `watch.py` to use `collect_files()` with the new parameter for consistency

## Test plan
- [x] Added 3 tests for `detect()`: symlinked directory, symlinked file, circular symlink protection
- [x] Added 2 tests for `collect_files()`: symlinked directory, circular symlink protection
- [x] All 359 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)