### PR TITLE
Fix: frontmatter-aware cache for Markdown files

### DIFF
--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -7,11 +7,27 @@ import os
 from pathlib import Path
 
 
+def _body_content(content: bytes) -> bytes:
+    """Strip YAML frontmatter from Markdown content, returning only the body."""
+    text = content.decode(errors="replace")
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            return text[end + 4:].encode()
+    return content
+
+
 def file_hash(path: Path) -> str:
-    """SHA256 of file contents + resolved path. Prevents cache collisions on identical content."""
+    """SHA256 of file contents + resolved path. Prevents cache collisions on identical content.
+
+    For Markdown files (.md), only the body below the YAML frontmatter is hashed,
+    so metadata-only changes (e.g. reviewed, status, tags) do not invalidate the cache.
+    """
     p = Path(path)
+    raw = p.read_bytes()
+    content = _body_content(raw) if p.suffix.lower() == ".md" else raw
     h = hashlib.sha256()
-    h.update(p.read_bytes())
+    h.update(content)
     h.update(b"\x00")
     h.update(str(p.resolve()).encode())
     return h.hexdigest()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,7 @@
 """Tests for graphify/cache.py."""
 import pytest
 from pathlib import Path
-from graphify.cache import file_hash, cache_dir, load_cached, save_cached, cached_files, clear_cache
+from graphify.cache import file_hash, cache_dir, load_cached, save_cached, cached_files, clear_cache, _body_content
 
 
 @pytest.fixture
@@ -64,6 +64,58 @@ def test_cached_files(tmp_path, cache_root):
     hashes = cached_files(cache_root)
     assert file_hash(f1) in hashes
     assert file_hash(f2) in hashes
+
+
+def test_md_frontmatter_only_change_same_hash(tmp_path):
+    """Changing only frontmatter fields in a .md file does not change the hash."""
+    f = tmp_path / "doc.md"
+    f.write_text("---\nreviewed: 2026-01-01\n---\n\n# Title\n\nBody text.")
+    h1 = file_hash(f)
+    f.write_text("---\nreviewed: 2026-04-09\n---\n\n# Title\n\nBody text.")
+    h2 = file_hash(f)
+    assert h1 == h2
+
+
+def test_md_body_change_different_hash(tmp_path):
+    """Changing the body of a .md file produces a different hash."""
+    f = tmp_path / "doc.md"
+    f.write_text("---\nreviewed: 2026-01-01\n---\n\n# Title\n\nOriginal body.")
+    h1 = file_hash(f)
+    f.write_text("---\nreviewed: 2026-01-01\n---\n\n# Title\n\nChanged body.")
+    h2 = file_hash(f)
+    assert h1 != h2
+
+
+def test_md_no_frontmatter_hashed_normally(tmp_path):
+    """A .md file with no frontmatter is hashed by its full content."""
+    f = tmp_path / "doc.md"
+    f.write_text("# Just a heading\n\nNo frontmatter here.")
+    h1 = file_hash(f)
+    f.write_text("# Just a heading\n\nDifferent content.")
+    h2 = file_hash(f)
+    assert h1 != h2
+
+
+def test_non_md_file_hashed_fully(tmp_path):
+    """Non-.md files are still hashed by their full content."""
+    f = tmp_path / "script.py"
+    f.write_text("# comment\nx = 1")
+    h1 = file_hash(f)
+    f.write_text("# changed comment\nx = 1")
+    h2 = file_hash(f)
+    assert h1 != h2
+
+
+def test_body_content_strips_frontmatter():
+    """_body_content correctly strips YAML frontmatter."""
+    content = b"---\ntitle: Test\n---\n\nActual body."
+    assert _body_content(content) == b"\n\nActual body."
+
+
+def test_body_content_no_frontmatter():
+    """_body_content returns content unchanged when no frontmatter present."""
+    content = b"No frontmatter here."
+    assert _body_content(content) == content
 
 
 def test_clear_cache(tmp_file, cache_root):


### PR DESCRIPTION
## Summary

Closes #131

- Adds `_body_content()` helper in `cache.py` that strips YAML frontmatter from `.md` files before hashing
- Updates `file_hash()` to use body-only content for `.md` files, leaving all other file types unchanged
- Adds 6 new tests covering frontmatter-only changes, body changes, no-frontmatter files, and non-`.md` files

## Problem

In docs-heavy workflows (e.g. Obsidian vaults), frontmatter fields like `reviewed`, `status`, or `tags` are updated regularly by maintenance scripts without touching actual content. Previously, every such update invalidated the cache for the touched file — triggering unnecessary LLM re-extraction.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Frontmatter-only change in `.md` | Cache miss (re-extracts) | Cache hit (skipped) |
| Body change in `.md` | Cache miss | Cache miss |
| No frontmatter in `.md` | Cache miss on any change | Cache miss on any change |
| Non-`.md` file | Full content hashed | Full content hashed (unchanged) |

## Test plan

- [ ] `test_md_frontmatter_only_change_same_hash` — metadata-only update produces same hash
- [ ] `test_md_body_change_different_hash` — body change produces different hash
- [ ] `test_md_no_frontmatter_hashed_normally` — files without frontmatter behave as before
- [ ] `test_non_md_file_hashed_fully` — non-`.md` files unaffected
- [ ] `test_body_content_strips_frontmatter` — unit test for the helper
- [ ] `test_body_content_no_frontmatter` — helper pass-through when no frontmatter

All 12 tests in `tests/test_cache.py` pass.
