### PR TITLE
fix: typo in SECURITY.md regarding MCP server

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ We will acknowledge receipt within 48 hours and aim to release a fix within 7 da
 
 ## Security Model
 
-graphify is a **local development tool**. It runs as a Claude Code skill and optionally as a local MCP stdio server. It makes no network calls during graph analysis - only during `ingest` (explicit URL fetch by the user).
+graphify is a **local development tool**. It runs as a Claude Code skill and optionally as a local MCP studio server. It makes no network calls during graph analysis - only during `ingest` (explicit URL fetch by the user).
 
 ### Threat Surface
 


### PR DESCRIPTION
In Security.md, there is a typo on the word studio (written 'stdio')