### PR TITLE
[codex] Fix codex install idempotency

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -343,18 +343,24 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
 def _agents_install(project_dir: Path, platform: str) -> None:
     """Write the graphify section to the local AGENTS.md (Codex/OpenCode/OpenClaw)."""
     target = (project_dir or Path(".")) / "AGENTS.md"
+    agents_already_configured = False
 
     if target.exists():
         content = target.read_text(encoding="utf-8")
         if _AGENTS_MD_MARKER in content:
-            print(f"graphify already configured in AGENTS.md")
-            return
-        new_content = content.rstrip() + "\n\n" + _AGENTS_MD_SECTION
+            agents_already_configured = True
+        else:
+            new_content = content.rstrip() + "\n\n" + _AGENTS_MD_SECTION
     else:
         new_content = _AGENTS_MD_SECTION
 
-    target.write_text(new_content, encoding="utf-8")
-    print(f"graphify section written to {target.resolve()}")
+    if agents_already_configured:
+        print("graphify already configured in AGENTS.md")
+        if platform not in ("codex", "opencode"):
+            return
+    else:
+        target.write_text(new_content, encoding="utf-8")
+        print(f"graphify section written to {target.resolve()}")
 
     if platform == "codex":
         _install_codex_hook(project_dir or Path("."))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 """Tests for graphify install --platform routing."""
+import json
 from pathlib import Path
 from unittest.mock import patch
 import pytest
@@ -122,11 +123,17 @@ def _agents_uninstall(tmp_path):
 
 
 def test_codex_agents_install_writes_agents_md(tmp_path):
+    from graphify.__main__ import _CODEX_HOOK
+
     _agents_install(tmp_path, "codex")
     agents_md = tmp_path / "AGENTS.md"
     assert agents_md.exists()
     assert "graphify" in agents_md.read_text()
     assert "GRAPH_REPORT.md" in agents_md.read_text()
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    assert hooks_path.exists()
+    hooks = json.loads(hooks_path.read_text())
+    assert hooks["hooks"]["PreToolUse"] == _CODEX_HOOK["hooks"]["PreToolUse"]
 
 
 def test_opencode_agents_install_writes_agents_md(tmp_path):
@@ -140,11 +147,27 @@ def test_claw_agents_install_writes_agents_md(tmp_path):
 
 
 def test_agents_install_idempotent(tmp_path):
-    """Installing twice does not duplicate the section."""
+    """Installing twice does not duplicate the section or Codex hook."""
     _agents_install(tmp_path, "codex")
     _agents_install(tmp_path, "codex")
     content = (tmp_path / "AGENTS.md").read_text()
     assert content.count("## graphify") == 1
+    hooks = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    assert len(hooks["hooks"]["PreToolUse"]) == 1
+
+
+def test_codex_agents_install_repairs_missing_hook_after_partial_install(tmp_path):
+    """A rerun heals a partial Codex install where only AGENTS.md exists."""
+    from graphify.__main__ import _AGENTS_MD_SECTION
+
+    (tmp_path / "AGENTS.md").write_text(_AGENTS_MD_SECTION, encoding="utf-8")
+
+    _agents_install(tmp_path, "codex")
+
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    assert hooks_path.exists()
+    hooks = json.loads(hooks_path.read_text())
+    assert len(hooks["hooks"]["PreToolUse"]) == 1
 
 
 def test_agents_install_appends_to_existing(tmp_path):


### PR DESCRIPTION
## Summary
- make `graphify codex install` continue past an existing `AGENTS.md` marker so reruns still install the Codex PreToolUse hook
- preserve idempotency by keeping the `AGENTS.md` section single-instance while letting Codex and OpenCode heal partial installs
- extend install tests to cover fresh Codex installs, repeated installs, and the partial-install recovery path

## Root cause
`_agents_install()` returned as soon as it saw the graphify marker in `AGENTS.md`. For Codex, that meant a partial install could never resume into `_install_codex_hook()`, leaving `.codex/hooks.json` missing forever after the first failure.

## Impact
`graphify codex install` is now resumable after a partial success. A rerun will create a missing `.codex/hooks.json` without duplicating the `AGENTS.md` section or the hook entry.

## Validation
- `uv run --with pytest pytest tests/test_install.py -q`
- CLI verification in fresh temp directories for:
  - fresh install creates `AGENTS.md` and `.codex/hooks.json`
  - partial install rerun creates the missing hook
  - repeated install keeps one graphify section and one hook entry
