### PR TITLE
feat: add dry-run and diff CLI commands

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -619,6 +619,8 @@ def main() -> None:
         print("    --type T                query type: query|path_query|explain (default: query)")
         print("    --nodes N1 N2 ...       source node labels cited in the answer")
         print("    --memory-dir DIR        memory directory (default: graphify-out/memory)")
+        print("  dry-run [path]          scan corpus and report file counts/health without building")
+        print("  diff <old.json> <new.json>  compare two graph snapshots and print what changed")
         print("  benchmark [graph.json]  measure token reduction vs naive full-corpus approach")
         print("  hook install            install post-commit/post-checkout git hooks (all platforms)")
         print("  hook uninstall          remove git hooks")
@@ -790,6 +792,82 @@ def main() -> None:
             source_nodes=opts.nodes or None,
         )
         print(f"Saved to {out}")
+    elif cmd == "dry-run":
+        root = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".")
+        if not root.exists():
+            print(f"error: path not found: {root}", file=sys.stderr)
+            sys.exit(1)
+        from graphify.detect import detect as _detect, FileType as _FileType
+        result = _detect(root)
+        files = result["files"]
+        total_files = result["total_files"]
+        total_words = result["total_words"]
+        print(f"Corpus scan: {root.resolve()}")
+        print()
+        type_labels = {
+            "code": "Code files",
+            "document": "Documents",
+            "paper": "Papers/PDFs",
+            "image": "Images",
+        }
+        for ftype, label in type_labels.items():
+            count = len(files.get(ftype, []))
+            if count:
+                print(f"  {label:<16} {count:>5}")
+        print(f"  {'Total':<16} {total_files:>5}  (~{total_words:,} words)")
+        if result.get("skipped_sensitive"):
+            print(f"\n  Skipped (sensitive): {len(result['skipped_sensitive'])} file(s)")
+        if result.get("warning"):
+            print(f"\nwarning: {result['warning']}")
+        else:
+            print("\nCorpus looks healthy — no warnings.")
+        print("\nNo files were written. Run without dry-run to build the graph.")
+    elif cmd == "diff":
+        if len(sys.argv) < 4:
+            print("Usage: graphify diff <old-graph.json> <new-graph.json>", file=sys.stderr)
+            sys.exit(1)
+        old_path = Path(sys.argv[2]).resolve()
+        new_path = Path(sys.argv[3]).resolve()
+        for p in (old_path, new_path):
+            if not p.exists():
+                print(f"error: file not found: {p}", file=sys.stderr)
+                sys.exit(1)
+            if p.suffix != ".json":
+                print(f"error: expected a .json file: {p}", file=sys.stderr)
+                sys.exit(1)
+        try:
+            import networkx as _nx
+            from networkx.readwrite import json_graph as _jg
+            def _load_graph(p: Path) -> _nx.Graph:
+                raw = json.loads(p.read_text(encoding="utf-8"))
+                try:
+                    return _jg.node_link_graph(raw, edges="links")
+                except TypeError:
+                    return _jg.node_link_graph(raw)
+            G_old = _load_graph(old_path)
+            G_new = _load_graph(new_path)
+        except Exception as exc:
+            print(f"error: could not load graphs: {exc}", file=sys.stderr)
+            sys.exit(1)
+        from graphify.analyze import graph_diff as _graph_diff
+        diff = _graph_diff(G_old, G_new)
+        print(f"Summary: {diff['summary']}")
+        if diff["new_nodes"]:
+            print(f"\nNew nodes ({len(diff['new_nodes'])}):")
+            for n in diff["new_nodes"]:
+                print(f"  + {n['label']} ({n['id']})")
+        if diff["removed_nodes"]:
+            print(f"\nRemoved nodes ({len(diff['removed_nodes'])}):")
+            for n in diff["removed_nodes"]:
+                print(f"  - {n['label']} ({n['id']})")
+        if diff["new_edges"]:
+            print(f"\nNew edges ({len(diff['new_edges'])}):")
+            for e in diff["new_edges"]:
+                print(f"  + {e['source']} --[{e['relation']}]--> {e['target']}")
+        if diff["removed_edges"]:
+            print(f"\nRemoved edges ({len(diff['removed_edges'])}):")
+            for e in diff["removed_edges"]:
+                print(f"  - {e['source']} --[{e['relation']}]--> {e['target']}")
     elif cmd == "benchmark":
         from graphify.benchmark import run_benchmark, print_benchmark
         graph_path = sys.argv[2] if len(sys.argv) > 2 else "graphify-out/graph.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,162 @@
+"""Tests for graphify CLI commands: dry-run and diff."""
+import json
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── dry-run ───────────────────────────────────────────────────────────────────
+
+def _run_main(argv):
+    """Run graphify.__main__.main() with the given argv, return (stdout, exit_code)."""
+    import io
+    from graphify.__main__ import main
+    buf = io.StringIO()
+    exit_code = 0
+    with patch("sys.argv", argv), patch("sys.stdout", buf):
+        try:
+            main()
+        except SystemExit as e:
+            exit_code = e.code or 0
+    return buf.getvalue(), exit_code
+
+
+def test_dry_run_prints_summary(tmp_path):
+    """dry-run on a directory with code files prints a file-count summary."""
+    (tmp_path / "app.py").write_text("x = 1\n")
+    (tmp_path / "utils.py").write_text("def f(): pass\n")
+    out, code = _run_main(["graphify", "dry-run", str(tmp_path)])
+    assert code == 0
+    assert "Corpus scan" in out
+    assert "Code files" in out
+    assert "Total" in out
+
+
+def test_dry_run_no_files_written(tmp_path):
+    """dry-run must not create graphify-out/ or any files."""
+    (tmp_path / "readme.md").write_text("# hello\n")
+    _run_main(["graphify", "dry-run", str(tmp_path)])
+    assert not (tmp_path / "graphify-out").exists()
+
+
+def test_dry_run_default_path(tmp_path, monkeypatch):
+    """dry-run with no path argument defaults to current directory."""
+    (tmp_path / "main.py").write_text("print('hi')\n")
+    monkeypatch.chdir(tmp_path)
+    out, code = _run_main(["graphify", "dry-run"])
+    assert code == 0
+    assert "Corpus scan" in out
+
+
+def test_dry_run_missing_path(tmp_path):
+    """dry-run with a non-existent path exits with error."""
+    out_stderr = []
+    with patch("sys.argv", ["graphify", "dry-run", str(tmp_path / "nonexistent")]), \
+         patch("sys.stderr") as mock_err:
+        mock_err.write = lambda s: out_stderr.append(s)
+        with pytest.raises(SystemExit) as exc:
+            from graphify.__main__ import main
+            main()
+    assert exc.value.code != 0
+
+
+def test_dry_run_no_graphify_out_written(tmp_path):
+    """dry-run message says no files were written."""
+    (tmp_path / "a.py").write_text("a = 1\n")
+    out, _ = _run_main(["graphify", "dry-run", str(tmp_path)])
+    assert "No files were written" in out
+
+
+# ── diff ──────────────────────────────────────────────────────────────────────
+
+try:
+    import networkx  # noqa: F401
+    _HAS_NETWORKX = True
+except ImportError:
+    _HAS_NETWORKX = False
+
+requires_networkx = pytest.mark.skipif(not _HAS_NETWORKX, reason="networkx not installed")
+
+
+def _make_graph_json(tmp_path, name, nodes, edges):
+    data = {
+        "directed": False,
+        "multigraph": False,
+        "graph": {},
+        "nodes": [{"id": n, "label": n} for n in nodes],
+        "links": [
+            {"source": s, "target": t, "relation": r, "confidence": "EXTRACTED", "weight": 1.0}
+            for s, t, r in edges
+        ],
+    }
+    p = tmp_path / name
+    p.write_text(json.dumps(data))
+    return p
+
+
+@requires_networkx
+def test_diff_no_changes(tmp_path):
+    """diff of identical graphs reports 'no changes'."""
+    nodes = ["alpha", "beta"]
+    edges = [("alpha", "beta", "calls")]
+    old = _make_graph_json(tmp_path, "old.json", nodes, edges)
+    new = _make_graph_json(tmp_path, "new.json", nodes, edges)
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "no changes" in out
+
+
+@requires_networkx
+def test_diff_new_node(tmp_path):
+    """diff detects a newly added node."""
+    old = _make_graph_json(tmp_path, "old.json", ["alpha"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["alpha", "gamma"], [])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "gamma" in out
+    assert "New nodes" in out
+
+
+@requires_networkx
+def test_diff_removed_node(tmp_path):
+    """diff detects a removed node."""
+    old = _make_graph_json(tmp_path, "old.json", ["alpha", "beta"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["alpha"], [])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "beta" in out
+    assert "Removed nodes" in out
+
+
+@requires_networkx
+def test_diff_new_edge(tmp_path):
+    """diff detects a new edge."""
+    old = _make_graph_json(tmp_path, "old.json", ["a", "b"], [])
+    new = _make_graph_json(tmp_path, "new.json", ["a", "b"], [("a", "b", "imports")])
+    out, code = _run_main(["graphify", "diff", str(old), str(new)])
+    assert code == 0
+    assert "New edges" in out
+    assert "imports" in out
+
+
+def test_diff_missing_file(tmp_path):
+    """diff exits with error when a file does not exist."""
+    old = _make_graph_json(tmp_path, "old.json", ["a"], [])
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["graphify", "diff", str(old), str(tmp_path / "missing.json")]):
+            from graphify.__main__ import main
+            main()
+    assert exc.value.code != 0
+
+
+def test_diff_missing_args(tmp_path):
+    """diff with fewer than 2 positional args exits with error."""
+    with pytest.raises(SystemExit) as exc:
+        with patch("sys.argv", ["graphify", "diff", str(tmp_path / "only_one.json")]):
+            from graphify.__main__ import main
+            main()
+    assert exc.value.code != 0


### PR DESCRIPTION
## Summary

Two new `graphify` CLI commands:

### `graphify dry-run [path]`
Scans the corpus and prints a file-count/health summary **without writing any files or building a graph**. Useful for validating what graphify sees before committing to a full extraction run.

```
$ graphify dry-run ./my-project
Corpus scan: /abs/path/my-project

  Code files          23
  Documents            7
  Total               30  (~84,200 words)

Corpus looks healthy — no warnings.

No files were written. Run without dry-run to build the graph.
```

Reuses `detect.detect()` — no new detection logic.

### `graphify diff <old.json> <new.json>`
Compares two `graph.json` snapshots and prints added/removed nodes and edges. Wires the existing `analyze.graph_diff()` function (line 444) to the CLI — zero new graph logic.

```
$ graphify diff graphify-out/graph-v1.json graphify-out/graph.json
Summary: 2 new nodes, 1 new edge, 1 node removed

New nodes (2):
  + AuthService (authservice)
  + TokenCache (tokencache)

Removed nodes (1):
  - OldAuth (oldauth)

New edges (1):
  + authservice --[imports_from]--> tokencache
```

## Changes

- `graphify/__main__.py` — two new `elif` branches (`dry-run`, `diff`) + help text entries
- `tests/test_cli.py` — 11 new tests (5 for `dry-run`, 6 for `diff`); `diff` tests that require `networkx` are skipped gracefully when the package is not installed

## Test plan

- [ ] `test_dry_run_prints_summary` — file-count table in output
- [ ] `test_dry_run_no_files_written` — `graphify-out/` not created
- [ ] `test_dry_run_default_path` — defaults to current directory
- [ ] `test_dry_run_missing_path` — exits non-zero for missing path
- [ ] `test_dry_run_no_graphify_out_written` — "No files were written" in output
- [ ] `test_diff_no_changes` — "no changes" for identical graphs
- [ ] `test_diff_new_node` — new node appears in output
- [ ] `test_diff_removed_node` — removed node appears in output
- [ ] `test_diff_new_edge` — new edge appears in output
- [ ] `test_diff_missing_file` — exits non-zero for missing file
- [ ] `test_diff_missing_args` — exits non-zero with < 2 positional args

🤖 Generated with [Claude Code](https://claude.com/claude-code)