### PR TITLE
feat: expose build command for direct graph generation without LLM integration

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -299,6 +299,59 @@ def claude_uninstall(project_dir: Path | None = None) -> None:
     _uninstall_claude_hook(project_dir or Path("."))
 
 
+def build_graph(target_dir: Path, generate_html: bool = True, cluster_only: bool = False) -> None:
+    from graphify.detect import detect
+    from graphify.extract import collect_files, extract
+    from graphify.build import build_from_json
+    from graphify.cluster import cluster, score_all
+    from graphify.analyze import god_nodes, surprising_connections, suggest_questions
+    from graphify.report import generate
+    from graphify.export import to_json
+    
+    print(f"[graphify] Detecting files in {target_dir}...")
+    detection = detect(target_dir)
+    code_files = []
+    for f in detection.get("files", {}).get("code", []):
+        f_path = Path(f)
+        if f_path.is_dir():
+            code_files.extend(collect_files(f_path))
+        else:
+            code_files.append(f_path)
+            
+    if not code_files:
+        print("[graphify] No code files found for AST extraction.")
+        sys.exit(0)
+        
+    print(f"[graphify] Extracting AST from {len(code_files)} code files...")
+    extraction = extract(code_files)
+    
+    print("[graphify] Building graph...")
+    G = build_from_json(extraction)
+    
+    if G.number_of_nodes() == 0:
+        print("[graphify] ERROR: Graph is empty - extraction produced no nodes.")
+        sys.exit(1)
+        
+    print("[graphify] Clustering communities...")
+    communities = cluster(G)
+    cohesion = score_all(G, communities)
+    
+    gods = god_nodes(G)
+    surprises = surprising_connections(G, communities)
+    labels = {cid: f"Community {cid}" for cid in communities}
+    questions = suggest_questions(G, communities, labels)
+    
+    out_dir = Path("graphify-out")
+    out_dir.mkdir(exist_ok=True)
+    
+    tokens = {'input': extraction.get('input_tokens', 0), 'output': extraction.get('output_tokens', 0)}
+    report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, str(target_dir), suggested_questions=questions)
+    
+    (out_dir / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
+    to_json(G, communities, str(out_dir / "graph.json"))
+    
+    print(f"[graphify] Graph built: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges, {len(communities)} communities.")
+
 def main() -> None:
     # Check all known skill install locations for a stale version stamp
     for cfg in _PLATFORM_CONFIG.values():
@@ -421,6 +474,30 @@ def main() -> None:
                 pass
         result = run_benchmark(graph_path, corpus_words=corpus_words)
         print_benchmark(result)
+    elif cmd == "." or cmd.startswith("./") or Path(cmd).is_dir() or cmd == "build":
+        # Expose the underlying build process!
+        target_dir = Path(cmd if cmd != "build" else ".")
+        if not target_dir.exists() or not target_dir.is_dir():
+            print(f"error: {cmd} is not a valid directory", file=sys.stderr)
+            sys.exit(1)
+        
+        # Support flags
+        no_viz = "--no-viz" in sys.argv
+        cluster_only = "--cluster-only" in sys.argv
+        
+        try:
+            print(f"Building knowledge graph for {target_dir.resolve()}...")
+            build_graph(
+                target_dir, 
+                generate_html=not no_viz,
+                cluster_only=cluster_only
+            )
+            print("Knowledge graph built successfully.")
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            print(f"Build failed: {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         print(f"error: unknown command '{cmd}'", file=sys.stderr)
         print("Run 'graphify --help' for usage.", file=sys.stderr)


### PR DESCRIPTION
### What this PR does
Currently, the `graphify` CLI acts primarily as a skill wrapper for AI assistants. The underlying deterministic AST extraction (via tree-sitter) is incredibly powerful, but it wasn't easily accessible as a standalone command to simply build the `graphify-out` directory directly from a terminal without triggering the LLM/Claude flow.

This PR exposes the internal build process so that users can run:
```bash
graphify .
# or
graphify build .
```
This will detect the files, extract the AST, build the NetworkX graph, cluster communities, and generate the `graph.json` and `GRAPH_REPORT.md` artifacts locally, fully bypassing the LLM subagents. 

### Why is this useful?
1. **Zero-LLM Pipeline**: Allows external tools and CLIs to leverage Graphify's AST engine purely for structural code analysis.
2. **Offline Mode**: Enables generation of the knowledge graph in entirely air-gapped environments without any API keys.
3. **CI/CD Integration**: The graph can be generated as a build artifact in pipelines before any LLM review steps.

### Changes made
- Added a `build_graph` orchestrator function in `__main__.py` that composes the existing modules (`detect`, `extract`, `build_from_json`, `cluster`, `analyze`, `report`, `export`).
- Added CLI routing for `cmd == "."` or `cmd == "build"` to trigger this flow.