### PR TITLE
Add hybrid semantic graph retrieval

### DIFF
--- a/graphify/__init__.py
+++ b/graphify/__init__.py
@@ -19,6 +19,9 @@ def __getattr__(name):
         "to_svg": ("graphify.export", "to_svg"),
         "to_canvas": ("graphify.export", "to_canvas"),
         "to_wiki": ("graphify.wiki", "to_wiki"),
+        "build_semantic_index": ("graphify.semantic", "build_semantic_index"),
+        "load_semantic_index": ("graphify.semantic", "load_semantic_index"),
+        "semantic_search": ("graphify.semantic", "semantic_search"),
     }
     if name in _map:
         import importlib

--- a/graphify/benchmark.py
+++ b/graphify/benchmark.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import networkx as nx
 from networkx.readwrite import json_graph
+from graphify.serve import _hybrid_seed_nodes
 
 
 _CHARS_PER_TOKEN = 4  # standard approximation
@@ -14,7 +15,7 @@ def _estimate_tokens(text: str) -> int:
 
 
 def _query_subgraph_tokens(G: nx.Graph, question: str, depth: int = 3) -> int:
-    """Run BFS from best-matching nodes and return estimated tokens in the subgraph context."""
+    """Run BFS from keyword seed nodes and return estimated tokens."""
     terms = [t.lower() for t in question.split() if len(t) > 2]
     scored = []
     for nid, data in G.nodes(data=True):
@@ -49,6 +50,34 @@ def _query_subgraph_tokens(G: nx.Graph, question: str, depth: int = 3) -> int:
             d = G.edges[u, v]
             lines.append(f"EDGE {G.nodes[u].get('label', u)} --{d.get('relation', '')}--> {G.nodes[v].get('label', v)}")
 
+    return _estimate_tokens("\n".join(lines))
+
+
+def _query_subgraph_tokens_semantic(G: nx.Graph, graph_path: str, question: str, depth: int = 3) -> int:
+    seeds = _hybrid_seed_nodes(G, graph_path, question)
+    start_nodes = [seed["id"] for seed in seeds]
+    if not start_nodes:
+        return 0
+    visited: set[str] = set(start_nodes)
+    frontier = set(start_nodes)
+    edges_seen: list[tuple] = []
+    for _ in range(depth):
+        next_frontier: set[str] = set()
+        for n in frontier:
+            for neighbor in G.neighbors(n):
+                if neighbor not in visited:
+                    next_frontier.add(neighbor)
+                    edges_seen.append((n, neighbor))
+        visited.update(next_frontier)
+        frontier = next_frontier
+    lines = []
+    for nid in visited:
+        d = G.nodes[nid]
+        lines.append(f"NODE {d.get('label', nid)} src={d.get('source_file', '')} loc={d.get('source_location', '')}")
+    for u, v in edges_seen:
+        if u in visited and v in visited:
+            d = G.edges[u, v]
+            lines.append(f"EDGE {G.nodes[u].get('label', u)} --{d.get('relation', '')}--> {G.nodes[v].get('label', v)}")
     return _estimate_tokens("\n".join(lines))
 
 
@@ -90,7 +119,7 @@ def run_benchmark(
     qs = questions or _SAMPLE_QUESTIONS
     per_question = []
     for q in qs:
-        qt = _query_subgraph_tokens(G, q)
+        qt = _query_subgraph_tokens_semantic(G, graph_path, q)
         if qt > 0:
             per_question.append({"question": q, "query_tokens": qt, "reduction": round(corpus_tokens / qt, 1)})
 

--- a/graphify/semantic.py
+++ b/graphify/semantic.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+
+from networkx.readwrite import json_graph
+
+
+_DEFAULT_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+_EMBEDDING_MATRIX_FILE = "semantic.embeddings.npy"
+_EMBEDDING_NODES_FILE = "semantic.nodes.json"
+_EMBEDDING_META_FILE = "semantic.meta.json"
+_SEMANTIC_INDEX_VERSION = 1
+_HASH_CHUNK_SIZE = 8192
+
+
+class EmbeddingBackend(Protocol):
+    def encode(self, texts: list[str]) -> np.ndarray: ...
+
+
+@dataclass(frozen=True)
+class SemanticIndex:
+    nodes: list[dict]
+    embeddings: np.ndarray
+    meta: dict
+
+
+class SentenceTransformerBackend:
+    def __init__(self, model_name: str = _DEFAULT_MODEL_NAME):
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "semantic embeddings require optional dependencies. Run: pip install 'graphifyy[embeddings]'"
+            ) from exc
+        self.model_name = model_name
+        self._model = SentenceTransformer(model_name)
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, 0), dtype=np.float32)
+        vectors = self._model.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
+        return np.asarray(vectors, dtype=np.float32)
+
+
+def graph_output_dir(graph_path: str | Path) -> Path:
+    path = Path(graph_path)
+    if path.is_dir():
+        return path
+    return path.parent
+
+
+def default_model_name() -> str:
+    return _DEFAULT_MODEL_NAME
+
+
+def semantic_artifact_paths(graph_path: str | Path) -> dict[str, Path]:
+    out_dir = graph_output_dir(graph_path)
+    return {
+        "out_dir": out_dir,
+        "embeddings": out_dir / _EMBEDDING_MATRIX_FILE,
+        "nodes": out_dir / _EMBEDDING_NODES_FILE,
+        "meta": out_dir / _EMBEDDING_META_FILE,
+    }
+
+
+@lru_cache(maxsize=4)
+def _get_backend(model_name: str) -> SentenceTransformerBackend:
+    return SentenceTransformerBackend(model_name=model_name)
+
+
+def semantic_text_for_node(node_id: str, data: dict) -> str:
+    parts = [
+        data.get("label", node_id),
+        data.get("source_file", ""),
+        data.get("file_type", ""),
+        data.get("source_location", ""),
+    ]
+    return " | ".join(part.strip() for part in parts if part and str(part).strip())
+
+
+def semantic_candidate_nodes(G) -> list[dict]:
+    items: list[dict] = []
+    for node_id, data in G.nodes(data=True):
+        label = str(data.get("label", "")).strip()
+        if not label:
+            continue
+        text = semantic_text_for_node(node_id, data)
+        items.append(
+            {
+                "id": node_id,
+                "label": label,
+                "text": text,
+                "source_file": data.get("source_file", ""),
+                "file_type": data.get("file_type", ""),
+                "source_location": data.get("source_location", ""),
+            }
+        )
+    return items
+
+
+def graph_content_hash(graph_path: str | Path) -> str:
+    sha256 = hashlib.sha256()
+    with Path(graph_path).open("rb") as handle:
+        while chunk := handle.read(_HASH_CHUNK_SIZE):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+@lru_cache(maxsize=32)
+def _cached_graph_content_hash(graph_path: str, stat_key: tuple[int, int, int]) -> str:
+    return graph_content_hash(graph_path)
+
+
+def _graph_hash_for_current_file(graph_path: str | Path) -> str:
+    path = Path(graph_path)
+    stat_result = path.stat()
+    stat_key = (stat_result.st_size, stat_result.st_mtime_ns, getattr(stat_result, "st_ino", 0))
+    return _cached_graph_content_hash(str(path.resolve()), stat_key)
+
+
+def save_semantic_index(graph_path: str | Path, nodes: list[dict], embeddings: np.ndarray, meta: dict) -> None:
+    paths = semantic_artifact_paths(graph_path)
+    paths["out_dir"].mkdir(parents=True, exist_ok=True)
+    np.save(paths["embeddings"], np.asarray(embeddings, dtype=np.float32))
+    paths["nodes"].write_text(json.dumps(nodes, indent=2), encoding="utf-8")
+    paths["meta"].write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+
+def load_semantic_index(graph_path: str | Path) -> SemanticIndex | None:
+    graph_path = Path(graph_path)
+    paths = semantic_artifact_paths(graph_path)
+    if not all(paths[name].exists() for name in ("embeddings", "nodes", "meta")):
+        return None
+    nodes = json.loads(paths["nodes"].read_text(encoding="utf-8"))
+    embeddings = np.load(paths["embeddings"])
+    meta = json.loads(paths["meta"].read_text(encoding="utf-8"))
+    current_hash = _graph_hash_for_current_file(graph_path)
+    if meta.get("version") != _SEMANTIC_INDEX_VERSION:
+        return None
+    if meta.get("graph_sha256") != current_hash:
+        return None
+    if len(nodes) != len(embeddings):
+        return None
+    if embeddings.ndim != 2:
+        return None
+    if meta.get("count") != len(nodes):
+        return None
+    if meta.get("dim") != int(embeddings.shape[1]):
+        return None
+    return SemanticIndex(nodes=nodes, embeddings=np.asarray(embeddings, dtype=np.float32), meta=meta)
+
+
+def build_semantic_index(
+    graph_path: str | Path,
+    backend: EmbeddingBackend | None = None,
+    model_name: str = _DEFAULT_MODEL_NAME,
+    force: bool = False,
+) -> dict:
+    graph_path = Path(graph_path)
+    current_hash = _graph_hash_for_current_file(graph_path)
+    existing = load_semantic_index(graph_path)
+    if existing and not force and existing.meta.get("graph_sha256") == current_hash and existing.meta.get("model_name") == model_name:
+        return existing.meta
+
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    G = json_graph.node_link_graph(data, edges="links")
+    nodes = semantic_candidate_nodes(G)
+    if backend is None:
+        backend = _get_backend(model_name)
+    texts = [node["text"] for node in nodes]
+    embeddings = np.asarray(backend.encode(texts), dtype=np.float32)
+    dim = int(embeddings.shape[1]) if embeddings.ndim == 2 and embeddings.shape[0] else 0
+    meta = {
+        "version": _SEMANTIC_INDEX_VERSION,
+        "model_name": model_name,
+        "graph_sha256": current_hash,
+        "normalized": True,
+        "count": len(nodes),
+        "dim": dim,
+    }
+    save_semantic_index(graph_path, nodes, embeddings, meta)
+    return meta
+
+
+def semantic_search(
+    graph_path: str | Path,
+    query: str,
+    index: SemanticIndex | None = None,
+    backend: EmbeddingBackend | None = None,
+    top_k: int = 5,
+    min_score: float = 0.2,
+    model_name: str = _DEFAULT_MODEL_NAME,
+) -> list[dict]:
+    if index is None:
+        index = load_semantic_index(graph_path)
+    if index is None:
+        raise FileNotFoundError("semantic index not found. Build it first.")
+    if backend is None:
+        backend = _get_backend(index.meta.get("model_name") or model_name or _DEFAULT_MODEL_NAME)
+    query_embedding = np.asarray(backend.encode([query]), dtype=np.float32)
+    if query_embedding.size == 0 or index.embeddings.size == 0:
+        return []
+    scores = index.embeddings @ query_embedding[0]
+    ranked = np.argsort(scores)[::-1]
+    results = []
+    for idx in ranked[:top_k]:
+        score = float(scores[idx])
+        if score < min_score:
+            continue
+        results.append({**index.nodes[int(idx)], "score": round(score, 4)})
+    return results

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import networkx as nx
 from networkx.readwrite import json_graph
 from graphify.security import validate_graph_path, sanitize_label
+from graphify.semantic import load_semantic_index, semantic_search
 
 
 def _load_graph(graph_path: str) -> nx.Graph:
@@ -43,6 +44,54 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
         if score > 0:
             scored.append((score, nid))
     return sorted(scored, reverse=True)
+
+
+def _reciprocal_rank_fusion(rankings: list[tuple[str, list[tuple[float, str]]]], k: int = 60) -> list[tuple[float, str, set[str], dict[str, float]]]:
+    fused: dict[str, float] = {}
+    sources: dict[str, set[str]] = {}
+    raw_scores: dict[str, dict[str, float]] = {}
+    for source, ranked in rankings:
+        for rank, (score, node_id) in enumerate(ranked, start=1):
+            fused[node_id] = fused.get(node_id, 0.0) + 1.0 / (k + rank)
+            sources.setdefault(node_id, set()).add(source)
+            raw_scores.setdefault(node_id, {})[source] = score
+    return sorted(((score, node_id, sources[node_id], raw_scores[node_id]) for node_id, score in fused.items()), reverse=True)
+
+
+def _hybrid_seed_nodes(
+    G: nx.Graph,
+    graph_path: str,
+    question: str,
+    keyword_limit: int = 3,
+    semantic_limit: int = 5,
+) -> list[dict]:
+    terms = [t.lower() for t in question.split() if len(t) > 2]
+    scored = _score_nodes(G, terms)
+    rankings: list[tuple[str, list[tuple[float, str]]]] = [("keyword", [(float(score), nid) for score, nid in scored[:keyword_limit]])]
+
+    index = load_semantic_index(graph_path)
+    if index is not None:
+        try:
+            semantic_ranked = [
+                (float(match["score"]), match["id"])
+                for match in semantic_search(graph_path, question, index=index, top_k=semantic_limit)
+            ]
+        except (FileNotFoundError, ImportError, ValueError):
+            semantic_ranked = []
+        if semantic_ranked:
+            rankings.append(("semantic", semantic_ranked))
+
+    fused = _reciprocal_rank_fusion(rankings)
+    seeds = []
+    for fused_score, nid, sources, raw_scores in fused[: max(keyword_limit, semantic_limit)]:
+        if not sources:
+            continue
+        if sources == {"keyword", "semantic"}:
+            source = "hybrid"
+        else:
+            source = next(iter(sources))
+        seeds.append({"source": source, "id": nid, "fused_score": fused_score, "raw_scores": raw_scores})
+    return seeds
 
 
 def _bfs(G: nx.Graph, start_nodes: list[str], depth: int) -> tuple[set[str], list[tuple]]:
@@ -195,13 +244,25 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         mode = arguments.get("mode", "bfs")
         depth = min(int(arguments.get("depth", 3)), 6)
         budget = int(arguments.get("token_budget", 2000))
-        terms = [t.lower() for t in question.split() if len(t) > 2]
-        scored = _score_nodes(G, terms)
-        start_nodes = [nid for _, nid in scored[:3]]
+        seeds = _hybrid_seed_nodes(G, graph_path, question)
+        start_nodes = [seed["id"] for seed in seeds]
         if not start_nodes:
             return "No matching nodes found."
         nodes, edges = _dfs(G, start_nodes, depth) if mode == "dfs" else _bfs(G, start_nodes, depth)
-        header = f"Traversal: {mode.upper()} depth={depth} | Start: {[G.nodes[n].get('label', n) for n in start_nodes]} | {len(nodes)} nodes found\n\n"
+        seed_summary = []
+        for seed in seeds:
+            nid = seed["id"]
+            label = G.nodes[nid].get("label", nid)
+            raw_scores = seed["raw_scores"]
+            if seed["source"] == "hybrid":
+                seed_summary.append(
+                    f"{label} (hybrid keyword={raw_scores.get('keyword', 0):.2f} semantic={raw_scores.get('semantic', 0):.2f})"
+                )
+            elif seed["source"] == "semantic":
+                seed_summary.append(f"{label} (semantic {raw_scores.get('semantic', 0):.2f})")
+            else:
+                seed_summary.append(f"{label} (keyword {raw_scores.get('keyword', 0):.2f})")
+        header = f"Traversal: {mode.upper()} depth={depth} | Start: {seed_summary} | {len(nodes)} nodes found\n\n"
         return header + _subgraph_to_text(G, nodes, edges, budget)
 
     def _tool_get_node(arguments: dict) -> str:

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -26,7 +26,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
         from graphify.export import to_json
 
         detected = detect(watch_path, follow_symlinks=follow_symlinks)
-        code_files = [Path(f) for f in detected[FileType.CODE]]
+        code_files = [Path(f) for f in detected["files"][FileType.CODE]]
 
         if not code_files:
             print("[graphify watch] No code files found - nothing to rebuild.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["claude", "claude-code", "codex", "opencode", "knowledge-graph", "ra
 requires-python = ">=3.10"
 dependencies = [
     "networkx",
+    "numpy",
     "tree-sitter>=0.23.0",
     "tree-sitter-python",
     "tree-sitter-javascript",
@@ -47,7 +48,8 @@ pdf = ["pypdf", "html2text"]
 watch = ["watchdog"]
 leiden = ["graspologic"]
 office = ["python-docx", "openpyxl"]
-all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic", "python-docx", "openpyxl"]
+embeddings = ["sentence-transformers"]
+all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic", "python-docx", "openpyxl", "sentence-transformers"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,11 +1,12 @@
 """Tests for graphify/benchmark.py."""
 from __future__ import annotations
 import json
+from unittest.mock import patch
 import pytest
 import networkx as nx
 from networkx.readwrite import json_graph
 
-from graphify.benchmark import run_benchmark, print_benchmark, _query_subgraph_tokens, _SAMPLE_QUESTIONS
+from graphify.benchmark import run_benchmark, print_benchmark, _query_subgraph_tokens, _query_subgraph_tokens_semantic, _SAMPLE_QUESTIONS
 
 
 def _make_graph() -> nx.Graph:
@@ -45,6 +46,19 @@ def test_query_bfs_expands_neighbors():
     tokens_deep = _query_subgraph_tokens(G, "authentication", depth=3)
     tokens_shallow = _query_subgraph_tokens(G, "authentication", depth=1)
     assert tokens_deep >= tokens_shallow
+
+def test_query_semantic_returns_zero_without_index(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    _write_graph(G, graph_file)
+    assert _query_subgraph_tokens_semantic(G, str(graph_file), "xyzzy plugh zorkmid") == 0
+
+def test_query_semantic_reuses_loaded_graph(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    _write_graph(G, graph_file)
+    with patch("graphify.benchmark.Path.read_text", side_effect=AssertionError("graph file should not be re-read")):
+        assert _query_subgraph_tokens_semantic(G, str(graph_file), "authentication") > 0
 
 
 # --- run_benchmark ---

--- a/tests/test_semantic_query.py
+++ b/tests/test_semantic_query.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+
+import networkx as nx
+import numpy as np
+from networkx.readwrite import json_graph
+
+from graphify.export import to_json
+from graphify.semantic import (
+    _get_backend,
+    _graph_hash_for_current_file,
+    build_semantic_index,
+    graph_content_hash,
+    load_semantic_index,
+    semantic_search,
+)
+from graphify.serve import _hybrid_seed_nodes
+
+
+class FakeBackend:
+    def __init__(self, mapping: dict[str, list[float]]):
+        self.mapping = {k: np.asarray(v, dtype=np.float32) for k, v in mapping.items()}
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        return np.vstack([self.mapping[text] for text in texts]).astype(np.float32)
+
+
+def _make_graph() -> nx.Graph:
+    G = nx.Graph()
+    G.add_node("auth", label="Authentication Flow", source_file="auth.py", file_type="code")
+    G.add_node("login", label="Login Handler", source_file="login.py", file_type="code")
+    G.add_node("ui", label="UI Renderer", source_file="ui.py", file_type="code")
+    G.add_edge("auth", "login", relation="calls", confidence="EXTRACTED")
+    return G
+
+
+def test_build_and_load_semantic_index(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+        }
+    )
+    meta = build_semantic_index(graph_file, backend=backend, model_name="fake")
+    index = load_semantic_index(graph_file)
+
+    assert meta["count"] == 3
+    assert index is not None
+    assert len(index.nodes) == 3
+    assert index.embeddings.shape == (3, 2)
+
+
+def test_semantic_search_returns_best_match(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+            "how sign in works": [0.95, 0.05],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake")
+    results = semantic_search(graph_file, "how sign in works", backend=backend, model_name="fake")
+
+    assert results
+    assert results[0]["id"] == "auth"
+
+
+def test_semantic_search_uses_preloaded_index(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+            "how sign in works": [0.95, 0.05],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake")
+    index = load_semantic_index(graph_file)
+
+    assert index is not None
+    results = semantic_search(graph_file, "how sign in works", index=index, backend=backend, model_name="fake")
+    assert results[0]["id"] == "auth"
+
+
+def test_hybrid_seed_nodes_falls_back_to_semantic(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    to_json(G, {0: ["auth", "login"], 1: ["ui"]}, str(graph_file))
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+            "sign in experience": [0.95, 0.05],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake", force=True)
+    import graphify.serve as serve_module
+
+    original = serve_module.semantic_search
+    serve_module.semantic_search = lambda *args, **kwargs: semantic_search(*args, backend=backend, model_name="fake", **kwargs)
+    try:
+        seeds = _hybrid_seed_nodes(G, str(graph_file), "sign in experience")
+    finally:
+        serve_module.semantic_search = original
+
+    assert seeds
+    assert any(seed["source"] == "semantic" and seed["id"] == "auth" for seed in seeds)
+
+
+def test_hybrid_seed_nodes_fuses_keyword_and_semantic(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.8, 0.2],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+            "authentication": [1.0, 0.0],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake", force=True)
+
+    import graphify.serve as serve_module
+
+    original = serve_module.semantic_search
+    serve_module.semantic_search = lambda *args, **kwargs: semantic_search(*args, backend=backend, model_name="fake", **kwargs)
+    try:
+        seeds = _hybrid_seed_nodes(G, str(graph_file), "authentication")
+    finally:
+        serve_module.semantic_search = original
+
+    assert seeds[0]["id"] == "auth"
+    assert seeds[0]["source"] == "hybrid"
+
+
+def test_load_semantic_index_rejects_invalid_meta(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake")
+    meta_file = graph_file.parent / "semantic.meta.json"
+    meta = json.loads(meta_file.read_text(encoding="utf-8"))
+    meta["version"] = 999
+    meta_file.write_text(json.dumps(meta), encoding="utf-8")
+
+    assert load_semantic_index(graph_file) is None
+
+
+def test_graph_content_hash_matches_chunked_read(tmp_path):
+    graph_file = tmp_path / "graph.json"
+    payload = b'{"nodes": [' + (b'"x",' * 10000) + b'0]}'
+    graph_file.write_bytes(payload)
+
+    assert graph_content_hash(graph_file) == __import__("hashlib").sha256(payload).hexdigest()
+
+
+def test_graph_hash_cache_reuses_unchanged_file(tmp_path):
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text('{"nodes":[]}', encoding="utf-8")
+
+    first = _graph_hash_for_current_file(graph_file)
+    second = _graph_hash_for_current_file(graph_file)
+
+    assert first == second
+
+
+def test_semantic_search_reuses_cached_backend(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    data = json_graph.node_link_data(G, edges="links")
+    graph_file.write_text(json.dumps(data), encoding="utf-8")
+
+    backend = FakeBackend(
+        {
+            "Authentication Flow | auth.py | code": [1.0, 0.0],
+            "Login Handler | login.py | code": [0.9, 0.1],
+            "UI Renderer | ui.py | code": [0.0, 1.0],
+            "how sign in works": [0.95, 0.05],
+        }
+    )
+    build_semantic_index(graph_file, backend=backend, model_name="fake")
+    index = load_semantic_index(graph_file)
+
+    class CountingBackend(FakeBackend):
+        init_count = 0
+
+        def __init__(self, model_name: str = "fake"):
+            type(self).init_count += 1
+            super().__init__(
+                {
+                    "Authentication Flow | auth.py | code": [1.0, 0.0],
+                    "Login Handler | login.py | code": [0.9, 0.1],
+                    "UI Renderer | ui.py | code": [0.0, 1.0],
+                    "how sign in works": [0.95, 0.05],
+                }
+            )
+
+    import graphify.semantic as semantic_module
+
+    original_backend = semantic_module.SentenceTransformerBackend
+    _get_backend.cache_clear()
+    semantic_module.SentenceTransformerBackend = CountingBackend
+    try:
+        semantic_search(graph_file, "how sign in works", index=index, model_name="fake")
+        semantic_search(graph_file, "how sign in works", index=index, model_name="fake")
+    finally:
+        semantic_module.SentenceTransformerBackend = original_backend
+        _get_backend.cache_clear()
+
+    assert CountingBackend.init_count == 1

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,5 +1,6 @@
 """Tests for serve.py - MCP graph query helpers (no mcp package required)."""
 import json
+from unittest.mock import patch
 import pytest
 import networkx as nx
 from networkx.readwrite import json_graph
@@ -7,6 +8,7 @@ from networkx.readwrite import json_graph
 from graphify.serve import (
     _communities_from_graph,
     _score_nodes,
+    _hybrid_seed_nodes,
     _bfs,
     _dfs,
     _subgraph_to_text,
@@ -71,6 +73,40 @@ def test_score_nodes_source_file_partial():
     scored = _score_nodes(G, ["cluster"])
     nids = [nid for _, nid in scored]
     assert "n2" in nids
+
+def test_hybrid_seed_nodes_keyword_only(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text(json.dumps(json_graph.node_link_data(G, edges="links")))
+    seeds = _hybrid_seed_nodes(G, str(graph_file), "extract")
+    assert seeds[0]["source"] == "keyword"
+    assert seeds[0]["id"] == "n1"
+
+
+def test_hybrid_seed_nodes_reuses_loaded_index(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text(json.dumps(json_graph.node_link_data(G, edges="links")))
+    fake_index = object()
+    with patch("graphify.serve.load_semantic_index", return_value=fake_index), patch(
+        "graphify.serve.semantic_search",
+        return_value=[{"id": "n1", "score": 0.9}],
+    ) as mock_search:
+        seeds = _hybrid_seed_nodes(G, str(graph_file), "extract")
+    assert seeds
+    assert mock_search.call_args.kwargs["index"] is fake_index
+
+
+def test_hybrid_seed_nodes_only_swallows_expected_semantic_errors(tmp_path):
+    G = _make_graph()
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text(json.dumps(json_graph.node_link_data(G, edges="links")))
+    with patch("graphify.serve.load_semantic_index", return_value=object()), patch(
+        "graphify.serve.semantic_search",
+        side_effect=RuntimeError("unexpected bug"),
+    ):
+        with pytest.raises(RuntimeError):
+            _hybrid_seed_nodes(G, str(graph_file), "extract")
 
 
 # --- _bfs ---


### PR DESCRIPTION
## Summary
- add persisted semantic embeddings and semantic query support for graph retrieval
- use hybrid keyword plus semantic seed selection in serve and benchmark paths
- address PR review feedback by caching semantic backends, caching graph hash validation, and hashing graph files in chunks

## Validation
- python3 -m pytest tests
