### PR TITLE
feat: expose graph_diff in public API + add worked example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ dist/
 
 Same syntax as `.gitignore`. Patterns match against file paths relative to the folder you run graphify on.
 
+## What it looks like
+
+Running graphify on [httpx](https://github.com/encode/httpx) produces this report:
+
+```
+Graph Report - httpx/  (144 nodes · 330 edges · 6 communities)
+Extraction: 53% EXTRACTED · 47% INFERRED · 0% AMBIGUOUS
+
+God Nodes (most connected - your core abstractions)
+  1. Client        - 26 edges
+  2. AsyncClient   - 25 edges
+  3. Response      - 24 edges
+  4. Request       - 21 edges
+  5. BaseClient    - 18 edges
+
+Surprising Connections (you probably didn't know these)
+  Timeout --uses--> URL        [INFERRED]  client.py → models.py
+  Timeout --uses--> Headers    [INFERRED]  client.py → models.py
+  Timeout --uses--> BaseTransport [INFERRED]  client.py → transport.py
+
+Communities
+  Community 0: ConnectError, AsyncHTTPTransport, BaseTransport, HTTPTransport … (8 nodes)
+  Community 1: Auth, BasicAuth, DigestAuth, Limits, Timeout, Request … (9 nodes)
+  Community 2: AsyncClient, BaseClient, Client (3 nodes)
+  Community 3: Cookies, Headers, URL (3 nodes)
+```
+
+`graph.html` is an interactive force-directed graph — click any node to highlight its neighbors, search by label, and filter by community. See the [`worked/`](worked/) directory for full examples on httpx and the Karpathy repos.
+
 ## How it works
 
 graphify runs in two passes. First, a deterministic AST pass extracts structure from code files (classes, functions, imports, call graphs, docstrings, rationale comments) with no LLM needed. Second, Claude subagents run in parallel over docs, papers, and images to extract concepts, relationships, and design rationale. The results are merged into a NetworkX graph, clustered with Leiden community detection, and exported as interactive HTML, queryable JSON, and a plain-language audit report.

--- a/graphify/__init__.py
+++ b/graphify/__init__.py
@@ -11,6 +11,7 @@ def __getattr__(name):
         "score_all": ("graphify.cluster", "score_all"),
         "cohesion_score": ("graphify.cluster", "cohesion_score"),
         "god_nodes": ("graphify.analyze", "god_nodes"),
+        "graph_diff": ("graphify.analyze", "graph_diff"),
         "surprising_connections": ("graphify.analyze", "surprising_connections"),
         "suggest_questions": ("graphify.analyze", "suggest_questions"),
         "generate": ("graphify.report", "generate"),

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -230,3 +230,25 @@ def test_graph_diff_empty_diff():
     assert diff["new_edges"] == []
     assert diff["removed_edges"] == []
     assert diff["summary"] == "no changes"
+
+
+# --- graph_diff public API export ---
+
+def test_graph_diff_importable_from_graphify():
+    import graphify
+    fn = graphify.graph_diff
+    assert callable(fn)
+
+
+def test_graph_diff_public_api_returns_correct_shape():
+    import graphify
+    nodes = [("a", "Alpha"), ("b", "Beta")]
+    G_old = _make_simple_graph(nodes, [])
+    G_new = _make_simple_graph(nodes + [("c", "Gamma")], [])
+    diff = graphify.graph_diff(G_old, G_new)
+    assert "new_nodes" in diff
+    assert "removed_nodes" in diff
+    assert "new_edges" in diff
+    assert "removed_edges" in diff
+    assert "summary" in diff
+    assert any(n["id"] == "c" for n in diff["new_nodes"])


### PR DESCRIPTION
## Summary

- `graph_diff` is now accessible as `graphify.graph_diff()` via the lazy-import map in `__init__.py` — no need to import from the internal `graphify.analyze` module.
- Add 2 tests verifying the public API is callable and returns the expected schema (`new_nodes`, `removed_nodes`, `new_edges`, `removed_edges`, `summary`).
- Add a "What it looks like" section to README with a worked example showing god nodes, surprising connections, and community output from running graphify on [httpx](https://github.com/encode/httpx).

## Motivation

`god_nodes`, `surprising_connections`, and `suggest_questions` were already in the public API — `graph_diff` (added recently) was the only analyze function missing from `__init__.py`. This closes the gap and makes the diff workflow scriptable without internal imports.

The README example closes issues #12 and #160 (requests for a visual/output demo).

## Test plan

- [x] `pytest tests/test_analyze.py -q` — all tests pass (including 2 new public API tests)
- [x] No regressions in full suite