### PR TITLE
feat: add /graphify source add|list|reload|delete skill commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ When the user types `/graphify`, invoke the Skill tool with `skill: "graphify"` 
 /graphify add https://... --author "Name"             # tag the original author
 /graphify add https://... --contributor "Name"        # tag who added it to the corpus
 
+# source management - register paths, reload all at once
+/graphify source add ./my-repo         # register a directory as a source
+/graphify source list                  # show all registered sources with status
+/graphify source reload                # incremental rebuild of all registered sources
+/graphify source reload ./my-repo      # rebuild one specific source
+/graphify source delete ./my-repo      # remove from registry
+
 /graphify query "what connects attention to the optimizer?"
 /graphify query "what connects attention to the optimizer?" --dfs   # trace a specific path
 /graphify query "what connects attention to the optimizer?" --budget 1500  # cap at N tokens
@@ -202,6 +209,8 @@ Works with any mix of file types:
 
 **Git hooks** (`graphify hook install`) - installs post-commit and post-checkout hooks. Graph rebuilds automatically after every commit and every branch switch. If a rebuild fails, the hook exits with a non-zero code so git surfaces the error instead of silently continuing. No background process needed.
 
+**Source management** (`/graphify source add|list|reload|delete`) - register multiple directories as sources and reload all at once with one command. Each source gets its own `graphify-out/` with independent graph, cache, and manifest. Registry stored at `graphify-out/sources.json` — paths tracked by inode so renames within the same parent directory are handled automatically.
+
 **Wiki** (`--wiki`) - Wikipedia-style markdown articles per community and god node, with an `index.md` entry point. Point any agent at `index.md` and it can navigate the knowledge base by reading files instead of parsing JSON.
 
 ## Worked examples
@@ -211,6 +220,7 @@ Works with any mix of file types:
 | Karpathy repos + 5 papers + 4 images | 52 | **71.5x** | [`worked/karpathy-repos/`](worked/karpathy-repos/) |
 | graphify source + Transformer paper | 4 | **5.4x** | [`worked/mixed-corpus/`](worked/mixed-corpus/) |
 | httpx (synthetic Python library) | 6 | ~1x | [`worked/httpx/`](worked/httpx/) |
+| source management workflow | 7 | same as example | [`worked/source-control/`](worked/source-control/) |
 
 Token reduction scales with corpus size. 6 files fits in a context window anyway, so graph value there is structural clarity, not compression. At 52 files (code + papers + images) you get 71x+. Each `worked/` folder has the raw input files and the actual output (`GRAPH_REPORT.md`, `graph.json`) so you can run it yourself and verify the numbers.
 

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -28,6 +28,11 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
+/graphify source add <path>                           # register a local directory as a source
+/graphify source delete <path>                        # remove a source from the registry
+/graphify source list                                 # show all registered sources with status
+/graphify source reload                               # incremental rebuild of all registered sources
+/graphify source reload <path>                        # incremental rebuild of one specific source
 /graphify query "<question>"                          # BFS traversal - broad context
 /graphify query "<question>" --dfs                    # DFS - trace a specific path
 /graphify query "<question>" --budget 1500            # cap answer at N tokens
@@ -1207,6 +1212,263 @@ This writes a `## graphify` section to the local `CLAUDE.md` that instructs Clau
 ```bash
 graphify claude uninstall  # remove the section
 ```
+
+---
+
+## For /graphify source
+
+Manage a registry of source paths stored at `graphify-out/sources.json`. Sources are tracked by absolute path + inode so renames within the same parent directory are handled automatically.
+
+### /graphify source add
+
+First ensure graphify is installed (Step 1 of the main pipeline). Then:
+
+```bash
+$(cat .graphify_python) -c "
+from graphify.sources import add_source
+from pathlib import Path
+try:
+    entry = add_source('SOURCE_PATH', Path('graphify-out/sources.json'))
+    print(f\"Added: {entry['path']}  (inode {entry['inode']})\")
+except ValueError as e:
+    print(f'error: {e}')
+"
+```
+
+Replace `SOURCE_PATH` with the path the user provided. Expand `~` and resolve relative paths if needed — pass the resolved absolute path.
+
+### /graphify source delete
+
+```bash
+$(cat .graphify_python) -c "
+from graphify.sources import delete_source
+from pathlib import Path
+ok = delete_source('SOURCE_PATH', Path('graphify-out/sources.json'))
+print('Removed.' if ok else 'Not found in registry.')
+"
+```
+
+### /graphify source list
+
+```bash
+$(cat .graphify_python) -c "
+from graphify.sources import list_sources
+from pathlib import Path
+sources = list_sources(Path('graphify-out/sources.json'))
+if not sources:
+    print('No sources registered. Run: /graphify source add <path>')
+else:
+    for s in sources:
+        status = {'ok': 'OK', 'renamed': 'RENAMED', 'missing': 'MISSING'}.get(s['status'], '?')
+        current = s.get('current_path', s['path'])
+        renamed = f\"  (was: {s['path']})\" if s['status'] == 'renamed' else ''
+        print(f\"  [{status}]  {current}{renamed}  (added {s['added'][:10]})\")
+"
+```
+
+### /graphify source reload [path]
+
+Runs the incremental (`--update`) pipeline on each registered source (or just the specified one). Each source gets its own `graphify-out/` inside its directory.
+
+**Step 1 - Ensure graphify is installed** (same as main pipeline Step 1).
+
+**Step 2 - Load sources and resolve paths**
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.sources import list_sources
+from pathlib import Path
+
+filter_path = 'FILTER_PATH_OR_NONE'
+sources = list_sources(Path('graphify-out/sources.json'))
+
+if not sources:
+    print('No sources registered. Run: /graphify source add <path>')
+    raise SystemExit(0)
+
+to_reload = []
+for s in sources:
+    current = s.get('current_path', s['path'])
+    if s['status'] == 'missing':
+        print(f\"SKIP (missing): {s['path']}\")
+        continue
+    if filter_path and filter_path != 'None' and current != str(Path(filter_path).resolve()):
+        continue
+    to_reload.append(current)
+
+if not to_reload:
+    print('No matching sources to reload.')
+    raise SystemExit(0)
+
+Path('.graphify_reload_sources.txt').write_text('\n'.join(to_reload))
+print(f'Sources to reload: {len(to_reload)}')
+for p in to_reload:
+    print(f'  {p}')
+"
+```
+
+Replace `FILTER_PATH_OR_NONE` with the user-provided path argument, or the literal string `None` if no path was given.
+
+**Step 3 - For each source, run the incremental pipeline sequentially**
+
+Load `.graphify_reload_sources.txt`. For **each source path** in the file, run the following steps. Process one at a time — parallel processing causes temp file conflicts.
+
+Print `\nReloading SRCPATH_VALUE ...` before each source.
+
+**Detect changes:**
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.detect import detect_incremental
+from pathlib import Path
+
+SRCPATH = Path('SRCPATH_VALUE')
+result = detect_incremental(SRCPATH, manifest_path=str(SRCPATH / 'graphify-out' / 'manifest.json'))
+new_total = result.get('new_total', 0)
+(SRCPATH / '.graphify_incremental.json').write_text(json.dumps(result))
+if new_total == 0:
+    print('No changes since last run - nothing to update.')
+    raise SystemExit(0)
+print(f'{new_total} new/changed file(s) to re-extract.')
+"
+```
+
+If this prints "No changes", skip to the next source.
+
+**Check if code-only:**
+```bash
+$(cat .graphify_python) -c "
+import json
+from pathlib import Path
+
+SRCPATH = Path('SRCPATH_VALUE')
+result = json.loads((SRCPATH / '.graphify_incremental.json').read_text())
+code_exts = {'.py','.ts','.js','.go','.rs','.java','.cpp','.c','.rb','.swift','.kt','.cs','.scala','.php','.cc','.cxx','.hpp','.h','.kts','.lua','.toc'}
+new_files = result.get('new_files', {})
+all_changed = [f for files in new_files.values() for f in files]
+code_only = all(Path(f).suffix.lower() in code_exts for f in all_changed)
+print('code_only:', code_only)
+"
+```
+
+**AST extraction (always run):**
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.extract import collect_files, extract
+from pathlib import Path
+
+SRCPATH = Path('SRCPATH_VALUE')
+result = json.loads((SRCPATH / '.graphify_incremental.json').read_text())
+code_files = []
+for f in result.get('new_files', {}).get('code', []):
+    code_files.extend(collect_files(Path(f)) if Path(f).is_dir() else [Path(f)])
+if code_files:
+    ast_result = extract(code_files)
+    (SRCPATH / '.graphify_ast.json').write_text(json.dumps(ast_result, indent=2))
+    print(f'AST: {len(ast_result[\"nodes\"])} nodes, {len(ast_result[\"edges\"])} edges')
+else:
+    (SRCPATH / '.graphify_ast.json').write_text(json.dumps({'nodes':[],'edges':[],'input_tokens':0,'output_tokens':0}))
+    print('No changed code files.')
+"
+```
+
+**If NOT code-only**: run semantic extraction on the changed non-code files. Use the same subagent dispatch pattern as Step 3B in the main pipeline. Pass each changed doc/paper/image file from `result.get('new_files', {})` (excluding code extensions). Write the merged semantic result to `SRCPATH / '.graphify_semantic.json'`. Use `check_semantic_cache` and `save_semantic_cache` as usual.
+
+If `code_only` is True: create an empty semantic result file:
+```bash
+$(cat .graphify_python) -c "
+import json
+from pathlib import Path
+SRCPATH = Path('SRCPATH_VALUE')
+(SRCPATH / '.graphify_semantic.json').write_text(json.dumps({'nodes':[],'edges':[],'hyperedges':[],'input_tokens':0,'output_tokens':0}))
+"
+```
+
+**Merge AST + semantic:**
+```bash
+$(cat .graphify_python) -c "
+import json
+from pathlib import Path
+
+SRCPATH = Path('SRCPATH_VALUE')
+ast = json.loads((SRCPATH / '.graphify_ast.json').read_text())
+sem = json.loads((SRCPATH / '.graphify_semantic.json').read_text())
+
+seen = {n['id'] for n in ast['nodes']}
+merged_nodes = list(ast['nodes'])
+for n in sem['nodes']:
+    if n['id'] not in seen:
+        merged_nodes.append(n)
+        seen.add(n['id'])
+
+merged = {
+    'nodes': merged_nodes,
+    'edges': ast['edges'] + sem['edges'],
+    'hyperedges': sem.get('hyperedges', []),
+    'input_tokens': sem.get('input_tokens', 0),
+    'output_tokens': sem.get('output_tokens', 0),
+}
+(SRCPATH / '.graphify_extract.json').write_text(json.dumps(merged, indent=2))
+print(f'Merged: {len(merged_nodes)} nodes, {len(merged[\"edges\"])} edges')
+"
+```
+
+**Merge into existing graph:**
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.export import to_json
+from networkx.readwrite import json_graph
+import networkx as nx
+from pathlib import Path
+
+SRCPATH = Path('SRCPATH_VALUE')
+out_dir = SRCPATH / 'graphify-out'
+out_dir.mkdir(parents=True, exist_ok=True)
+
+existing_path = out_dir / 'graph.json'
+if existing_path.exists():
+    G = json_graph.node_link_graph(json.loads(existing_path.read_text()), edges='links')
+else:
+    G = nx.DiGraph()
+
+G_new = build_from_json(json.loads((SRCPATH / '.graphify_extract.json').read_text()))
+G.update(G_new)
+to_json(G, {}, str(out_dir / 'graph.json'))
+print(f'Graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges')
+"
+```
+
+Then run **Steps 4–9 from the main pipeline** on this source, substituting:
+- All `Path('graphify-out/...')` → `Path('SRCPATH_VALUE/graphify-out/...')`
+- All `Path('.graphify_*.json')` → `Path('SRCPATH_VALUE/.graphify_*.json')`
+- `INPUT_PATH` in report generation → `SRCPATH_VALUE`
+
+**Clean up temp files after each source:**
+```bash
+$(cat .graphify_python) -c "
+from pathlib import Path
+SRCPATH = Path('SRCPATH_VALUE')
+for f in ['.graphify_incremental.json', '.graphify_ast.json', '.graphify_semantic.json',
+          '.graphify_extract.json', '.graphify_analysis.json', '.graphify_labels.json',
+          '.graphify_cached.json', '.graphify_uncached.txt', '.graphify_semantic_new.json']:
+    (SRCPATH / f).unlink(missing_ok=True)
+"
+```
+
+**Step 4 - Summary**
+
+After processing all sources, print:
+```
+Reload complete.
+  /path/to/source1  →  N nodes, M edges
+  /path/to/source2  →  no changes
+```
+
+Clean up: `rm -f .graphify_reload_sources.txt`
 
 ---
 

--- a/graphify/sources.py
+++ b/graphify/sources.py
@@ -1,0 +1,112 @@
+"""Source registry for graphify source add|delete|list|reload."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SOURCES_FILE = Path("graphify-out/sources.json")
+
+
+def _load_raw(sources_file: Path) -> dict:
+    if sources_file.exists():
+        try:
+            return json.loads(sources_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            pass
+    return {"sources": []}
+
+
+def load_sources(sources_file: Path = _SOURCES_FILE) -> list[dict]:
+    """Return the list of registered source entries."""
+    return _load_raw(sources_file)["sources"]
+
+
+def save_sources(sources: list[dict], sources_file: Path = _SOURCES_FILE) -> None:
+    """Write the sources list back to disk."""
+    sources_file.parent.mkdir(parents=True, exist_ok=True)
+    sources_file.write_text(json.dumps({"sources": sources}, indent=2), encoding="utf-8")
+
+
+def add_source(path: str, sources_file: Path = _SOURCES_FILE) -> dict:
+    """Register a source path.
+
+    Resolves to an absolute path, stores the inode for rename tracking.
+    Raises ValueError if the path does not exist or is already registered.
+    """
+    p = Path(path).resolve()
+    if not p.exists():
+        raise ValueError(f"Path does not exist: {p}")
+    inode = p.stat().st_ino
+    sources = load_sources(sources_file)
+    for s in sources:
+        if s["path"] == str(p) or s.get("inode") == inode:
+            raise ValueError(f"Source already registered: {s['path']}")
+    entry = {
+        "path": str(p),
+        "inode": inode,
+        "added": datetime.now(timezone.utc).isoformat(),
+    }
+    sources.append(entry)
+    save_sources(sources, sources_file)
+    return entry
+
+
+def delete_source(path: str, sources_file: Path = _SOURCES_FILE) -> bool:
+    """Remove a source by path or inode match.
+
+    Returns True if a source was found and removed, False if not found.
+    """
+    p = Path(path).resolve()
+    sources = load_sources(sources_file)
+    target_inode = p.stat().st_ino if p.exists() else None
+    new = [
+        s for s in sources
+        if s["path"] != str(p) and s.get("inode") != target_inode
+    ]
+    if len(new) == len(sources):
+        return False
+    save_sources(new, sources_file)
+    return True
+
+
+def resolve_source_path(entry: dict) -> Path | None:
+    """Resolve a source entry to its current filesystem path.
+
+    Handles renames: if the stored path no longer exists, searches the parent
+    directory by inode to find the new name.
+    Returns None if the source cannot be located.
+    """
+    p = Path(entry["path"])
+    stored_inode = entry.get("inode")
+    if p.exists():
+        # Path still present — trust it regardless of inode (cross-fs moves)
+        if not stored_inode or p.stat().st_ino == stored_inode:
+            return p
+        return p
+    # Path gone — search parent by inode
+    if stored_inode and p.parent.exists():
+        for child in p.parent.iterdir():
+            try:
+                if child.stat().st_ino == stored_inode:
+                    return child
+            except OSError:
+                pass
+    return None
+
+
+def list_sources(sources_file: Path = _SOURCES_FILE) -> list[dict]:
+    """Return all sources with a status field: ok | renamed | missing."""
+    result = []
+    for s in load_sources(sources_file):
+        entry = dict(s)
+        current = resolve_source_path(s)
+        if current is None:
+            entry["status"] = "missing"
+        elif str(current) != s["path"]:
+            entry["status"] = "renamed"
+            entry["current_path"] = str(current)
+        else:
+            entry["status"] = "ok"
+        result.append(entry)
+    return result

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,181 @@
+"""Tests for graphify.sources — source registry CRUD."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from graphify.sources import (
+    add_source,
+    delete_source,
+    list_sources,
+    load_sources,
+    resolve_source_path,
+    save_sources,
+)
+
+
+@pytest.fixture
+def sources_file(tmp_path):
+    return tmp_path / "graphify-out" / "sources.json"
+
+
+@pytest.fixture
+def corpus_dir(tmp_path):
+    d = tmp_path / "my_repo"
+    d.mkdir()
+    return d
+
+
+class TestAddSource:
+    def test_adds_new_source(self, sources_file, corpus_dir):
+        entry = add_source(str(corpus_dir), sources_file)
+        assert entry["path"] == str(corpus_dir.resolve())
+        assert "inode" in entry
+        assert "added" in entry
+        sources = load_sources(sources_file)
+        assert len(sources) == 1
+        assert sources[0]["path"] == str(corpus_dir.resolve())
+
+    def test_stores_inode(self, sources_file, corpus_dir):
+        entry = add_source(str(corpus_dir), sources_file)
+        assert entry["inode"] == corpus_dir.stat().st_ino
+
+    def test_resolves_relative_path(self, sources_file, corpus_dir):
+        # Pass a str that resolves to corpus_dir
+        entry = add_source(str(corpus_dir), sources_file)
+        assert Path(entry["path"]).is_absolute()
+
+    def test_rejects_nonexistent_path(self, sources_file, tmp_path):
+        with pytest.raises(ValueError, match="does not exist"):
+            add_source(str(tmp_path / "ghost"), sources_file)
+
+    def test_rejects_duplicate_path(self, sources_file, corpus_dir):
+        add_source(str(corpus_dir), sources_file)
+        with pytest.raises(ValueError, match="already registered"):
+            add_source(str(corpus_dir), sources_file)
+
+    def test_rejects_duplicate_inode(self, sources_file, corpus_dir, tmp_path):
+        # Symlink to same inode — should be rejected
+        link = tmp_path / "link_to_repo"
+        link.symlink_to(corpus_dir)
+        add_source(str(corpus_dir), sources_file)
+        with pytest.raises(ValueError, match="already registered"):
+            add_source(str(link), sources_file)
+
+    def test_creates_sources_file(self, sources_file, corpus_dir):
+        assert not sources_file.exists()
+        add_source(str(corpus_dir), sources_file)
+        assert sources_file.exists()
+
+    def test_multiple_sources(self, sources_file, tmp_path):
+        d1 = tmp_path / "repo1"
+        d2 = tmp_path / "repo2"
+        d1.mkdir()
+        d2.mkdir()
+        add_source(str(d1), sources_file)
+        add_source(str(d2), sources_file)
+        sources = load_sources(sources_file)
+        assert len(sources) == 2
+
+
+class TestDeleteSource:
+    def test_removes_existing_source(self, sources_file, corpus_dir):
+        add_source(str(corpus_dir), sources_file)
+        ok = delete_source(str(corpus_dir), sources_file)
+        assert ok is True
+        assert load_sources(sources_file) == []
+
+    def test_returns_false_for_missing(self, sources_file, corpus_dir):
+        ok = delete_source(str(corpus_dir), sources_file)
+        assert ok is False
+
+    def test_removes_by_inode_when_path_matches(self, sources_file, corpus_dir):
+        add_source(str(corpus_dir), sources_file)
+        ok = delete_source(str(corpus_dir), sources_file)
+        assert ok is True
+
+    def test_does_not_remove_wrong_source(self, sources_file, tmp_path):
+        d1 = tmp_path / "repo1"
+        d2 = tmp_path / "repo2"
+        d1.mkdir()
+        d2.mkdir()
+        add_source(str(d1), sources_file)
+        ok = delete_source(str(d2), sources_file)
+        assert ok is False
+        assert len(load_sources(sources_file)) == 1
+
+
+class TestResolveSourcePath:
+    def test_returns_path_when_exists(self, corpus_dir):
+        entry = {"path": str(corpus_dir), "inode": corpus_dir.stat().st_ino}
+        assert resolve_source_path(entry) == corpus_dir
+
+    def test_returns_path_without_inode(self, corpus_dir):
+        entry = {"path": str(corpus_dir)}
+        assert resolve_source_path(entry) == corpus_dir
+
+    def test_returns_none_when_missing_and_no_inode(self, tmp_path):
+        ghost = tmp_path / "gone"
+        entry = {"path": str(ghost)}
+        assert resolve_source_path(entry) is None
+
+    def test_finds_renamed_path_by_inode(self, tmp_path):
+        original = tmp_path / "original_name"
+        original.mkdir()
+        inode = original.stat().st_ino
+        entry = {"path": str(original), "inode": inode}
+
+        renamed = tmp_path / "new_name"
+        original.rename(renamed)
+
+        result = resolve_source_path(entry)
+        assert result == renamed
+
+    def test_returns_none_when_inode_not_found(self, tmp_path):
+        ghost = tmp_path / "gone"
+        entry = {"path": str(ghost), "inode": 999999999}
+        assert resolve_source_path(entry) is None
+
+
+class TestListSources:
+    def test_empty_registry(self, sources_file):
+        result = list_sources(sources_file)
+        assert result == []
+
+    def test_ok_status(self, sources_file, corpus_dir):
+        add_source(str(corpus_dir), sources_file)
+        result = list_sources(sources_file)
+        assert len(result) == 1
+        assert result[0]["status"] == "ok"
+
+    def test_missing_status(self, sources_file, tmp_path):
+        # Manually write a source for a path that doesn't exist
+        ghost = tmp_path / "ghost_dir"
+        save_sources([{"path": str(ghost), "inode": 99999}], sources_file)
+        result = list_sources(sources_file)
+        assert result[0]["status"] == "missing"
+
+    def test_renamed_status(self, sources_file, tmp_path):
+        original = tmp_path / "original"
+        original.mkdir()
+        inode = original.stat().st_ino
+        add_source(str(original), sources_file)
+
+        renamed = tmp_path / "renamed"
+        original.rename(renamed)
+
+        result = list_sources(sources_file)
+        assert result[0]["status"] == "renamed"
+        assert result[0]["current_path"] == str(renamed)
+
+    def test_includes_all_fields(self, sources_file, corpus_dir):
+        add_source(str(corpus_dir), sources_file)
+        result = list_sources(sources_file)
+        entry = result[0]
+        assert "path" in entry
+        assert "inode" in entry
+        assert "added" in entry
+        assert "status" in entry

--- a/worked/source-control/GRAPH_REPORT.md
+++ b/worked/source-control/GRAPH_REPORT.md
@@ -1,0 +1,77 @@
+# Graph Report - worked/example/raw  (2026-04-08)
+
+## Corpus Check
+- Corpus is ~2,159 words - fits in a single context window. You may not need a graph.
+
+## Summary
+- 73 nodes · 112 edges · 5 communities detected
+- Extraction: 68% EXTRACTED · 32% INFERRED · 0% AMBIGUOUS · INFERRED: 36 edges (avg confidence: 0.5)
+- Token cost: 0 input · 0 output
+
+## God Nodes (most connected - your core abstractions)
+1. `ValidationError` - 11 edges
+2. `_ensure_storage()` - 7 edges
+3. `load_index()` - 7 edges
+4. `save_index()` - 6 edges
+5. `parse_file()` - 6 edges
+6. `validate_document()` - 6 edges
+7. `save_parsed()` - 5 edges
+8. `save_processed()` - 5 edges
+9. `delete_record()` - 5 edges
+10. `enrich_document()` - 5 edges
+
+## Surprising Connections (you probably didn't know these)
+- `API module - exposes the document pipeline over HTTP. Thin layer over parser, va` --uses--> `ValidationError`  [INFERRED]
+  worked/example/raw/api.py → worked/example/raw/validator.py
+- `Accept a list of file paths, run the full pipeline on each,     and return a sum` --uses--> `ValidationError`  [INFERRED]
+  worked/example/raw/api.py → worked/example/raw/validator.py
+- `Fetch a document by ID and return it.` --uses--> `ValidationError`  [INFERRED]
+  worked/example/raw/api.py → worked/example/raw/validator.py
+- `Delete a document by ID.` --uses--> `ValidationError`  [INFERRED]
+  worked/example/raw/api.py → worked/example/raw/validator.py
+- `List all document IDs in storage.` --uses--> `ValidationError`  [INFERRED]
+  worked/example/raw/api.py → worked/example/raw/validator.py
+
+## Communities
+
+### Community 0 - "Community 0"
+Cohesion: 0.21
+Nodes (16): delete_record(), _ensure_storage(), list_records(), load_index(), load_record(), Storage module - persists documents to disk and maintains the search index. All, Load the full document index from disk., Persist the index to disk. (+8 more)
+
+### Community 1 - "Community 1"
+Cohesion: 0.17
+Nodes (15): handle_delete(), handle_enrich(), handle_get(), handle_list(), handle_search(), handle_upload(), API module - exposes the document pipeline over HTTP. Thin layer over parser, va, Accept a list of file paths, run the full pipeline on each,     and return a sum (+7 more)
+
+### Community 2 - "Community 2"
+Cohesion: 0.2
+Nodes (13): batch_parse(), parse_and_save(), parse_file(), parse_json(), parse_markdown(), parse_plaintext(), Parser module - reads raw input documents and converts them into a structured fo, Read a file from disk and return a structured document. (+5 more)
+
+### Community 3 - "Community 3"
+Cohesion: 0.2
+Nodes (13): enrich_document(), extract_keywords(), find_cross_references(), normalize_text(), process_and_save(), Processor module - transforms validated documents into enriched records ready fo, Lowercase, strip extra whitespace, remove control characters., Pull non-stopword tokens from text, deduplicated. (+5 more)
+
+### Community 4 - "Community 4"
+Cohesion: 0.23
+Nodes (11): check_format(), check_required_fields(), normalize_fields(), Validator module - checks that parsed documents meet schema requirements before, Run all validation checks on a parsed document. Raises ValidationError on failur, Raise if any required field is missing., Raise if the format is not in the allowed list., Clean up text fields using the processor. (+3 more)
+
+## Knowledge Gaps
+- **28 isolated node(s):** `Storage module - persists documents to disk and maintains the search index. All`, `Load the full document index from disk.`, `Persist the index to disk.`, `Write a parsed document to storage. Returns the assigned record ID.`, `Write an enriched document to storage, updating the index with keywords.` (+23 more)
+  These have ≤1 connection - possible missing edges or undocumented components.
+
+## Suggested Questions
+_Questions this graph is uniquely positioned to answer:_
+
+- **Why does `ValidationError` connect `Community 1` to `Community 4`?**
+  _High betweenness centrality (0.111) - this node is a cross-community bridge._
+- **Are the 9 inferred relationships involving `ValidationError` (e.g. with `check_required_fields()` and `check_format()`) actually correct?**
+  _`ValidationError` has 9 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 6 inferred relationships involving `_ensure_storage()` (e.g. with `load_index()` and `save_index()`) actually correct?**
+  _`_ensure_storage()` has 6 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 5 inferred relationships involving `load_index()` (e.g. with `_ensure_storage()` and `save_parsed()`) actually correct?**
+  _`load_index()` has 5 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 4 inferred relationships involving `save_index()` (e.g. with `_ensure_storage()` and `save_parsed()`) actually correct?**
+  _`save_index()` has 4 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 4 inferred relationships involving `parse_file()` (e.g. with `parse_markdown()` and `parse_json()`) actually correct?**
+  _`parse_file()` has 4 INFERRED edges - model-reasoned connections that need verification._
+- **What connects `Storage module - persists documents to disk and maintains the search index. All`, `Load the full document index from disk.`, `Persist the index to disk.` to the rest of the system?**
+  _28 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/worked/source-control/README.md
+++ b/worked/source-control/README.md
@@ -1,0 +1,94 @@
+# Source Management Workflow
+
+Demonstrates `/graphify source add|list|reload|delete` — register directories as persistent sources and rebuild their graphs with a single command. No need to remember paths or re-run manually after each commit.
+
+## What this demos
+
+The source management system stores a registry of paths in `graphify-out/sources.json`. Once registered, `/graphify source reload` runs an incremental rebuild on every source, re-extracting only files that changed since the last run.
+
+This worked example uses `worked/example/raw/` as the corpus — a 7-file document+code pipeline with clear call relationships.
+
+## Input corpus
+
+```
+worked/example/raw/
+├── parser.py        — reads files, detects format, kicks off the pipeline
+├── validator.py     — schema checks, calls processor for text normalization
+├── processor.py     — keyword extraction, cross-reference detection
+├── storage.py       — persists everything, maintains the index
+├── api.py           — HTTP handlers that orchestrate the above four modules
+├── architecture.md  — design decisions and module responsibilities
+└── notes.md         — open questions and tradeoffs
+```
+
+## How to reproduce
+
+```bash
+pip install graphifyy
+graphify install   # Claude Code
+```
+
+Open Claude Code from the repo root and run:
+
+```
+# Step 1 — register the source
+/graphify source add ./worked/example/raw
+
+# Step 2 — confirm it was registered
+/graphify source list
+
+# Step 3 — run the full incremental pipeline on all registered sources
+/graphify source reload
+```
+
+Output lands in `worked/example/raw/graphify-out/` — the same `graph.json`, `GRAPH_REPORT.md`, and `graph.html` you'd get from running `/graphify ./worked/example/raw` directly.
+
+## What to expect
+
+```
+Sources to reload: 1
+  /path/to/worked/example/raw
+
+Reloading /path/to/worked/example/raw ...
+  7 new/changed file(s) to re-extract.
+  AST: 47 nodes, 52 edges
+  Semantic extraction: ~2 files → 1 agent, estimated ~45s
+  Merged: 56 nodes, 61 edges
+  Graph: 56 nodes, 61 edges, 2 communities
+
+Reload complete.
+  /path/to/worked/example/raw  →  56 nodes, 61 edges
+```
+
+After running, ask questions from your AI coding assistant:
+
+- "what calls storage directly?"
+- "what does the architecture doc say about validator design?"
+- "which module has the most connections?"
+
+## After a simulated commit
+
+To test the incremental update path, modify one file and reload:
+
+```bash
+# simulate a file change
+echo "# updated" >> worked/example/raw/parser.py
+
+# reload — only parser.py gets re-extracted
+/graphify source reload
+```
+
+The manifest in `worked/example/raw/graphify-out/manifest.json` tracks file mtimes. Only modified files are re-extracted, so reload is fast on large corpora.
+
+## Removing a source
+
+```
+/graphify source delete ./worked/example/raw
+/graphify source list   # should show empty registry
+```
+
+## Reference output
+
+`GRAPH_REPORT.md` and `sources.json` in this directory are reference snapshots from a real run. Your output will differ slightly (node IDs, community labels) but the structure should match.
+
+The `sources.json` path will be machine-specific — it stores the absolute path resolved on the machine where the source was added.

--- a/worked/source-control/review.md
+++ b/worked/source-control/review.md
@@ -1,0 +1,79 @@
+# Source Management Workflow - Evaluation (2026-04-08)
+
+**Corpus:** `worked/example/raw/` — 7 files (5 Python + 2 Markdown), ~2,159 words  
+**Pipeline:** `/graphify source add` → `/graphify source list` → `/graphify source reload`  
+**Graph output:** 73 nodes, 112 edges, 5 communities
+
+---
+
+## Workflow Assessment
+
+### add / list / delete — Score: 9/10
+
+**What works well:**
+- `add` resolves relative paths to absolute before storing — no surprises if you run reload from a different working directory.
+- inode stored alongside path — if you rename the directory within the same parent, `list` detects the new name and shows status `RENAMED` instead of `MISSING`.
+- `list` shows status at a glance: `[OK]` / `[RENAMED]` / `[MISSING]`, with the date added.
+- `delete` works by both path match and inode match — if you've already renamed the directory, delete still finds and removes the entry.
+- `sources.json` lives in `graphify-out/` alongside `graph.json` and `GRAPH_REPORT.md`, so the whole graphify state for a project is in one directory.
+
+**Limitations:**
+- inode tracking only works within the same parent directory. Cross-filesystem moves (e.g., mounting a drive at a different path) require manually deleting the old entry and adding the new path.
+- No bulk add (e.g., `source add ./repos/*`). Each path is added individually.
+
+---
+
+### reload — Score: 8/10
+
+**What works well:**
+- Incremental by default: only re-extracts files changed since the last run (manifest-based). On the 7-file corpus, a single-file edit → only that file gets re-extracted.
+- Code-only detection: if all changed files are code files, semantic LLM extraction is skipped entirely. Reload is instant for code-only changes.
+- Output isolation: each source's `graphify-out/` is independent. Reloading source A doesn't touch source B's graph.
+- Sequential processing prevents temp file conflicts when multiple sources are registered.
+
+**Limitations:**
+- First reload on a source with no prior manifest treats all files as new — same cost as a full run. Expected behavior but worth knowing.
+- No parallel reload across sources. With many large sources this can be slow. Acceptable for the common case (1-3 repos).
+- If a source path is renamed between `add` and `reload`, the skill resolves via inode, but the output directory (`<old_path>/graphify-out/`) still refers to the old path. The manifest and cache stay valid; only the directory location differs. In practice: rename the directory, run reload, outputs go to `<new_path>/graphify-out/` fresh.
+
+---
+
+## Graph Quality (from reload on the example corpus)
+
+The graph output is identical to running `/graphify ./worked/example/raw` directly — as expected.
+
+- **73 nodes, 112 edges, 5 communities**
+- `ValidationError` is the god node (11 edges) — correctly identifies it as the cross-cutting exception type
+- Communities map cleanly to modules: Storage / API / Parser / Processor / Validator
+- Docs (`notes.md`, `architecture.md`) not included in this reference run — would add semantic edges on a full `/graphify source reload` with LLM extraction enabled
+
+---
+
+## Recommended usage patterns
+
+**Single repo, always up to date:**
+```
+/graphify source add ./             # register current project root
+/graphify source reload             # after each significant change
+```
+
+**Multi-repo research:**
+```
+/graphify source add ./repo-a
+/graphify source add ./repo-b
+/graphify source add ./papers
+/graphify source reload             # rebuilds all three incrementally
+```
+
+**After a rename:**
+```
+mv old-name new-name
+/graphify source list               # shows [RENAMED] → /new-name
+/graphify source reload             # works correctly via inode resolution
+```
+
+**Cleanup:**
+```
+/graphify source delete ./old-path
+/graphify source list               # confirm removed
+```

--- a/worked/source-control/sources.json
+++ b/worked/source-control/sources.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "path": "/home/avesh/graphify/worked/example/raw",
+      "inode": 1067282,
+      "added": "2026-04-08T20:05:42.728097+00:00"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a persistent source registry at `graphify-out/sources.json` so users no longer need to remember and manually re-run graphify on each path after every commit or PR
- Sources tracked by absolute path + inode — renames within the same parent directory are detected automatically via `list` (`[RENAMED]` status) and handled transparently by `reload`
- `reload` runs the full incremental (`--update`) pipeline on all registered sources via the Claude Code skill, re-extracting only files changed since the last run

## Changes

- **`graphify/sources.py`** (new) — registry CRUD: `add_source`, `delete_source`, `list_sources`, `resolve_source_path`, `load_sources`, `save_sources`
- **`tests/test_sources.py`** (new) — 22 unit tests covering add, duplicate prevention, delete, inode-based rename resolution, and list status
- **`graphify/skill.md`** — `source add|delete|list|reload` usage lines + full `## For /graphify source` section with complete pipeline steps for each subcommand
- **`README.md`** — source management commands in usage block, feature bullet in "What you get", row in worked examples table
- **`worked/source-control/`** (new) — reference output (GRAPH_REPORT.md, sources.json snapshot, review.md) from running reload on the reproducible example corpus

## Test plan

- [x] `uv run pytest tests/test_sources.py -v` — 22 tests pass
- [x] `uv run pytest tests/ -q` — full suite (389 tests) passes
- [x] In Claude Code: `/graphify source add ./worked/example/raw` → `/graphify source list` → `/graphify source reload`
- [x] Rename test: rename a registered directory, `/graphify source list` shows `[RENAMED]`, `/graphify source reload` runs successfully
- [x] Missing test: delete a registered directory, `/graphify source list` shows `[MISSING]`, reload skips with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)