### PR TITLE
fix: pin tree-sitter>=0.23.0 with clear version error

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2334,6 +2334,24 @@ def extract_elixir(path: Path) -> dict:
 
 # ── Main extract and collect_files ────────────────────────────────────────────
 
+
+def _check_tree_sitter_version() -> None:
+    """Raise a clear error if tree-sitter is too old for the new Language API."""
+    try:
+        from tree_sitter import LANGUAGE_VERSION
+    except ImportError:
+        raise ImportError(
+            "tree-sitter is not installed. Run: pip install 'tree-sitter>=0.23.0'"
+        )
+    # Language API v2 starts at LANGUAGE_VERSION 14
+    if LANGUAGE_VERSION < 14:
+        import tree_sitter as _ts
+        raise RuntimeError(
+            f"tree-sitter {getattr(_ts, '__version__', 'unknown')} is too old. "
+            f"graphify requires tree-sitter >= 0.23.0 (Language API v2). "
+            f"Run: pip install --upgrade tree-sitter"
+        )
+
 def extract(paths: list[Path]) -> dict:
     """Extract AST nodes and edges from a list of code files.
 
@@ -2342,6 +2360,7 @@ def extract(paths: list[Path]) -> dict:
     2. Cross-file import resolution: turns file-level imports into
        class-level INFERRED edges (DigestAuth --uses--> Response)
     """
+    _check_tree_sitter_version()
     per_file: list[dict] = []
 
     # Infer a common root for cache keys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["claude", "claude-code", "codex", "opencode", "knowledge-graph", "ra
 requires-python = ">=3.10"
 dependencies = [
     "networkx",
-    "tree-sitter",
+    "tree-sitter>=0.23.0",
     "tree-sitter-python",
     "tree-sitter-javascript",
     "tree-sitter-typescript",


### PR DESCRIPTION
## Summary
Users with `tree-sitter<0.23.0` hit a cryptic `TypeError: Language.__init__() missing 1 required positional argument: 'name'` because the codebase uses the Language API v2 (`Language(lang_fn())`) but `pyproject.toml` had no minimum version pin.

Pins `tree-sitter>=0.23.0` in `pyproject.toml` and adds a `_check_tree_sitter_version()` guard at the top of `extract()` that catches stale environments and gives an actionable error message instead of a deep traceback.

## Behavior
- **Before:** `TypeError` crash deep in the AST pipeline, no indication of what's wrong
- **After:** `RuntimeError: tree-sitter X.Y.Z is too old. graphify requires tree-sitter >= 0.23.0. Run: pip install --upgrade tree-sitter`

## Diff
- `pyproject.toml`: `"tree-sitter"` → `"tree-sitter>=0.23.0"` (+1/-1)
- `graphify/extract.py`: `_check_tree_sitter_version()` function + call in `extract()` (+19)

Total: 2 files, +20/-1

Addresses #52 (Issue 1)