### PR TITLE
fix: git hooks fail when graphify is installed via pipx

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -8,6 +8,16 @@ _HOOK_MARKER_END = "# graphify-hook-end"
 _CHECKOUT_MARKER = "# graphify-checkout-hook-start"
 _CHECKOUT_MARKER_END = "# graphify-checkout-hook-end"
 
+_PYTHON_DETECT = """\
+# Detect the correct Python interpreter (handles pipx, venv, system installs)
+GRAPHIFY_BIN=$(which graphify 2>/dev/null)
+if [ -n "$GRAPHIFY_BIN" ]; then
+    GRAPHIFY_PYTHON=$(head -1 "$GRAPHIFY_BIN" | sed 's/^#!//' | tr -d ' ')
+else
+    GRAPHIFY_PYTHON="python3"
+fi
+"""
+
 _HOOK_SCRIPT = """\
 # graphify-hook-start
 # Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
@@ -18,8 +28,9 @@ if [ -z "$CHANGED" ]; then
     exit 0
 fi
 
+""" + _PYTHON_DETECT + """
 export GRAPHIFY_CHANGED="$CHANGED"
-python3 -c "
+$GRAPHIFY_PYTHON -c "
 import os, sys
 from pathlib import Path
 
@@ -67,8 +78,9 @@ if [ ! -d "graphify-out" ]; then
     exit 0
 fi
 
+""" + _PYTHON_DETECT + """
 echo "[graphify] Branch switched - rebuilding knowledge graph (code files)..."
-python3 -c "
+$GRAPHIFY_PYTHON -c "
 from graphify.watch import _rebuild_code
 from pathlib import Path
 import sys

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -10,9 +10,16 @@ _CHECKOUT_MARKER_END = "# graphify-checkout-hook-end"
 
 _PYTHON_DETECT = """\
 # Detect the correct Python interpreter (handles pipx, venv, system installs)
-GRAPHIFY_BIN=$(which graphify 2>/dev/null)
+GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
 if [ -n "$GRAPHIFY_BIN" ]; then
-    GRAPHIFY_PYTHON=$(head -1 "$GRAPHIFY_BIN" | sed 's/^#!//' | tr -d ' ')
+    _SHEBANG=$(head -1 "$GRAPHIFY_BIN" | sed 's/^#![[:space:]]*//')
+    case "$_SHEBANG" in
+        */env\\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+        *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+    esac
+    if ! "$GRAPHIFY_PYTHON" -c "import graphify" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    fi
 else
     GRAPHIFY_PYTHON="python3"
 fi


### PR DESCRIPTION
## Summary

- Git hooks (`post-commit`, `post-checkout`) hardcode `python3` as the interpreter, but when graphify is installed via `pipx`, the `graphify` module only exists inside pipx's isolated virtualenv — system `python3` cannot import it
- Added Python interpreter detection logic (already used in `skill.md` Step 1) to both hook scripts: reads the shebang from the `graphify` binary to find the correct interpreter, falls back to `python3` for system installs
- Fixes hook failures on systems where PEP 668 prevents `pip install` as root (modern distros like Ubuntu 24.04, Debian 12+)

## Follow-up fix (d0da7f1)

- Use POSIX `command -v` instead of non-standard `which`
- Handle `#!/usr/bin/env python3` shebangs correctly (previous `tr -d ' '` would produce `/usr/bin/envpython3`)
- Add import validation fallback when resolved interpreter cannot import graphify

## Reproduction

```bash
pipx install graphifyy
cd /some/git/repo
graphify hook install
git commit ...  # post-commit hook fails: ModuleNotFoundError: No module named 'graphify'
```

## Test plan

- [x] Verified `_PYTHON_DETECT` correctly resolves to pipx venv python
- [x] Verified the resolved interpreter can `import graphify` successfully
- [x] Verified generated hook scripts contain the detection block before `$GRAPHIFY_PYTHON -c` calls
- [x] Falls back to `python3` when `graphify` binary is not in PATH
- [x] Correctly parses `#!/usr/bin/env python3` style shebangs
- [x] Falls back to `python3` when resolved interpreter cannot import graphify