### PR TITLE
Add GitHub Copilot CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Add: GitHub Copilot CLI support via `graphify install --platform copilot`
+- Add: OS-aware Copilot skill installation — Windows gets the PowerShell skill, macOS/Linux get the POSIX skill
+- Add: `graphify copilot install` / `graphify copilot uninstall` for `.github/copilot-instructions.md`
+- Docs: README and README.zh-CN now document Copilot install and always-on usage
+- Test: install routing covers both Windows and macOS Copilot skill variants
+
 ## 0.3.21 (2026-04-09)
 
 - Fix: Codex PreToolUse hook now places `systemMessage` at the top level of the output JSON instead of inside `hookSpecificOutput` — matches the strict schema enforced by codex-cli 0.118.0+ which uses `additionalProperties: false` (#138)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/graphifyy)](https://pypi.org/project/graphifyy/)
 [![Sponsor](https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors)](https://github.com/sponsors/safishamsi)
 
-**An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, OpenClaw, Factory Droid, or Trae - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
+**An AI coding assistant skill.** Type `/graphify` in Claude Code, GitHub Copilot CLI, Codex, OpenCode, OpenClaw, Factory Droid, or Trae - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
 
 Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, even images in other languages - graphify uses Claude vision to extract concepts and relationships from all of it and connects them into one graph. 20 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia).
 
@@ -46,7 +46,7 @@ Every relationship is tagged `EXTRACTED` (found directly in source), `INFERRED` 
 
 ## Install
 
-**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
+**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
 
 ```bash
 pip install graphifyy && graphify install
@@ -66,8 +66,23 @@ pip install graphifyy && graphify install
 | Factory Droid | `graphify install --platform droid` |
 | Trae | `graphify install --platform trae` |
 | Trae CN | `graphify install --platform trae-cn` |
+| GitHub Copilot CLI | `graphify install --platform copilot` |
 
-Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw uses sequential extraction (parallel agent support is still early on that platform). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism.
+Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw uses sequential extraction (parallel agent support is still early on that platform). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism. GitHub Copilot CLI reads files directly for semantic extraction (sequential).
+
+> GitHub Copilot CLI users should explicitly run `graphify install --platform copilot`. On Windows, this installs the PowerShell-specific Copilot skill. On macOS/Linux, it installs the POSIX shell Copilot skill.
+
+### Deploying a modified local checkout for GitHub Copilot CLI
+
+If you are testing a fork or a locally modified checkout, install from source instead of PyPI:
+
+```bash
+python -m pip install .
+graphify install --platform copilot
+graphify copilot install
+```
+
+This copies the Copilot skill to `~/.copilot/skills/graphify/SKILL.md` and writes the always-on project rules to `.github/copilot-instructions.md`. The installed skill is OS-aware: Windows gets the PowerShell variant, while macOS/Linux gets the POSIX shell variant.
 
 Then open your AI coding assistant and type:
 
@@ -90,6 +105,7 @@ After building a graph, run this once in your project:
 | Factory Droid | `graphify droid install` |
 | Trae | `graphify trae install` |
 | Trae CN | `graphify trae-cn install` |
+| GitHub Copilot CLI | `graphify copilot install` |
 
 **Claude Code** does two things: writes a `CLAUDE.md` section telling Claude to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs a **PreToolUse hook** (`settings.json`) that fires before every Glob and Grep call. If a knowledge graph exists, Claude sees: _"graphify: Knowledge graph exists. Read GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ — so Claude navigates via the graph instead of grepping through every file.
 
@@ -98,6 +114,8 @@ After building a graph, run this once in your project:
 **OpenCode** writes to `AGENTS.md` and also installs a **`tool.execute.before` plugin** (`.opencode/plugins/graphify.js` + `opencode.json` registration) that fires before bash tool calls and injects the graph reminder into tool output when the graph exists.
 
 **OpenClaw, Factory Droid, Trae** write the same rules to `AGENTS.md` in your project root. These platforms don't support tool hooks, so AGENTS.md is the always-on mechanism.
+
+**GitHub Copilot CLI** writes rules to `.github/copilot-instructions.md`, which Copilot CLI reads automatically. The skill is also installed to `~/.copilot/skills/graphify/SKILL.md` for invocation via `/graphify`.
 
 Uninstall with the matching uninstall command (e.g. `graphify claude uninstall`).
 
@@ -210,6 +228,7 @@ graphify trae install              # AGENTS.md (Trae)
 graphify trae uninstall
 graphify trae-cn install           # AGENTS.md (Trae CN)
 graphify trae-cn uninstall
+graphify copilot install           # .github/copilot-instructions.md (GitHub Copilot CLI)
 
 # query the graph directly from the terminal (no AI assistant needed)
 graphify query "what connects attention to the optimizer?"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/safishamsi/graphify/actions/workflows/ci.yml/badge.svg?branch=v3)](https://github.com/safishamsi/graphify/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/graphifyy)](https://pypi.org/project/graphifyy/)
+[![Sponsor](https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors)](https://github.com/sponsors/safishamsi)
 
 **一个面向 AI 编码助手的技能。** 在 Claude Code、Codex、OpenCode、OpenClaw、Factory Droid 或 Trae 中输入 `/graphify`，它会读取你的文件、构建知识图谱，并把原本不明显的结构关系还给你。更快理解代码库，找到架构决策背后的"为什么"。
 
@@ -23,6 +24,18 @@ graphify-out/
 └── cache/           SHA256 缓存：重复运行时只处理变更过的文件
 ```
 
+如果有目录不想纳入图谱，可以添加 `.graphifyignore`：
+
+```
+# .graphifyignore
+vendor/
+node_modules/
+dist/
+*.generated.py
+```
+
+语法与 `.gitignore` 一致，模式匹配的是相对于 graphify 运行目录的文件路径。
+
 ## 工作原理
 
 graphify 分两轮执行。第一轮是确定性的 AST 提取，对代码文件做结构分析（类、函数、导入、调用图、docstring、解释性注释），这一轮不需要 LLM。第二轮会并行调用 Claude 子代理处理文档、论文和图片，从中提取概念、关系和设计动机。最后把两边结果合并到一个 NetworkX 图里，用 Leiden 社区发现算法做聚类，并导出成可交互 HTML、可查询 JSON，以及一份人类可读的审计报告。
@@ -33,7 +46,7 @@ graphify 分两轮执行。第一轮是确定性的 AST 提取，对代码文件
 
 ## 安装
 
-**要求：** Python 3.10+，并且使用以下平台之一：[Claude Code](https://claude.ai/code)、[Codex](https://openai.com/codex)、[OpenCode](https://opencode.ai)、[OpenClaw](https://openclaw.ai)、[Factory Droid](https://factory.ai) 或 [Trae](https://trae.ai)
+**要求：** Python 3.10+，并且使用以下平台之一：[Claude Code](https://claude.ai/code)、[GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli)、[Codex](https://openai.com/codex)、[OpenCode](https://opencode.ai)、[OpenClaw](https://openclaw.ai)、[Factory Droid](https://factory.ai) 或 [Trae](https://trae.ai)
 
 ```bash
 pip install graphifyy && graphify install
@@ -45,21 +58,39 @@ pip install graphifyy && graphify install
 
 | 平台 | 安装命令 |
 |------|----------|
-| Claude Code | `graphify install` |
+| Claude Code（Linux/Mac） | `graphify install` |
+| Claude Code（Windows） | `graphify install`（自动识别）或 `graphify install --platform windows` |
 | Codex | `graphify install --platform codex` |
 | OpenCode | `graphify install --platform opencode` |
 | OpenClaw | `graphify install --platform claw` |
 | Factory Droid | `graphify install --platform droid` |
 | Trae | `graphify install --platform trae` |
 | Trae CN | `graphify install --platform trae-cn` |
+| GitHub Copilot CLI | `graphify install --platform copilot` |
 
-Codex 用户还需要在 `~/.codex/config.toml` 的 `[features]` 下打开 `multi_agent = true`，这样才能并行提取。OpenClaw 目前的并行 agent 支持还比较早期，所以使用顺序提取。Trae 使用 Agent 工具进行并行子代理调度，**不支持** PreToolUse hook，因此 AGENTS.md 是其常驻机制。
+Codex 用户还需要在 `~/.codex/config.toml` 的 `[features]` 下打开 `multi_agent = true`，这样才能并行提取。Factory Droid 通过 `Task` 工具并行分发子代理。OpenClaw 目前的并行 agent 支持还比较早期，所以使用顺序提取。Trae 使用 Agent 工具进行并行子代理调度，**不支持** PreToolUse hook，因此 AGENTS.md 是其常驻机制。GitHub Copilot CLI 会顺序读取文件并做语义提取。
+
+> GitHub Copilot CLI 用户应显式运行 `graphify install --platform copilot`。在 Windows 上它会安装 PowerShell 版 Copilot skill；在 macOS/Linux 上它会安装 POSIX shell 版 skill。
+
+### 为 GitHub Copilot CLI 部署本地修改版 checkout
+
+如果你是在测试 fork，或者本地已经改过 graphify，请不要走 PyPI，直接从源码安装：
+
+```bash
+python -m pip install .
+graphify install --platform copilot
+graphify copilot install
+```
+
+这会把 Copilot skill 复制到 `~/.copilot/skills/graphify/SKILL.md`，并把常驻规则写入项目内的 `.github/copilot-instructions.md`。安装逻辑会按操作系统自动分流：Windows 使用 PowerShell 版 skill，macOS/Linux 使用 POSIX shell 版 skill。
 
 然后打开你的 AI 编码助手，输入：
 
 ```
 /graphify .
 ```
+
+注意：Codex 的 skill 触发前缀是 `$`，不是 `/`，所以应使用 `$graphify .`。
 
 ### 让助手始终优先使用图谱（推荐）
 
@@ -74,6 +105,7 @@ Codex 用户还需要在 `~/.codex/config.toml` 的 `[features]` 下打开 `mult
 | Factory Droid | `graphify droid install` |
 | Trae | `graphify trae install` |
 | Trae CN | `graphify trae-cn install` |
+| GitHub Copilot CLI | `graphify copilot install` |
 
 **Claude Code** 会做两件事：
 1. 在 `CLAUDE.md` 中写入一段规则，告诉 Claude 在回答架构问题前先读 `graphify-out/GRAPH_REPORT.md`
@@ -82,6 +114,8 @@ Codex 用户还需要在 `~/.codex/config.toml` 的 `[features]` 下打开 `mult
 如果知识图谱存在，Claude 会先看到：_"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ —— 这样 Claude 会优先按图谱导航，而不是一上来就 grep 整个项目。
 
 **Codex、OpenCode、OpenClaw、Factory Droid、Trae** 会把同样的规则写进项目根目录的 `AGENTS.md`。这些平台没有 PreToolUse hook，所以 `AGENTS.md` 是它们的常驻机制。
+
+**GitHub Copilot CLI** 会把规则写进项目内的 `.github/copilot-instructions.md`，Copilot CLI 会自动读取它；skill 本体则安装到 `~/.copilot/skills/graphify/SKILL.md`。
 
 卸载时使用对应平台的 uninstall 命令即可（例如 `graphify claude uninstall`）。
 
@@ -157,14 +191,16 @@ graphify trae install              # AGENTS.md（Trae）
 graphify trae uninstall
 graphify trae-cn install           # AGENTS.md（Trae CN）
 graphify trae-cn uninstall
+graphify copilot install           # .github/copilot-instructions.md（GitHub Copilot CLI）
 ```
 
 支持混合文件类型：
 
 | 类型 | 扩展名 | 提取方式 |
 |------|--------|----------|
-| 代码 | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php` | tree-sitter AST + 调用图 + docstring / 注释中的 rationale |
+| 代码 | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm` | tree-sitter AST + 调用图 + docstring / 注释中的 rationale |
 | 文档 | `.md .txt .rst` | 通过 Claude 提取概念、关系和设计动机 |
+| Office | `.docx .xlsx` | 先转成 Markdown，再经由 Claude 提取（需要 `pip install graphifyy[office]`） |
 | 论文 | `.pdf` | 引文挖掘 + 概念提取 |
 | 图片 | `.png .jpg .webp .gif` | Claude vision —— 截图、图表、任意语言都可以 |
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1,4 +1,4 @@
-"""graphify CLI - `graphify install` sets up the Claude Code skill."""
+"""graphify CLI - install skills and project instructions for supported platforms."""
 from __future__ import annotations
 import json
 import platform
@@ -45,6 +45,13 @@ _SKILL_REGISTRATION = (
     "with `skill: \"graphify\"` before doing anything else.\n"
 )
 
+_REBUILD_GRAPH_COMMAND = (
+    "`python -c \"from graphify.watch import _rebuild_code; from pathlib import Path; "
+    "_rebuild_code(Path('.'))\"` "
+    "(or `python3 -c \"from graphify.watch import _rebuild_code; from pathlib import Path; "
+    "_rebuild_code(Path('.'))\"` if `python` is unavailable)"
+)
+
 
 _PLATFORM_CONFIG: dict[str, dict] = {
     "claude": {
@@ -82,12 +89,24 @@ _PLATFORM_CONFIG: dict[str, dict] = {
         "skill_dst": Path(".trae-cn") / "skills" / "graphify" / "SKILL.md",
         "claude_md": False,
     },
+    "copilot": {
+        "skill_file": "skill-copilot.md",
+        "skill_dst": Path(".copilot") / "skills" / "graphify" / "SKILL.md",
+        "claude_md": False,
+    },
     "windows": {
         "skill_file": "skill-windows.md",
         "skill_dst": Path(".claude") / "skills" / "graphify" / "SKILL.md",
         "claude_md": True,
     },
 }
+
+
+def _resolve_platform_config(platform_name: str) -> dict:
+    cfg = dict(_PLATFORM_CONFIG[platform_name])
+    if platform_name == "copilot" and platform.system() == "Windows":
+        cfg["skill_file"] = "skill-copilot-windows.md"
+    return cfg
 
 
 def install(platform: str = "claude") -> None:
@@ -98,7 +117,7 @@ def install(platform: str = "claude") -> None:
         )
         sys.exit(1)
 
-    cfg = _PLATFORM_CONFIG[platform]
+    cfg = _resolve_platform_config(platform)
     skill_src = Path(__file__).parent / cfg["skill_file"]
     if not skill_src.exists():
         print(f"error: {cfg['skill_file']} not found in package - reinstall graphify", file=sys.stderr)
@@ -140,9 +159,10 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- After modifying code files in this session, run {rebuild_command} to keep the graph current
 """
 
+_CLAUDE_MD_SECTION = _CLAUDE_MD_SECTION.format(rebuild_command=_REBUILD_GRAPH_COMMAND)
 _CLAUDE_MD_MARKER = "## graphify"
 
 # AGENTS.md section for Codex, OpenCode, and OpenClaw.
@@ -155,9 +175,10 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- After modifying code files in this session, run {rebuild_command} to keep the graph current
 """
 
+_AGENTS_MD_SECTION = _AGENTS_MD_SECTION.format(rebuild_command=_REBUILD_GRAPH_COMMAND)
 _AGENTS_MD_MARKER = "## graphify"
 
 # OpenCode tool.execute.before plugin — fires before every tool call.
@@ -299,6 +320,73 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
     existing["hooks"]["PreToolUse"] = filtered
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
+
+# Copilot instructions section for .github/copilot-instructions.md
+_COPILOT_INSTRUCTIONS_SECTION = """\
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run {rebuild_command} to keep the graph current
+"""
+
+_COPILOT_INSTRUCTIONS_SECTION = _COPILOT_INSTRUCTIONS_SECTION.format(rebuild_command=_REBUILD_GRAPH_COMMAND)
+_COPILOT_INSTRUCTIONS_MARKER = "## graphify"
+
+
+def _copilot_install(project_dir: Path) -> None:
+    """Write the graphify section to .github/copilot-instructions.md (GitHub Copilot CLI)."""
+    target = (project_dir or Path(".")) / ".github" / "copilot-instructions.md"
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.exists():
+        content = target.read_text(encoding="utf-8")
+        if _COPILOT_INSTRUCTIONS_MARKER in content:
+            print("graphify already configured in .github/copilot-instructions.md")
+            return
+        new_content = content.rstrip() + "\n\n" + _COPILOT_INSTRUCTIONS_SECTION
+    else:
+        new_content = _COPILOT_INSTRUCTIONS_SECTION
+
+    target.write_text(new_content, encoding="utf-8")
+    print(f"graphify section written to {target.resolve()}")
+    print()
+    print("GitHub Copilot CLI will now check the knowledge graph before answering")
+    print("codebase questions and rebuild it after code changes.")
+    print()
+    print("Note: GitHub Copilot CLI reads .github/copilot-instructions.md automatically.")
+    print("The skill is also installed at ~/.copilot/skills/graphify/SKILL.md")
+
+
+def _copilot_uninstall(project_dir: Path) -> None:
+    """Remove the graphify section from .github/copilot-instructions.md."""
+    target = (project_dir or Path(".")) / ".github" / "copilot-instructions.md"
+
+    if not target.exists():
+        print("No .github/copilot-instructions.md found - nothing to do")
+        return
+
+    content = target.read_text(encoding="utf-8")
+    if _COPILOT_INSTRUCTIONS_MARKER not in content:
+        print("graphify section not found in .github/copilot-instructions.md - nothing to do")
+        return
+
+    cleaned = re.sub(
+        r"\n*## graphify\n.*?(?=\n## |\Z)",
+        "",
+        content,
+        flags=re.DOTALL,
+    ).rstrip()
+    if cleaned:
+        target.write_text(cleaned + "\n", encoding="utf-8")
+        print(f"graphify section removed from {target.resolve()}")
+    else:
+        target.unlink()
+        print(f".github/copilot-instructions.md was empty after removal - deleted {target.resolve()}")
 
 
 def _agents_install(project_dir: Path, platform: str) -> None:
@@ -468,7 +556,7 @@ def main() -> None:
         print("Usage: graphify <command>")
         print()
         print("Commands:")
-        print("  install [--platform P]  copy skill to platform config dir (claude|windows|codex|opencode|claw|droid|trae|trae-cn)")
+        print("  install [--platform P]  copy skill to platform config dir (claude|windows|codex|opencode|claw|droid|trae|trae-cn|copilot)")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
         print("    --budget N              cap output at N tokens (default 2000)")
@@ -492,11 +580,13 @@ def main() -> None:
         print("  claw install            write graphify section to AGENTS.md (OpenClaw)")
         print("  claw uninstall          remove graphify section from AGENTS.md")
         print("  droid install           write graphify section to AGENTS.md (Factory Droid)")
-        print("  droid uninstall        remove graphify section from AGENTS.md")
+        print("  droid uninstall         remove graphify section from AGENTS.md")
         print("  trae install            write graphify section to AGENTS.md (Trae)")
-        print("  trae uninstall         remove graphify section from AGENTS.md")
+        print("  trae uninstall          remove graphify section from AGENTS.md")
         print("  trae-cn install         write graphify section to AGENTS.md (Trae CN)")
-        print("  trae-cn uninstall      remove graphify section from AGENTS.md")
+        print("  trae-cn uninstall       remove graphify section from AGENTS.md")
+        print("  copilot install         write graphify section to .github/copilot-instructions.md (GitHub Copilot CLI)")
+        print("  copilot uninstall       remove graphify section from .github/copilot-instructions.md")
         print()
         return
 
@@ -536,6 +626,15 @@ def main() -> None:
                 _uninstall_codex_hook(Path("."))
         else:
             print(f"Usage: graphify {cmd} [install|uninstall]", file=sys.stderr)
+            sys.exit(1)
+    elif cmd == "copilot":
+        subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
+        if subcmd == "install":
+            _copilot_install(Path("."))
+        elif subcmd == "uninstall":
+            _copilot_uninstall(Path("."))
+        else:
+            print("Usage: graphify copilot [install|uninstall]", file=sys.stderr)
             sys.exit(1)
     elif cmd == "hook":
         from graphify.hooks import install as hook_install, uninstall as hook_uninstall, status as hook_status

--- a/graphify/skill-copilot-windows.md
+++ b/graphify/skill-copilot-windows.md
@@ -1,0 +1,165 @@
+---
+name: graphify
+description: >
+  Turn any folder of code, docs, papers, or images into a queryable knowledge graph.
+  Use when the user types /graphify, asks to build a knowledge graph, understand a codebase,
+  find connections between files, or wants to explore code architecture. Generates HTML,
+  JSON, Obsidian vault, and a plain-language audit report.
+allowed-tools:
+  - powershell
+  - view
+  - glob
+  - rg
+  - ask_user
+---
+
+# /graphify
+
+Turn any folder of files into a navigable knowledge graph with community detection, an honest audit trail, and three primary outputs: interactive HTML, `graph.json`, and `GRAPH_REPORT.md`.
+
+## Usage
+
+```
+/graphify
+/graphify <path>
+/graphify <path> --mode deep
+/graphify <path> --update
+/graphify <path> --cluster-only
+/graphify <path> --no-viz
+/graphify <path> --svg
+/graphify <path> --graphml
+/graphify <path> --neo4j
+/graphify <path> --neo4j-push bolt://localhost:7687
+/graphify <path> --mcp
+/graphify <path> --watch
+/graphify add <url>
+/graphify query "<question>"
+/graphify path "Node A" "Node B"
+/graphify explain "Node"
+```
+
+## GitHub Copilot CLI requirements
+
+This platform uses PowerShell-oriented commands and Copilot CLI tools. Do not emit bash-specific commands such as `which`, `rm -f`, `$(cat file)`, or `python3`-only instructions without a Windows fallback.
+
+If no path was given, use `.`. Only ask the user for a narrower path when the corpus is too large.
+
+## What you must do when invoked
+
+### Step 1 - Ensure `graphify` is importable
+
+Use the `powershell` tool and prefer this order:
+
+1. Try `python -c "import graphify"`.
+2. If that fails and `py` exists, try `py -3 -c "import graphify"`.
+3. If graphify is still unavailable, install it with `python -m pip install graphifyy`.
+4. Write the chosen interpreter path to `.graphify_python`.
+
+Example PowerShell:
+
+```powershell
+$chosen = $null
+if (Get-Command python -ErrorAction SilentlyContinue) {
+  try { python -c "import graphify"; if ($LASTEXITCODE -eq 0) { $chosen = "python" } } catch {}
+}
+if (-not $chosen -and (Get-Command py -ErrorAction SilentlyContinue)) {
+  try { py -3 -c "import graphify"; if ($LASTEXITCODE -eq 0) { $chosen = "py -3" } } catch {}
+}
+if (-not $chosen) {
+  $chosen = if (Get-Command python -ErrorAction SilentlyContinue) { "python" } else { "py -3" }
+  & $chosen -m pip install graphifyy
+}
+$exe = (& $chosen -c "import sys; print(sys.executable)").Trim()
+Set-Content -Path .graphify_python -Value $exe -NoNewline
+```
+
+### Step 2 - Detect the corpus
+
+Use the interpreter recorded in `.graphify_python`:
+
+```powershell
+$py = Get-Content .graphify_python -Raw
+& $py -c "import json; from pathlib import Path; from graphify.detect import detect; result = detect(Path('INPUT_PATH')); Path('.graphify_detect.json').write_text(json.dumps(result), encoding='utf-8')"
+```
+
+Do not print the raw JSON. Summarize it like this:
+
+```text
+Corpus: X files · ~Y words
+  code:   N files
+  docs:   N files
+  papers: N files
+  images: N files
+```
+
+Then:
+
+- If `total_files == 0`, stop with `No supported files found in [path].`
+- If sensitive files were skipped, mention only the count.
+- If `total_words > 2_000_000` or `total_files > 200`, summarize the busiest subdirectories and ask the user which subfolder to run on.
+- Otherwise continue immediately.
+
+### Step 3 - Structural extraction for code files
+
+Run AST extraction first:
+
+```powershell
+$py = Get-Content .graphify_python -Raw
+& $py -c "import json; from pathlib import Path; from graphify.extract import collect_files, extract; detect = json.loads(Path('.graphify_detect.json').read_text(encoding='utf-8')); code_files = []; [code_files.extend(collect_files(Path(f)) if Path(f).is_dir() else [Path(f)]) for f in detect.get('files', {}).get('code', [])]; result = extract(code_files) if code_files else {'nodes': [], 'edges': [], 'hyperedges': [], 'input_tokens': 0, 'output_tokens': 0}; Path('.graphify_ast.json').write_text(json.dumps(result, indent=2), encoding='utf-8'); print(f'AST: {len(result["nodes"])} nodes, {len(result["edges"])} edges')"
+```
+
+If there are no code files, write the empty JSON and continue.
+
+### Step 4 - Semantic extraction for docs, papers, and images
+
+GitHub Copilot CLI should read uncached files directly and extract concepts sequentially in chunks of roughly 20-25 files.
+
+Before extracting, check cache:
+
+```powershell
+$py = Get-Content .graphify_python -Raw
+& $py -c "import json; from pathlib import Path; from graphify.cache import check_semantic_cache; detect = json.loads(Path('.graphify_detect.json').read_text(encoding='utf-8')); all_files = [f for files in detect['files'].values() for f in files]; cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files); import json as _json; Path('.graphify_uncached.txt').write_text('\n'.join(uncached), encoding='utf-8'); Path('.graphify_cached.json').write_text(_json.dumps({'nodes': cached_nodes, 'edges': cached_edges, 'hyperedges': cached_hyperedges}), encoding='utf-8') if (cached_nodes or cached_edges or cached_hyperedges) else None; print(f'Cache: {len(all_files)-len(uncached)} files hit, {len(uncached)} files need extraction')"
+```
+
+Extraction rules:
+
+- Explicit relationships are `EXTRACTED` with `confidence_score: 1.0`.
+- Reasonable indirect links are `INFERRED` with `confidence_score` between `0.6` and `0.9`.
+- Uncertain links are `AMBIGUOUS` with `confidence_score` between `0.1` and `0.3`.
+- Code files should only add semantic edges AST did not already provide.
+- Doc and paper files should extract named concepts, citations, rationale, and trade-offs.
+- Image files should reason about the image content, not only OCR.
+- In `--mode deep`, be more aggressive with `INFERRED` edges.
+
+Write fresh semantic output to `.graphify_semantic_new.json`, then save cache and merge into `.graphify_semantic.json`.
+
+### Step 5 - Build, analyze, cluster, and export
+
+Using `.graphify_python`, call the Python modules under `graphify.build`, `graphify.cluster`, `graphify.analyze`, `graphify.report`, and `graphify.export`.
+
+Produce at least:
+
+- `graphify-out/graph.json`
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.html` unless `--no-viz` was requested
+
+If optional flags such as `--svg`, `--graphml`, `--neo4j`, `--wiki`, or `--obsidian` were requested, run the matching exporter too.
+
+### Step 6 - Clean up temporary files
+
+Use PowerShell cleanup, not `rm -f`:
+
+```powershell
+Remove-Item .graphify_cached.json, .graphify_uncached.txt, .graphify_semantic_new.json -ErrorAction SilentlyContinue
+```
+
+### Step 7 - Report results
+
+End with a concise summary that includes:
+
+- corpus size
+- nodes / edges / communities
+- output paths
+- whether cache was used
+
+If any step fails, surface the exact failing step and command output instead of silently degrading.

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -1,0 +1,133 @@
+---
+name: graphify
+description: >
+  Turn any folder of code, docs, papers, or images into a queryable knowledge graph.
+  Use when the user types /graphify, asks to build a knowledge graph, understand a codebase,
+  find connections between files, or wants to explore code architecture. Generates HTML,
+  JSON, Obsidian vault, and a plain-language audit report.
+allowed-tools: shell
+---
+
+# /graphify
+
+Turn any folder of files into a navigable knowledge graph with community detection, an honest audit trail, and three primary outputs: interactive HTML, `graph.json`, and `GRAPH_REPORT.md`.
+
+## GitHub Copilot CLI requirements
+
+This is the macOS/Linux Copilot skill. Use POSIX shell commands here. On Windows, graphify installs a separate PowerShell-specific Copilot skill automatically.
+
+If no path was given, use `.`. Only ask the user for a narrower path when the corpus is too large.
+
+## What you must do when invoked
+
+### Step 1 - Ensure `graphify` is importable
+
+Use shell commands and prefer this order:
+
+1. Try `python -c "import graphify"`.
+2. If that fails, try `python3 -c "import graphify"`.
+3. If graphify is still unavailable, install it with `python -m pip install graphifyy` or `python3 -m pip install graphifyy`.
+4. Write the chosen interpreter path to `.graphify_python`.
+
+Example shell flow:
+
+```bash
+GRAPHIFY_BIN=$(which graphify 2>/dev/null)
+if [ -n "$GRAPHIFY_BIN" ]; then
+    PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
+elif python -c "import graphify" >/dev/null 2>&1; then
+    PYTHON="python"
+else
+    PYTHON="python3"
+fi
+$PYTHON -c "import graphify" >/dev/null 2>&1 || $PYTHON -m pip install graphifyy
+$PYTHON -c "import sys; open('.graphify_python', 'w').write(sys.executable)"
+```
+
+### Step 2 - Detect the corpus
+
+Use the interpreter recorded in `.graphify_python`:
+
+```bash
+$(cat .graphify_python) -c "import json; from pathlib import Path; from graphify.detect import detect; result = detect(Path('INPUT_PATH')); Path('.graphify_detect.json').write_text(json.dumps(result), encoding='utf-8')"
+```
+
+Do not print the raw JSON. Summarize it like this:
+
+```text
+Corpus: X files · ~Y words
+  code:   N files
+  docs:   N files
+  papers: N files
+  images: N files
+```
+
+Then:
+
+- If `total_files == 0`, stop with `No supported files found in [path].`
+- If sensitive files were skipped, mention only the count.
+- If `total_words > 2_000_000` or `total_files > 200`, summarize the busiest subdirectories and ask the user which subfolder to run on.
+- Otherwise continue immediately.
+
+### Step 3 - Structural extraction for code files
+
+Run AST extraction first:
+
+```bash
+$(cat .graphify_python) -c "import json; from pathlib import Path; from graphify.extract import collect_files, extract; detect = json.loads(Path('.graphify_detect.json').read_text(encoding='utf-8')); code_files = []; [code_files.extend(collect_files(Path(f)) if Path(f).is_dir() else [Path(f)]) for f in detect.get('files', {}).get('code', [])]; result = extract(code_files) if code_files else {'nodes': [], 'edges': [], 'hyperedges': [], 'input_tokens': 0, 'output_tokens': 0}; Path('.graphify_ast.json').write_text(json.dumps(result, indent=2), encoding='utf-8'); print(f'AST: {len(result["nodes"])} nodes, {len(result["edges"])} edges')"
+```
+
+If there are no code files, write the empty JSON and continue.
+
+### Step 4 - Semantic extraction for docs, papers, and images
+
+GitHub Copilot CLI should read uncached files directly and extract concepts sequentially in chunks of roughly 20-25 files.
+
+Before extracting, check cache:
+
+```bash
+$(cat .graphify_python) -c "import json; from pathlib import Path; from graphify.cache import check_semantic_cache; detect = json.loads(Path('.graphify_detect.json').read_text(encoding='utf-8')); all_files = [f for files in detect['files'].values() for f in files]; cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files); import json as _json; open('.graphify_uncached.txt', 'w', encoding='utf-8').write('\n'.join(uncached)); Path('.graphify_cached.json').write_text(_json.dumps({'nodes': cached_nodes, 'edges': cached_edges, 'hyperedges': cached_hyperedges}), encoding='utf-8') if (cached_nodes or cached_edges or cached_hyperedges) else None; print(f'Cache: {len(all_files)-len(uncached)} files hit, {len(uncached)} files need extraction')"
+```
+
+Extraction rules:
+
+- Explicit relationships are `EXTRACTED` with `confidence_score: 1.0`.
+- Reasonable indirect links are `INFERRED` with `confidence_score` between `0.6` and `0.9`.
+- Uncertain links are `AMBIGUOUS` with `confidence_score` between `0.1` and `0.3`.
+- Code files should only add semantic edges AST did not already provide.
+- Doc and paper files should extract named concepts, citations, rationale, and trade-offs.
+- Image files should reason about the image content, not only OCR.
+- In `--mode deep`, be more aggressive with `INFERRED` edges.
+
+Write fresh semantic output to `.graphify_semantic_new.json`, then save cache and merge into `.graphify_semantic.json`.
+
+### Step 5 - Build, analyze, cluster, and export
+
+Using `.graphify_python`, call the Python modules under `graphify.build`, `graphify.cluster`, `graphify.analyze`, `graphify.report`, and `graphify.export`.
+
+Produce at least:
+
+- `graphify-out/graph.json`
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.html` unless `--no-viz` was requested
+
+If optional flags such as `--svg`, `--graphml`, `--neo4j`, `--wiki`, or `--obsidian` were requested, run the matching exporter too.
+
+### Step 6 - Clean up temporary files
+
+Use POSIX cleanup:
+
+```bash
+rm -f .graphify_cached.json .graphify_uncached.txt .graphify_semantic_new.json
+```
+
+### Step 7 - Report results
+
+End with a concise summary that includes:
+
+- corpus size
+- nodes / edges / communities
+- output paths
+- whether cache was used
+
+If any step fails, surface the exact failing step and command output instead of silently degrading.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ where = ["."]
 include = ["graphify*"]
 
 [tool.setuptools.package-data]
-graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md"]
+graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md", "skill-copilot.md", "skill-copilot-windows.md"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ import pytest
 
 PLATFORMS = {
     "claude": (".claude/skills/graphify/SKILL.md",),
+    "copilot": (".copilot/skills/graphify/SKILL.md",),
     "codex": (".agents/skills/graphify/SKILL.md",),
     "opencode": (".config/opencode/skills/graphify/SKILL.md",),
     "claw": (".claw/skills/graphify/SKILL.md",),
@@ -16,10 +17,14 @@ PLATFORMS = {
 }
 
 
-def _install(tmp_path, platform):
+def _install(tmp_path, platform, system_name=None):
     from graphify.__main__ import install
     with patch("graphify.__main__.Path.home", return_value=tmp_path):
-        install(platform=platform)
+        if system_name is None:
+            install(platform=platform)
+        else:
+            with patch("graphify.__main__.platform.system", return_value=system_name):
+                install(platform=platform)
 
 
 def test_install_default_claude(tmp_path):
@@ -30,6 +35,25 @@ def test_install_default_claude(tmp_path):
 def test_install_codex(tmp_path):
     _install(tmp_path, "codex")
     assert (tmp_path / ".agents" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_copilot(tmp_path):
+    _install(tmp_path, "copilot")
+    assert (tmp_path / ".copilot" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_copilot_windows_uses_windows_skill(tmp_path):
+    _install(tmp_path, "copilot", system_name="Windows")
+    skill = (tmp_path / ".copilot" / "skills" / "graphify" / "SKILL.md").read_text(encoding="utf-8")
+    assert "powershell" in skill
+    assert "Remove-Item" in skill
+
+
+def test_install_copilot_macos_uses_posix_skill(tmp_path):
+    _install(tmp_path, "copilot", system_name="Darwin")
+    skill = (tmp_path / ".copilot" / "skills" / "graphify" / "SKILL.md").read_text(encoding="utf-8")
+    assert "which graphify" in skill
+    assert "Remove-Item" not in skill
 
 
 def test_install_opencode(tmp_path):
@@ -70,21 +94,21 @@ def test_install_unknown_platform_exits(tmp_path):
 def test_codex_skill_contains_spawn_agent():
     """Codex skill file must reference spawn_agent."""
     import graphify
-    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-codex.md").read_text(encoding="utf-8")
     assert "spawn_agent" in skill
 
 
 def test_opencode_skill_contains_mention():
     """OpenCode skill file must reference @mention."""
     import graphify
-    skill = (Path(graphify.__file__).parent / "skill-opencode.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-opencode.md").read_text(encoding="utf-8")
     assert "@mention" in skill
 
 
 def test_claw_skill_is_sequential():
     """OpenClaw skill file must describe sequential extraction."""
     import graphify
-    skill = (Path(graphify.__file__).parent / "skill-claw.md").read_text()
+    skill = (Path(graphify.__file__).parent / "skill-claw.md").read_text(encoding="utf-8")
     assert "sequential" in skill.lower()
     assert "spawn_agent" not in skill
     assert "@mention" not in skill
@@ -94,7 +118,7 @@ def test_all_skill_files_exist_in_package():
     """All installable platform skill files must be present in the installed package."""
     import graphify
     pkg = Path(graphify.__file__).parent
-    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md"):
+    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md", "skill-copilot.md", "skill-copilot-windows.md"):
         assert (pkg / name).exists(), f"Missing: {name}"
 
 
@@ -107,6 +131,16 @@ def test_claude_install_registers_claude_md(tmp_path):
 def test_codex_install_does_not_write_claude_md(tmp_path):
     _install(tmp_path, "codex")
     assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
+
+def _copilot_install(tmp_path):
+    from graphify.__main__ import _copilot_install as _install_fn
+    _install_fn(tmp_path)
+
+
+def _copilot_uninstall(tmp_path):
+    from graphify.__main__ import _copilot_uninstall as _uninstall_fn
+    _uninstall_fn(tmp_path)
 
 
 # --- always-on AGENTS.md install/uninstall tests ---
@@ -225,3 +259,49 @@ def test_opencode_agents_uninstall_removes_plugin(tmp_path):
     if config_file.exists():
         config = _json.loads(config_file.read_text())
         assert not any("graphify.js" in p for p in config.get("plugin", []))
+
+
+# --- Copilot tests ---
+
+def test_copilot_install_writes_copilot_instructions(tmp_path):
+    _copilot_install(tmp_path)
+    target = tmp_path / ".github" / "copilot-instructions.md"
+    assert target.exists()
+    content = target.read_text()
+    assert "## graphify" in content
+    assert "GRAPH_REPORT.md" in content
+
+
+def test_copilot_install_is_idempotent(tmp_path):
+    _copilot_install(tmp_path)
+    _copilot_install(tmp_path)
+    content = (tmp_path / ".github" / "copilot-instructions.md").read_text()
+    assert content.count("## graphify") == 1
+
+
+def test_copilot_uninstall_removes_only_graphify_section(tmp_path):
+    target = tmp_path / ".github" / "copilot-instructions.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# existing\n")
+    _copilot_install(tmp_path)
+    _copilot_uninstall(tmp_path)
+    assert target.exists()
+    content = target.read_text()
+    assert "# existing" in content
+    assert "## graphify" not in content
+
+
+def test_copilot_skill_uses_posix_instructions():
+    import graphify
+    skill = (Path(graphify.__file__).parent / "skill-copilot.md").read_text(encoding="utf-8")
+    assert "which graphify" in skill
+    assert "Remove-Item" not in skill
+
+
+def test_copilot_windows_skill_uses_powershell_friendly_instructions():
+    import graphify
+    skill = (Path(graphify.__file__).parent / "skill-copilot-windows.md").read_text(encoding="utf-8")
+    assert "allowed-tools:" in skill
+    assert "powershell" in skill
+    assert "Remove-Item" in skill
+    assert "which graphify" not in skill


### PR DESCRIPTION
## Summary

- add GitHub Copilot CLI support via `graphify install --platform copilot`
- add OS-aware Copilot skill install routing
- add `graphify copilot install` / `graphify copilot uninstall`
- document Copilot usage in `README.md` and `README.zh-CN.md`
- add install tests for Windows and macOS Copilot skill variants

## Validation

- python -m py_compile graphify\__main__.py graphify\security.py graphify\export.py
- python -m pytest tests\test_install.py tests\test_claude_md.py tests\test_security.py -q

## Changes

Rebased on latest `v3` (`23d88c5`), with `security.py` changes dropped (already applied upstream).