### PR TITLE
Fix packaged skill coverage for install targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ where = ["."]
 include = ["graphify*"]
 
 [tool.setuptools.package-data]
-graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md"]
+graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,10 @@ PLATFORMS = {
     "codex": (".agents/skills/graphify/SKILL.md",),
     "opencode": (".config/opencode/skills/graphify/SKILL.md",),
     "claw": (".claw/skills/graphify/SKILL.md",),
+    "droid": (".factory/skills/graphify/SKILL.md",),
+    "trae": (".trae/skills/graphify/SKILL.md",),
+    "trae-cn": (".trae-cn/skills/graphify/SKILL.md",),
+    "windows": (".claude/skills/graphify/SKILL.md",),
 }
 
 
@@ -36,6 +40,26 @@ def test_install_opencode(tmp_path):
 def test_install_claw(tmp_path):
     _install(tmp_path, "claw")
     assert (tmp_path / ".claw" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_droid(tmp_path):
+    _install(tmp_path, "droid")
+    assert (tmp_path / ".factory" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_trae(tmp_path):
+    _install(tmp_path, "trae")
+    assert (tmp_path / ".trae" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_trae_cn(tmp_path):
+    _install(tmp_path, "trae-cn")
+    assert (tmp_path / ".trae-cn" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_windows(tmp_path):
+    _install(tmp_path, "windows")
+    assert (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
 
 
 def test_install_unknown_platform_exits(tmp_path):
@@ -67,10 +91,10 @@ def test_claw_skill_is_sequential():
 
 
 def test_all_skill_files_exist_in_package():
-    """All four platform skill files must be present in the installed package."""
+    """All installable platform skill files must be present in the installed package."""
     import graphify
     pkg = Path(graphify.__file__).parent
-    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md"):
+    for name in ("skill.md", "skill-codex.md", "skill-opencode.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md"):
         assert (pkg / name).exists(), f"Missing: {name}"
 
 


### PR DESCRIPTION
## Behavior before

  - CLI accepted newer install targets
  - package metadata did not fully include all required skill files
  - packaged installs for some supported platforms were at risk of failing with missing-file errors

  ## Behavior after

  - all supported install targets have matching packaged skill assets
  - tests now cover the full supported install matrix exposed by the CLI
  - future regressions are more likely to be caught during test runs

  ## Validation

  Verified with:

  - `python3 -m compileall graphify tests`
  - direct `install(platform=...)` execution for:
    - `claude`
    - `codex`
    - `opencode`
    - `claw`
    - `droid`
    - `trae`
    - `trae-cn`
    - `windows`

  `pytest` was not available in the current environment, so full test-suite execution was not run here.

  ## Scope

  This PR intentionally avoids broader refactors and only fixes the packaging/test gap needed to make supported
  install targets consistent with shipped artifacts.