### PR TITLE
fix: extension set drift in analyze.py and watch.py; remove dead build_graph

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -1,6 +1,7 @@
 """Graph analysis: god nodes (most connected), surprising connections (cross-community), suggested questions."""
 from __future__ import annotations
 import networkx as nx
+from .detect import CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS
 
 
 def _node_community_map(communities: dict[int, list[str]]) -> dict[str, int]:
@@ -109,19 +110,13 @@ def _is_concept_node(G: nx.Graph, node_id: str) -> bool:
     return False
 
 
-_CODE_EXTENSIONS = {"py", "ts", "tsx", "js", "go", "rs", "java", "rb", "cpp", "c", "h", "cs", "kt", "scala", "php"}
-_DOC_EXTENSIONS = {"md", "txt", "rst"}
-_PAPER_EXTENSIONS = {"pdf"}
-_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "webp", "gif", "svg"}
-
-
 def _file_category(path: str) -> str:
-    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-    if ext in _CODE_EXTENSIONS:
+    ext = ("." + path.rsplit(".", 1)[-1].lower()) if "." in path else ""
+    if ext in CODE_EXTENSIONS:
         return "code"
-    if ext in _PAPER_EXTENSIONS:
+    if ext in PAPER_EXTENSIONS:
         return "paper"
-    if ext in _IMAGE_EXTENSIONS:
+    if ext in IMAGE_EXTENSIONS:
         return "image"
     return "doc"
 

--- a/graphify/cluster.py
+++ b/graphify/cluster.py
@@ -52,23 +52,6 @@ def _partition(G: nx.Graph) -> dict[str, int]:
     return {node: cid for cid, nodes in enumerate(communities) for node in nodes}
 
 
-def build_graph(nodes: list[dict], edges: list[dict]) -> nx.Graph:
-    """Build a NetworkX graph from graphify node/edge dicts.
-
-    Preserves original edge direction as _src/_tgt attributes so that
-    display functions can show relationships in the correct direction,
-    even though the graph is undirected for structural analysis.
-    """
-    G = nx.Graph()
-    for n in nodes:
-        G.add_node(n["id"], **{k: v for k, v in n.items() if k != "id"})
-    for e in edges:
-        attrs = {k: v for k, v in e.items() if k not in ("source", "target")}
-        attrs["_src"] = e["source"]
-        attrs["_tgt"] = e["target"]
-        G.add_edge(e["source"], e["target"], **attrs)
-    return G
-
 _MAX_COMMUNITY_FRACTION = 0.25   # communities larger than 25% of graph get split
 _MIN_SPLIT_SIZE = 10             # only split if community has at least this many nodes
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -3,19 +3,10 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from .detect import CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS
 
-
-_WATCHED_EXTENSIONS = {
-    ".py", ".ts", ".js", ".go", ".rs", ".java", ".cpp", ".c", ".rb", ".swift", ".kt",
-    ".cs", ".scala", ".php", ".cc", ".cxx", ".hpp", ".h", ".kts",
-    ".md", ".txt", ".rst", ".pdf",
-    ".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg",
-}
-
-_CODE_EXTENSIONS = {
-    ".py", ".ts", ".js", ".go", ".rs", ".java", ".cpp", ".c", ".rb", ".swift", ".kt",
-    ".cs", ".scala", ".php", ".cc", ".cxx", ".hpp", ".h", ".kts",
-}
+_WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAGE_EXTENSIONS
+_CODE_EXTENSIONS = CODE_EXTENSIONS
 
 
 def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -137,6 +137,15 @@ def test_file_category():
     assert _file_category("flash.pdf") == "paper"
     assert _file_category("diagram.png") == "image"
     assert _file_category("notes.md") == "doc"
+    # Languages that were previously misclassified as "doc"
+    assert _file_category("main.swift") == "code"
+    assert _file_category("lib.lua") == "code"
+    assert _file_category("build.zig") == "code"
+    assert _file_category("script.ps1") == "code"
+    assert _file_category("app.ex") == "code"
+    assert _file_category("view.jsx") == "code"
+    assert _file_category("solver.jl") == "code"
+    assert _file_category("bridge.m") == "code"
 
 
 def test_is_concept_node_empty_source():


### PR DESCRIPTION
## Problem

Three modules maintain independent copies of the supported-file-extension sets. They have drifted apart as new languages were added.

### 1. `analyze.py:_file_category()` misclassifies 15 of 30 supported languages

`analyze.py:112` defined its own `_CODE_EXTENSIONS` with only 15 entries:

```python
# analyze.py (before)
_CODE_EXTENSIONS = {"py", "ts", "tsx", "js", "go", "rs", "java", "rb", "cpp", "c", "h", "cs", "kt", "scala", "php"}
```

The canonical set in `detect.py:20` has 30 entries. Missing from `analyze.py`:

> `.jsx`, `.swift`, `.lua`, `.zig`, `.ps1`, `.ex`, `.exs`, `.m`, `.mm`, `.jl`, `.cc`, `.cxx`, `.hpp`, `.kts`, `.toc`

**Effect:** `_file_category()` classifies Swift, Lua, Zig, Julia, PowerShell, Elixir, Objective-C, and JSX files as `"doc"` instead of `"code"`. This inflates surprise scores for cross-file edges involving those languages — they get a +2 "crosses file types (doc ↔ code)" bonus from `_surprise_score()` that they shouldn't.

There was also a format mismatch: `detect.py` uses dotted extensions (`.py`), while `analyze.py` used bare extensions (`py`). The lookup worked before only because both sides were consistent within themselves. This PR normalizes `_file_category()` to prepend `.` before lookup.

### 2. `watch.py` ignores newer languages in `--watch` mode

`watch.py:8-18` maintained two hardcoded sets (`_WATCHED_EXTENSIONS`, `_CODE_EXTENSIONS`) that were also behind `detect.py`. File saves in Lua, Zig, PowerShell, Elixir, Objective-C, Julia, JSX, and TSX would not trigger auto-rebuild during `--watch`.

### 3. `cluster.py:build_graph()` is dead code

`cluster.py:55-70` defines a `build_graph(nodes, edges)` function that:
- Is never imported by any module or test (`grep` confirms)
- Is not exported via `__init__.py` (which exports `build_from_json` from `build.py`)
- Duplicates the logic in `build.build_from_json()`, including the `_src`/`_tgt` direction-preservation pattern

## Fix

- **analyze.py**: Delete the 4 local extension sets. Import `CODE_EXTENSIONS`, `DOC_EXTENSIONS`, `PAPER_EXTENSIONS`, `IMAGE_EXTENSIONS` from `detect.py`. Fix `_file_category()` to use dotted extension format.
- **watch.py**: Delete the 2 local extension sets. Derive `_WATCHED_EXTENSIONS` and `_CODE_EXTENSIONS` from `detect.py` imports.
- **cluster.py**: Delete the unused `build_graph()` function.
- **test_analyze.py**: Add 8 assertions to `test_file_category()` covering the languages that were previously misclassified (swift, lua, zig, ps1, ex, jsx, jl, m).

## Verification

- 375/375 tests pass (the 7 `test_security.py` failures in my environment are pre-existing — caused by a local proxy resolving public hostnames to `198.18.x.x` private IPs, unrelated to this change)
- `git grep` confirms no remaining imports of `cluster.build_graph` anywhere in the codebase
- Net change: **+17 lines, −39 lines** across 4 files

## Test plan

- [x] `pytest tests/test_analyze.py` — all pass, including new `test_file_category` assertions
- [x] `pytest tests/test_cluster.py` — all pass after `build_graph` removal
- [x] `pytest tests/test_watch.py` — all pass with derived extension sets
- [x] Full suite `pytest tests/` — 375 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)