### PR TITLE
Fix .graphifyignore discovery to search parent directories

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -250,21 +250,34 @@ def _is_noise_dir(part: str) -> bool:
 
 
 def _load_graphifyignore(root: Path) -> list[str]:
-    """Read .graphifyignore from root and return a list of patterns.
+    """Read .graphifyignore from root **and ancestor directories**, returning patterns.
+
+    Walks upward from *root* towards the filesystem root, collecting patterns
+    from every ``.graphifyignore`` encountered (like ``.gitignore`` discovery).
+    The search stops at the filesystem root or at a ``.git`` directory boundary
+    so it doesn't leak outside the repository.
 
     Lines starting with # are comments. Blank lines are ignored.
     Patterns follow gitignore semantics: glob matched against the path
     relative to root. A leading slash anchors to root. A trailing slash
     matches directories only (we match both dir and file for simplicity).
     """
-    ignore_file = root / ".graphifyignore"
-    if not ignore_file.exists():
-        return []
-    patterns = []
-    for line in ignore_file.read_text(errors="ignore").splitlines():
-        line = line.strip()
-        if line and not line.startswith("#"):
-            patterns.append(line)
+    patterns: list[str] = []
+    current = root.resolve()
+    while True:
+        ignore_file = current / ".graphifyignore"
+        if ignore_file.exists():
+            for line in ignore_file.read_text(errors="ignore").splitlines():
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+        # Stop climbing once we've processed the git repo root
+        if (current / ".git").exists():
+            break
+        parent = current.parent
+        if parent == current:
+            break  # filesystem root
+        current = parent
     return patterns
 
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -138,6 +138,84 @@ def test_detect_follows_symlinked_file(tmp_path):
     assert any("link.py" in f for f in code)
 
 
+def test_graphifyignore_discovered_from_parent(tmp_path):
+    """A .graphifyignore in a parent directory applies to subdirectory scans."""
+    # Parent has .graphifyignore that excludes vendor/
+    (tmp_path / ".graphifyignore").write_text("vendor/\n")
+    sub = tmp_path / "packages" / "mylib"
+    sub.mkdir(parents=True)
+    (sub / "main.py").write_text("x = 1")
+    vendor = sub / "vendor"
+    vendor.mkdir()
+    (vendor / "dep.py").write_text("y = 2")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+    assert any("main.py" in f for f in code_files)
+    assert not any("vendor" in f for f in code_files)
+    assert result["graphifyignore_patterns"] >= 1
+
+
+def test_graphifyignore_merges_parent_and_local(tmp_path):
+    """Patterns from both the local and ancestor .graphifyignore are merged."""
+    # Parent excludes vendor/
+    (tmp_path / ".graphifyignore").write_text("vendor/\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    # Local excludes generated files
+    (sub / ".graphifyignore").write_text("*.generated.py\n")
+    (sub / "main.py").write_text("x = 1")
+    (sub / "schema.generated.py").write_text("y = 2")
+    vendor = sub / "vendor"
+    vendor.mkdir()
+    (vendor / "dep.py").write_text("z = 3")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+    assert any("main.py" in f for f in code_files)
+    assert not any("vendor" in f for f in code_files)
+    assert not any("generated" in f for f in code_files)
+    assert result["graphifyignore_patterns"] == 2
+
+
+def test_graphifyignore_stops_at_git_boundary(tmp_path):
+    """Upward search stops at the git repo root (.git directory)."""
+    # Grandparent has an ignore file (outside the repo)
+    (tmp_path / ".graphifyignore").write_text("main.py\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()  # marks repo root
+    sub = repo / "sub"
+    sub.mkdir()
+    (sub / "main.py").write_text("x = 1")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+    # The grandparent's ignore should NOT apply — it's outside the repo
+    assert any("main.py" in f for f in code_files)
+    assert result["graphifyignore_patterns"] == 0
+
+
+def test_graphifyignore_at_git_root_is_included(tmp_path):
+    """A .graphifyignore at the git repo root is included when scanning a subdir."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".graphifyignore").write_text("vendor/\n")
+    sub = repo / "packages" / "mylib"
+    sub.mkdir(parents=True)
+    (sub / "main.py").write_text("x = 1")
+    vendor = sub / "vendor"
+    vendor.mkdir()
+    (vendor / "dep.py").write_text("y = 2")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+    assert any("main.py" in f for f in code_files)
+    assert not any("vendor" in f for f in code_files)
+    assert result["graphifyignore_patterns"] == 1
+
+
 def test_detect_handles_circular_symlinks(tmp_path):
     sub = tmp_path / "a"
     sub.mkdir()


### PR DESCRIPTION
## Summary
- `.graphifyignore` is now discovered by walking upward from the scan root through parent directories, matching `.gitignore` behavior
- Stops at the git repo boundary (`.git` directory) so patterns don't leak across repositories
- Patterns from all ancestor `.graphifyignore` files are merged with the local one

## Test plan
- [x] Existing `.graphifyignore` tests still pass
- [x] New test: parent's ignore file applies to subdirectory scans
- [x] New test: patterns from local and ancestor files are merged
- [x] New test: upward search stops at `.git` boundary
- [x] New test: ignore file at repo root is included when scanning a subdir

🤖 Generated with [Claude Code](https://claude.com/claude-code)