### PR TITLE
fix(codex): update hooks on reinstall to fix outdated format (#182)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -217,10 +217,13 @@ def _install_gemini_hook(project_dir: Path) -> None:
     except json.JSONDecodeError:
         settings = {}
     before_tool = settings.setdefault("hooks", {}).setdefault("BeforeTool", [])
-    if any("graphify" in str(h) for h in before_tool):
-        print("  .gemini/settings.json  ->  hook already registered (no change)")
-        return
-    before_tool.append(_GEMINI_HOOK)
+
+    # Remove any existing graphify hooks (handles upgrades from old versions)
+    filtered = [h for h in before_tool if "graphify" not in str(h)]
+    settings["hooks"]["BeforeTool"] = filtered
+
+    # Install fresh hook
+    settings["hooks"]["BeforeTool"].append(_GEMINI_HOOK)
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     print("  .gemini/settings.json  ->  BeforeTool hook registered")
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -542,12 +542,12 @@ def _install_claude_hook(project_dir: Path) -> None:
     hooks = settings.setdefault("hooks", {})
     pre_tool = hooks.setdefault("PreToolUse", [])
 
-    # Check if already installed
-    if any(h.get("matcher") == "Glob|Grep" and "graphify" in str(h) for h in pre_tool):
-        print(f"  .claude/settings.json  ->  hook already registered (no change)")
-        return
+    # Remove any existing graphify hooks (handles upgrades from old versions)
+    filtered = [h for h in pre_tool if not (h.get("matcher") == "Glob|Grep" and "graphify" in str(h))]
+    settings["hooks"]["PreToolUse"] = filtered
 
-    pre_tool.append(_SETTINGS_HOOK)
+    # Install fresh hook
+    settings["hooks"]["PreToolUse"].append(_SETTINGS_HOOK)
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     print(f"  .claude/settings.json  ->  PreToolUse hook registered")
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -417,11 +417,13 @@ def _install_codex_hook(project_dir: Path) -> None:
         existing = {}
 
     pre_tool = existing.setdefault("hooks", {}).setdefault("PreToolUse", [])
-    if any("graphify" in str(h) for h in pre_tool):
-        print(f"  .codex/hooks.json  ->  hook already registered (no change)")
-        return
 
-    pre_tool.extend(_CODEX_HOOK["hooks"]["PreToolUse"])
+    # Remove any existing graphify hooks (handles upgrades from old versions)
+    filtered = [h for h in pre_tool if "graphify" not in str(h)]
+    existing["hooks"]["PreToolUse"] = filtered
+
+    # Install fresh hook with correct format
+    existing["hooks"]["PreToolUse"].extend(_CODEX_HOOK["hooks"]["PreToolUse"])
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook registered")
 


### PR DESCRIPTION
## Problem Statement

Users running **codex-cli 0.118.0** with **graphify 0.3.27** encounter the following error when upgrading from older graphify versions:

```
PreToolUse hook (failed)
  error: PreToolUse hook returned unsupported additionalContext
```

### Root Cause

The hook installation functions (`_install_codex_hook()`, `_install_claude_hook()`, `_install_gemini_hook()`) contain early-exit checks that prevent updating existing hooks:

```python
if any("graphify" in str(h) for h in pre_tool):
    print(f"  hook already registered (no change)")
    return  # ❌ Prevents updates
```

**Impact:** When users upgrade from graphify 0.3.17 or earlier (which used `additionalContext`) to 0.3.27 (which uses `systemMessage`), the install command detects an existing hook and exits without updating it, leaving the old broken hook in place.

## Solution Approach

### Considered Approaches

1. **Always Remove and Reinstall (Selected)** ✅
   - Remove all existing graphify hooks before installing
   - Install fresh hook with correct format every time
   - Simple, guarantees correctness, future-proof

2. **Detect and Update Only If Wrong**
   - Check if existing hook has correct format
   - Only update if format is wrong
   - More complex, harder to maintain as format evolves

3. **Version-Based Migration**
   - Store hook version in the hook itself
   - Migrate based on version number
   - Overkill for current problem, adds unnecessary complexity

**Selected Approach 1** because it:
- Is the simplest implementation (minimal code)
- Guarantees correctness every time
- Matches the pattern already used in `_uninstall_*` functions
- Is consistent with the fix from issue #153
- Handles any future format changes automatically

### Implementation

Replace the early-exit check with a remove-then-install pattern in all three functions:

**Before (broken):**
```python
if any("graphify" in str(h) for h in pre_tool):
    print(f"  hook already registered (no change)")
    return
```

**After (fixed):**
```python
# Remove any existing graphify hooks (handles upgrades from old versions)
filtered = [h for h in pre_tool if "graphify" not in str(h)]
existing["hooks"]["PreToolUse"] = filtered

# Install fresh hook with correct format
existing["hooks"]["PreToolUse"].extend(_CODEX_HOOK["hooks"]["PreToolUse"])
```

## Changes Made

### Modified Functions

1. **`_install_codex_hook()`** (graphify/__main__.py)
   - Removes early-exit check at lines 458-460
   - Implements remove-then-install pattern
   - Ensures `.codex/hooks.json` always has correct format

2. **`_install_claude_hook()`** (graphify/__main__.py)
   - Removes early-exit check at lines 580-582
   - Implements remove-then-install pattern
   - Ensures `.claude/settings.json` always has correct format

3. **`_install_gemini_hook()`** (graphify/__main__.py)
   - Removes early-exit check at lines 243-245
   - Implements remove-then-install pattern
   - Ensures `.gemini/settings.json` always has correct format

### Key Benefits

- **Idempotent:** Running install multiple times produces the same result
- **Upgrade-safe:** Automatically replaces outdated hooks with correct format
- **Non-destructive:** Preserves non-graphify hooks in the same file
- **Backwards compatible:** Works for both fresh installs and upgrades

## Testing

All test scenarios passed:

### 1. Fresh Install ✅
- **Test:** Install hook in empty `.codex/hooks.json`
- **Result:** Hook created with correct `systemMessage` format
- **Verification:** No `additionalContext` present

### 2. Upgrade Scenario ✅ (Critical)
- **Test:** Install over old hook format (using `additionalContext`)
- **Result:** Old hook completely replaced with new format (using `systemMessage`)
- **Verification:** `additionalContext` removed, `systemMessage` present

### 3. Idempotency ✅
- **Test:** Run install twice consecutively
- **Result:** Exactly 1 graphify hook exists (no duplicates)
- **Verification:** Hook count = 1

### 4. Hook Preservation ✅
- **Test:** Install with existing non-graphify hook present
- **Result:** Non-graphify hook preserved, graphify hook added
- **Verification:** Both hooks coexist (total count = 2)

### 5. Syntax Validation ✅
- **Test:** `python -m py_compile graphify/__main__.py`
- **Result:** No errors

## Expected Outcomes

### Immediate Benefits

1. **Issue #182 Resolved:** Users can upgrade without encountering "unsupported additionalContext" error
2. **No Manual Intervention:** Users no longer need to manually edit `.codex/hooks.json`
3. **Consistent Behavior:** All three platform install functions now use the same pattern
4. **Reduced Support Burden:** Fewer upgrade-related issues reported

### Long-Term Benefits

1. **Future-Proof:** Any future hook format changes will automatically propagate to users
2. **Maintainability:** Simpler code is easier to understand and modify
3. **Reliability:** Remove-then-install pattern is a proven approach for idempotent operations
4. **Consistency:** Matches the pattern established in issue #153 fix

## Future Improvements

### Potential Enhancements

1. **Hook Version Tracking (Optional)**
   - Add version metadata to hook output for debugging
   - Would help identify which graphify version installed the hook
   - Not critical but could aid troubleshooting

2. **Migration Logging (Optional)**
   - Log when old hooks are replaced during upgrade
   - Could help users understand what changed
   - Example: "Updated hook from v0.3.17 format to v0.3.27 format"

3. **Validation on Install (Optional)**
   - Verify hook format after installation
   - Catch any JSON serialization issues immediately
   - Would add robustness but increases complexity

4. **Unified Install Function (Refactoring)**
   - Extract common pattern into shared helper function
   - Reduce code duplication across three install functions
   - Would improve maintainability but requires larger refactor

### Recommended Next Steps

1. **Monitor Issue #182:** Verify no further reports after this fix
2. **Consider Backport:** Evaluate if fix should be backported to older versions
3. **Documentation Update:** Update upgrade guide to mention automatic hook updates
4. **Release Notes:** Highlight this fix in next release notes

## Commits

- `b3777a2` fix(codex): remove early-exit check in _install_codex_hook
- `007298c` fix(claude): remove early-exit check in _install_claude_hook
- `00a9ca7` fix(gemini): remove early-exit check in _install_gemini_hook

## Related Issues

- Fixes #182 - codex hook failed with "unsupported additionalContext"
- Related to #153 - Fixed `_agents_install()` to not return early (same pattern)
- Related to #138 - Fixed hook format to use `systemMessage` at top level
- Related to #121 - Changed from `additionalContext` to `systemMessage`

Closes #182
