### PR TITLE
Add GitHub Copilot CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every relationship is tagged `EXTRACTED` (found directly in source), `INFERRED` 
 
 ## Install
 
-**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
+**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
 
 ```bash
 pip install graphifyy && graphify install
@@ -60,6 +60,7 @@ pip install graphifyy && graphify install
 |----------|----------------|
 | Claude Code (Linux/Mac) | `graphify install` |
 | Claude Code (Windows) | `graphify install` (auto-detected) or `graphify install --platform windows` |
+| GitHub Copilot CLI | `graphify install --platform copilot` |
 | Codex | `graphify install --platform codex` |
 | OpenCode | `graphify install --platform opencode` |
 | OpenClaw | `graphify install --platform claw` |
@@ -67,7 +68,7 @@ pip install graphifyy && graphify install
 | Trae | `graphify install --platform trae` |
 | Trae CN | `graphify install --platform trae-cn` |
 
-Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw uses sequential extraction (parallel agent support is still early on that platform). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism.
+GitHub Copilot CLI installs the skill to `~/.copilot/skills/graphify/SKILL.md`. Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw uses sequential extraction (parallel agent support is still early on that platform). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism.
 
 Then open your AI coding assistant and type:
 
@@ -84,6 +85,7 @@ After building a graph, run this once in your project:
 | Platform | Command |
 |----------|---------|
 | Claude Code | `graphify claude install` |
+| GitHub Copilot CLI | `graphify copilot install` |
 | Codex | `graphify codex install` |
 | OpenCode | `graphify opencode install` |
 | OpenClaw | `graphify claw install` |
@@ -92,6 +94,8 @@ After building a graph, run this once in your project:
 | Trae CN | `graphify trae-cn install` |
 
 **Claude Code** does two things: writes a `CLAUDE.md` section telling Claude to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs a **PreToolUse hook** (`settings.json`) that fires before every Glob and Grep call. If a knowledge graph exists, Claude sees: _"graphify: Knowledge graph exists. Read GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ — so Claude navigates via the graph instead of grepping through every file.
+
+**GitHub Copilot CLI** writes the same rules to `AGENTS.md`, which Copilot CLI reads in the repository root. There is no PreToolUse hook equivalent.
 
 **Codex** writes to `AGENTS.md` and also installs a **PreToolUse hook** in `.codex/hooks.json` that fires before every Bash tool call — same always-on mechanism as Claude Code.
 
@@ -202,6 +206,8 @@ graphify hook status
 # always-on assistant instructions - platform-specific
 graphify claude install            # CLAUDE.md + PreToolUse hook (Claude Code)
 graphify claude uninstall
+graphify copilot install           # AGENTS.md (GitHub Copilot CLI)
+graphify copilot uninstall
 graphify codex install             # AGENTS.md (Codex)
 graphify opencode install          # AGENTS.md + tool.execute.before plugin (OpenCode)
 graphify claw install              # AGENTS.md (OpenClaw)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1,4 +1,4 @@
-"""graphify CLI - `graphify install` sets up the Claude Code skill."""
+"""graphify CLI - `graphify install` sets up assistant skills."""
 from __future__ import annotations
 import json
 import platform
@@ -52,6 +52,11 @@ _PLATFORM_CONFIG: dict[str, dict] = {
         "skill_dst": Path(".claude") / "skills" / "graphify" / "SKILL.md",
         "claude_md": True,
     },
+    "copilot": {
+        "skill_file": "skill.md",
+        "skill_dst": Path(".copilot") / "skills" / "graphify" / "SKILL.md",
+        "claude_md": False,
+    },
     "codex": {
         "skill_file": "skill-codex.md",
         "skill_dst": Path(".agents") / "skills" / "graphify" / "SKILL.md",
@@ -90,6 +95,14 @@ _PLATFORM_CONFIG: dict[str, dict] = {
 }
 
 
+def _install_prompt(platform: str) -> tuple[str, str | None]:
+    if platform == "codex":
+        return "$graphify .", None
+    if platform == "copilot":
+        return "Use the /graphify skill on .", "If Copilot CLI is already running, run `/skills reload` first."
+    return "/graphify .", None
+
+
 def install(platform: str = "claude") -> None:
     if platform not in _PLATFORM_CONFIG:
         print(
@@ -126,9 +139,14 @@ def install(platform: str = "claude") -> None:
             print(f"  CLAUDE.md        ->  created at {claude_md}")
 
     print()
-    print("Done. Open your AI coding assistant and type:")
+    prompt, note = _install_prompt(platform)
+
+    print("Done. In your AI coding assistant, use:")
     print()
-    print("  /graphify .")
+    print(f"  {prompt}")
+    if note:
+        print()
+        print(note)
     print()
 
 
@@ -145,8 +163,7 @@ Rules:
 
 _CLAUDE_MD_MARKER = "## graphify"
 
-# AGENTS.md section for Codex, OpenCode, and OpenClaw.
-# All three platforms read AGENTS.md in the project root for persistent instructions.
+# AGENTS.md section for platforms that use repository instructions.
 _AGENTS_MD_SECTION = """\
 ## graphify
 
@@ -302,7 +319,7 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
 
 
 def _agents_install(project_dir: Path, platform: str) -> None:
-    """Write the graphify section to the local AGENTS.md (Codex/OpenCode/OpenClaw)."""
+    """Write the graphify section to the local AGENTS.md (Copilot/Codex/OpenCode/OpenClaw)."""
     target = (project_dir or Path(".")) / "AGENTS.md"
 
     if target.exists():
@@ -468,7 +485,7 @@ def main() -> None:
         print("Usage: graphify <command>")
         print()
         print("Commands:")
-        print("  install [--platform P]  copy skill to platform config dir (claude|windows|codex|opencode|claw|droid|trae|trae-cn)")
+        print("  install [--platform P]  copy skill to platform config dir (claude|windows|copilot|codex|opencode|claw|droid|trae|trae-cn)")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
         print("    --budget N              cap output at N tokens (default 2000)")
@@ -485,6 +502,8 @@ def main() -> None:
         print("  hook status             check if git hooks are installed")
         print("  claude install          write graphify section to CLAUDE.md + PreToolUse hook (Claude Code)")
         print("  claude uninstall        remove graphify section from CLAUDE.md + PreToolUse hook")
+        print("  copilot install         write graphify section to AGENTS.md (GitHub Copilot CLI)")
+        print("  copilot uninstall       remove graphify section from AGENTS.md")
         print("  codex install           write graphify section to AGENTS.md (Codex)")
         print("  codex uninstall         remove graphify section from AGENTS.md")
         print("  opencode install        write graphify section to AGENTS.md + tool.execute.before plugin (OpenCode)")
@@ -526,7 +545,7 @@ def main() -> None:
         else:
             print("Usage: graphify claude [install|uninstall]", file=sys.stderr)
             sys.exit(1)
-    elif cmd in ("codex", "opencode", "claw", "droid", "trae", "trae-cn"):
+    elif cmd in ("copilot", "codex", "opencode", "claw", "droid", "trae", "trae-cn"):
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
         if subcmd == "install":
             _agents_install(Path("."), cmd)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ import pytest
 
 PLATFORMS = {
     "claude": (".claude/skills/graphify/SKILL.md",),
+    "copilot": (".copilot/skills/graphify/SKILL.md",),
     "codex": (".agents/skills/graphify/SKILL.md",),
     "opencode": (".config/opencode/skills/graphify/SKILL.md",),
     "claw": (".claw/skills/graphify/SKILL.md",),
@@ -25,6 +26,11 @@ def _install(tmp_path, platform):
 def test_install_default_claude(tmp_path):
     _install(tmp_path, "claude")
     assert (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_copilot(tmp_path):
+    _install(tmp_path, "copilot")
+    assert (tmp_path / ".copilot" / "skills" / "graphify" / "SKILL.md").exists()
 
 
 def test_install_codex(tmp_path):
@@ -109,6 +115,11 @@ def test_codex_install_does_not_write_claude_md(tmp_path):
     assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
 
 
+def test_copilot_install_does_not_write_claude_md(tmp_path):
+    _install(tmp_path, "copilot")
+    assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
+
 # --- always-on AGENTS.md install/uninstall tests ---
 
 def _agents_install(tmp_path, platform):
@@ -127,6 +138,11 @@ def test_codex_agents_install_writes_agents_md(tmp_path):
     assert agents_md.exists()
     assert "graphify" in agents_md.read_text()
     assert "GRAPH_REPORT.md" in agents_md.read_text()
+
+
+def test_copilot_agents_install_writes_agents_md(tmp_path):
+    _agents_install(tmp_path, "copilot")
+    assert (tmp_path / "AGENTS.md").exists()
 
 
 def test_opencode_agents_install_writes_agents_md(tmp_path):


### PR DESCRIPTION
## Summary
Add GitHub Copilot CLI as a supported graphify platform.

## What changed
- add `graphify install --platform copilot` to install the skill into `~/.copilot/skills/graphify/SKILL.md`
- add `graphify copilot install` / `graphify copilot uninstall` for project-level `AGENTS.md` integration
- extend installer tests to cover the Copilot CLI path
- keep the README changes minimal to the Copilot install and project integration notes

## Validation
- `pytest tests/ -q --tb=short`

## Notes
- I checked the repo guidance: there is no separate `CONTRIBUTING.md` or PR template in the repo. The README contribution note focuses on worked examples and extraction bug reports, so this PR keeps the scope to platform integration and the minimum related docs.
