### PR TITLE
fix(update): prune graph nodes when source files are deleted (#51)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -21,9 +21,68 @@
 #    before any graph construction happens.
 #
 from __future__ import annotations
+import os
 import sys
 import networkx as nx
 from .validate import validate_extraction
+
+
+def _canonical_file_key(path: str) -> str:
+    """Normalize paths for comparing manifest paths to node source_file (Windows-safe)."""
+    return os.path.normcase(os.path.normpath(path))
+
+
+def prune_nodes_for_deleted_files(G: nx.Graph, deleted_files: list[str]) -> int:
+    """Remove nodes tied to deleted source files, plus incident edges.
+
+    Matches ``node['source_file']`` to paths in *deleted_files* using normalized
+    path comparison. Nodes without ``source_file`` are kept (e.g. some inferred
+    aggregates). Hyperedges that belong to a deleted file are dropped; remaining
+    hyperedges have removed node ids stripped, and hyperedges with fewer than two
+    nodes left are dropped.
+
+    Returns the number of nodes removed.
+    """
+    if not deleted_files:
+        return 0
+
+    deleted_keys = {_canonical_file_key(p) for p in deleted_files}
+    to_remove: list = []
+    for nid, data in G.nodes(data=True):
+        sf = (data.get("source_file") or "").strip()
+        if not sf:
+            continue
+        if _canonical_file_key(sf) in deleted_keys:
+            to_remove.append(nid)
+
+    removed_ids = set(to_remove)
+    G.remove_nodes_from(to_remove)
+    _prune_hyperedges_after_deletions(G, removed_ids, deleted_keys)
+    return len(to_remove)
+
+
+def _prune_hyperedges_after_deletions(
+    G: nx.Graph,
+    removed_node_ids: set[str],
+    deleted_keys: set[str],
+) -> None:
+    hes = G.graph.get("hyperedges")
+    if not hes:
+        return
+    new_list: list[dict] = []
+    for h in hes:
+        sf = (h.get("source_file") or "").strip()
+        if sf and _canonical_file_key(sf) in deleted_keys:
+            continue
+        nodes = h.get("nodes", [])
+        if isinstance(nodes, list):
+            nodes = [n for n in nodes if n not in removed_node_ids]
+        if len(nodes) < 2:
+            continue
+        h2 = dict(h)
+        h2["nodes"] = nodes
+        new_list.append(h2)
+    G.graph["hyperedges"] = new_list
 
 
 def build_from_json(extraction: dict) -> nx.Graph:

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -635,12 +635,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -669,7 +674,7 @@ Then:
 ```bash
 $(cat .graphify_python) -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -678,6 +683,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -692,12 +692,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -726,7 +731,7 @@ Then:
 ```bash
 $(cat .graphify_python) -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -735,6 +740,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -688,12 +688,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -722,7 +727,7 @@ Then:
 ```bash
 $(cat .graphify_python) -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -731,6 +736,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -687,12 +687,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -721,7 +726,7 @@ Then:
 ```bash
 $(cat .graphify_python) -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -730,6 +735,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -682,12 +682,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -716,7 +721,7 @@ Then:
 ```powershell
 python -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -725,6 +730,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -691,12 +691,17 @@ from pathlib import Path
 
 result = detect_incremental(Path('INPUT_PATH'))
 new_total = result.get('new_total', 0)
+deleted_files = result.get('deleted_files') or []
 print(json.dumps(result, indent=2))
 Path('.graphify_incremental.json').write_text(json.dumps(result))
-if new_total == 0:
+if new_total == 0 and not deleted_files:
     print('No files changed since last run. Nothing to update.')
     raise SystemExit(0)
-print(f'{new_total} new/changed file(s) to re-extract.')
+if new_total == 0 and deleted_files:
+    print(f'{len(deleted_files)} file(s) removed from corpus — graph will be pruned (no re-extraction).')
+    Path('.graphify_extract.json').write_text(json.dumps({'nodes': [], 'edges': [], 'hyperedges': []}))
+else:
+    print(f'{new_total} new/changed file(s) to re-extract.')
 "
 ```
 
@@ -725,7 +730,7 @@ Then:
 ```bash
 $(cat .graphify_python) -c "
 import sys, json
-from graphify.build import build_from_json
+from graphify.build import build_from_json, prune_nodes_for_deleted_files
 from graphify.export import to_json
 from networkx.readwrite import json_graph
 import networkx as nx
@@ -734,6 +739,15 @@ from pathlib import Path
 # Load existing graph
 existing_data = json.loads(Path('graphify-out/graph.json').read_text())
 G_existing = json_graph.node_link_graph(existing_data, edges='links')
+if 'hyperedges' in existing_data:
+    G_existing.graph['hyperedges'] = list(existing_data['hyperedges'])
+
+# Remove nodes for files deleted since last run (see detect_incremental deleted_files)
+inc = json.loads(Path('.graphify_incremental.json').read_text()) if Path('.graphify_incremental.json').exists() else {}
+deleted = inc.get('deleted_files') or []
+if deleted:
+    n_pruned = prune_nodes_for_deleted_files(G_existing, deleted)
+    print(f'Pruned {n_pruned} node(s) for {len(deleted)} deleted source file(s)')
 
 # Load new extraction
 new_extraction = json.loads(Path('.graphify_extract.json').read_text())

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,33 +1,44 @@
 import json
 from pathlib import Path
-from graphify.build import build_from_json, build
+
+from networkx.readwrite import json_graph
+
+from graphify.build import build, build_from_json, prune_nodes_for_deleted_files
+from graphify.detect import detect_incremental
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
+
 def load_extraction():
     return json.loads((FIXTURES / "extraction.json").read_text())
+
 
 def test_build_from_json_node_count():
     G = build_from_json(load_extraction())
     assert G.number_of_nodes() == 4
 
+
 def test_build_from_json_edge_count():
     G = build_from_json(load_extraction())
     assert G.number_of_edges() == 4
 
+
 def test_nodes_have_label():
     G = build_from_json(load_extraction())
     assert G.nodes["n_transformer"]["label"] == "Transformer"
+
 
 def test_edges_have_confidence():
     G = build_from_json(load_extraction())
     data = G.edges["n_attention", "n_concept_attn"]
     assert data["confidence"] == "INFERRED"
 
+
 def test_ambiguous_edge_preserved():
     G = build_from_json(load_extraction())
     data = G.edges["n_layernorm", "n_concept_attn"]
     assert data["confidence"] == "AMBIGUOUS"
+
 
 def test_build_merges_multiple_extractions():
     ext1 = {"nodes": [{"id": "n1", "label": "A", "file_type": "code", "source_file": "a.py"}],
@@ -39,3 +50,244 @@ def test_build_merges_multiple_extractions():
     G = build([ext1, ext2])
     assert G.number_of_nodes() == 2
     assert G.number_of_edges() == 1
+
+
+# --- prune / --update (deleted source files) ---
+
+
+def test_detect_incremental_lists_deleted_files(tmp_path):
+    """Manifest entries for removed files appear in deleted_files."""
+    gone = tmp_path / "gone.py"
+    stay = tmp_path / "stay.py"
+    gone.write_text("def gone(): pass\n", encoding="utf-8")
+    stay.write_text("def stay(): pass\n", encoding="utf-8")
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({str(gone): 1.0, str(stay): 2.0}),
+        encoding="utf-8",
+    )
+
+    gone.unlink()
+
+    result = detect_incremental(tmp_path, manifest_path=str(manifest_path))
+    assert str(gone) in result["deleted_files"]
+    assert str(stay) not in result["deleted_files"]
+
+
+def test_detect_incremental_no_deletions_empty_deleted_files(tmp_path):
+    """When manifest matches current files, deleted_files is empty."""
+    f = tmp_path / "keep.py"
+    f.write_text("def x(): pass\n", encoding="utf-8")
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({str(f): 100.0}), encoding="utf-8")
+
+    result = detect_incremental(tmp_path, manifest_path=str(manifest_path))
+    assert result["deleted_files"] == []
+
+
+def test_prune_after_incremental_matches_detect_paths(tmp_path):
+    """deleted_files from detect_incremental removes matching source_file nodes."""
+    gone = tmp_path / "gone.py"
+    stay = tmp_path / "stay.py"
+    gone.write_text("def gone(): pass\n", encoding="utf-8")
+    stay.write_text("def stay(): pass\n", encoding="utf-8")
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({str(gone): 1.0, str(stay): 2.0}),
+        encoding="utf-8",
+    )
+    gone.unlink()
+
+    inc = detect_incremental(tmp_path, manifest_path=str(manifest_path))
+    deleted = inc["deleted_files"]
+    assert deleted
+
+    ext = {
+        "nodes": [
+            {"id": "n_gone", "label": "gone_fn", "source_file": str(gone)},
+            {"id": "n_stay", "label": "stay_fn", "source_file": str(stay)},
+        ],
+        "edges": [
+            {
+                "source": "n_gone",
+                "target": "n_stay",
+                "relation": "calls",
+                "confidence": "EXTRACTED",
+                "source_file": str(gone),
+            }
+        ],
+        "hyperedges": [],
+    }
+    G = build_from_json(ext)
+    assert prune_nodes_for_deleted_files(G, deleted) == 1
+    assert set(G.nodes()) == {"n_stay"}
+    assert G.number_of_edges() == 0
+
+
+def test_prune_then_merge_update_like_skill(tmp_path):
+    """Load graph JSON → prune → merge empty extraction (skill order)."""
+    gone = tmp_path / "gone.py"
+    stay = tmp_path / "stay.py"
+    gone.write_text("x=1\n", encoding="utf-8")
+    stay.write_text("y=2\n", encoding="utf-8")
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({str(gone): 1.0, str(stay): 2.0}),
+        encoding="utf-8",
+    )
+    gone.unlink()
+
+    inc = detect_incremental(tmp_path, manifest_path=str(manifest_path))
+
+    existing_data = {
+        "nodes": [
+            {"id": "a", "label": "A", "source_file": str(gone)},
+            {"id": "b", "label": "B", "source_file": str(stay)},
+        ],
+        "links": [],
+        "hyperedges": [],
+    }
+    G_existing = json_graph.node_link_graph(existing_data, edges="links")
+    if "hyperedges" in existing_data:
+        G_existing.graph["hyperedges"] = list(existing_data["hyperedges"])
+
+    prune_nodes_for_deleted_files(G_existing, inc["deleted_files"])
+    G_new = build_from_json({"nodes": [], "edges": [], "hyperedges": []})
+    G_existing.update(G_new)
+
+    assert set(G_existing.nodes()) == {"b"}
+    assert G_existing.number_of_edges() == 0
+
+
+def test_prune_removes_nodes_and_incident_edges():
+    ext = {
+        "nodes": [
+            {"id": "x1", "label": "X", "source_file": "gone.py"},
+            {"id": "x2", "label": "Y", "source_file": "stay.py"},
+        ],
+        "edges": [
+            {
+                "source": "x1",
+                "target": "x2",
+                "relation": "calls",
+                "confidence": "EXTRACTED",
+                "source_file": "gone.py",
+            },
+        ],
+        "hyperedges": [],
+    }
+    G = build_from_json(ext)
+    assert prune_nodes_for_deleted_files(G, ["gone.py"]) == 1
+    assert "x1" not in G and "x2" in G and G.number_of_edges() == 0
+
+
+def test_prune_path_normalization():
+    p = Path("sub") / "foo.py"
+    G = build_from_json(
+        {"nodes": [{"id": "a", "label": "A", "source_file": str(p)}], "edges": []}
+    )
+    assert prune_nodes_for_deleted_files(G, ["sub/foo.py"]) == 1
+    assert G.number_of_nodes() == 0
+
+
+def test_prune_keeps_nodes_without_source_file():
+    G = build_from_json(
+        {
+            "nodes": [
+                {"id": "ext", "label": "stdlib", "source_file": ""},
+                {"id": "x", "label": "X", "source_file": "gone.py"},
+            ],
+            "edges": [],
+        }
+    )
+    prune_nodes_for_deleted_files(G, ["gone.py"])
+    assert "ext" in G and "x" not in G
+
+
+def test_prune_hyperedges_when_file_deleted():
+    G = build_from_json(
+        {
+            "nodes": [
+                {"id": "A", "label": "A", "source_file": "auth.py"},
+                {"id": "B", "label": "B", "source_file": "auth.py"},
+                {"id": "C", "label": "C", "source_file": "other.py"},
+            ],
+            "edges": [],
+            "hyperedges": [
+                {
+                    "id": "h1",
+                    "label": "auth",
+                    "nodes": ["A", "B", "C"],
+                    "source_file": "auth.py",
+                }
+            ],
+        }
+    )
+    prune_nodes_for_deleted_files(G, ["auth.py"])
+    assert G.graph.get("hyperedges") == []
+    assert set(G.nodes()) == {"C"}
+
+
+def test_prune_noop_when_no_deleted_list():
+    G = build_from_json(
+        {"nodes": [{"id": "a", "label": "A", "source_file": "f.py"}], "edges": []}
+    )
+    assert prune_nodes_for_deleted_files(G, []) == 0
+    assert "a" in G
+
+
+def test_prune_drops_hyperedge_when_fewer_than_two_nodes_remain():
+    G = build_from_json(
+        {
+            "nodes": [
+                {"id": "A", "label": "A", "source_file": "keep.py"},
+                {"id": "B", "label": "B", "source_file": "gone.py"},
+            ],
+            "edges": [],
+            "hyperedges": [
+                {
+                    "id": "h1",
+                    "label": "pair",
+                    "nodes": ["A", "B"],
+                    "source_file": "keep.py",
+                }
+            ],
+        }
+    )
+    prune_nodes_for_deleted_files(G, ["gone.py"])
+    assert G.graph.get("hyperedges") == []
+
+
+def test_prune_second_call_removes_nothing():
+    G = build_from_json(
+        {"nodes": [{"id": "a", "label": "A", "source_file": "f.py"}], "edges": []}
+    )
+    assert prune_nodes_for_deleted_files(G, ["f.py"]) == 1
+    assert G.number_of_nodes() == 0
+    assert prune_nodes_for_deleted_files(G, ["f.py"]) == 0
+
+
+def test_prune_deleted_path_not_in_graph_is_safe():
+    """Extra paths in deleted_files that do not match any node are ignored."""
+    G = build_from_json(
+        {"nodes": [{"id": "a", "label": "A", "source_file": "only.py"}], "edges": []}
+    )
+    assert prune_nodes_for_deleted_files(G, ["missing.py", "only.py"]) == 1
+    assert G.number_of_nodes() == 0
+
+
+def test_prune_multiple_deleted_files_one_call():
+    G = build_from_json(
+        {
+            "nodes": [
+                {"id": "a", "label": "A", "source_file": "a.py"},
+                {"id": "b", "label": "B", "source_file": "b.py"},
+            ],
+            "edges": [],
+        }
+    )
+    assert prune_nodes_for_deleted_files(G, ["a.py", "b.py"]) == 2
+    assert G.number_of_nodes() == 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,8 +1,16 @@
 """Tests for hooks.py - git hook install/uninstall."""
 import subprocess
+import sys
 from pathlib import Path
 import pytest
 from graphify.hooks import install, uninstall, status, _HOOK_MARKER, _CHECKOUT_MARKER
+
+
+def _assert_hook_executable(hook: Path) -> None:
+    """Unix git hooks must be executable; Windows does not expose Unix mode bits."""
+    assert hook.exists() and hook.stat().st_size > 0
+    if sys.platform != "win32":
+        assert hook.stat().st_mode & 0o111
 
 
 def _make_git_repo(tmp_path: Path) -> Path:
@@ -23,7 +31,7 @@ def test_install_is_executable(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
     hook = repo / ".git" / "hooks" / "post-commit"
-    assert hook.stat().st_mode & 0o111  # executable bit set
+    _assert_hook_executable(hook)
 
 
 def test_install_idempotent(tmp_path):
@@ -92,7 +100,7 @@ def test_install_post_checkout_is_executable(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
     hook = repo / ".git" / "hooks" / "post-checkout"
-    assert hook.stat().st_mode & 0o111
+    _assert_hook_executable(hook)
 
 
 def test_uninstall_removes_post_checkout_hook(tmp_path):


### PR DESCRIPTION

`detect_incremental()` already computes `deleted_files` (manifest paths that no longer exist on disk). The `--update` merge path merged new extractions into the existing graph but never removed nodes tied to deleted sources, so `graph.json` could retain **stale nodes and edges**—reported in [#51](https://github.com/safishamsi/graphify/issues/51).

### What changed

**1. Library: `prune_nodes_for_deleted_files` (`graphify/build.py`)**

- Selects nodes whose `source_file` matches an entry in `deleted_files`, comparing paths via a normalized key (`normpath` + `normcase`) so Windows and POSIX spellings align with manifest strings.
- Skips nodes with no `source_file` (e.g. external/stdlib-style stubs).
- Removes selected nodes; incident edges drop with the nodes (undirected `Graph` semantics).
- Updates `G.graph["hyperedges"]`: drop hyperedges anchored to a deleted file; otherwise strip removed node ids; drop entries with fewer than two remaining members (avoids dangling references in exports/report).

**2. Skills: `--update` flow (`skill*.md`)**

- **Delete-only updates** no longer early-exit when `new_total == 0` if `deleted_files` is non-empty; writes an empty extraction artifact so the merge step still runs.
- **Merge:** load `hyperedges` from existing `graph.json` into the in-memory graph (parity with prior `to_json` output), **prune** using `deleted_files` from `.graphify_incremental.json`, then merge the new extraction and continue with the existing pipeline (cluster / report / export unchanged).

**3. Tests**

- `tests/test_build.py`: regression coverage for incremental detection, pruning, merge ordering, path normalization, and hyperedge behavior.
- `tests/test_hooks.py`: relax executable-bit assertions on **Windows** (POSIX execute bits are not reflected in `st_mode` the same way); still assert executable semantics on non-Windows. Unrelated to #51 but restores a green suite on Windows CI/dev machines.

### How to verify

```bash
pip install -e ".[mcp,pdf,watch]"
pytest tests/ -q
```

### Scope / follow-ups

- **`--update --no-prune`** is **out of scope** here; pruning is **always applied** in the updated skill merge. If maintainers want an opt-out, that should be a separate change (CLI flag and/or skill parameter).

---
Closes #51 