### PR TITLE
feat: add --mode prose for non-code corpus extraction

### DIFF
--- a/graphify/__init__.py
+++ b/graphify/__init__.py
@@ -19,6 +19,7 @@ def __getattr__(name):
         "to_svg": ("graphify.export", "to_svg"),
         "to_canvas": ("graphify.export", "to_canvas"),
         "to_wiki": ("graphify.wiki", "to_wiki"),
+        "extract_prose": ("graphify.extract_prose", "extract_prose"),
     }
     if name in _map:
         import importlib

--- a/graphify/extract_prose.py
+++ b/graphify/extract_prose.py
@@ -1,0 +1,269 @@
+"""Deterministic structural extraction from prose documents. Outputs nodes+edges dicts.
+
+Unlike extract.py (which uses tree-sitter AST parsing for code files), this module
+handles non-code corpora: markdown, plain text, reStructuredText, Jupyter notebooks,
+PDF, and DOCX files. It parses document structure (headings, sections, paragraphs)
+deterministically and builds a structural graph without any LLM calls.
+
+The LLM-based semantic extraction for prose mode happens in skill.md subagent prompts,
+not here. This module provides the structural backbone that semantic extraction builds on.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+# ── ID normalization ─────────────────────────────────────────────────────────
+
+def _make_id(*parts: str) -> str:
+    """Build a stable node ID from one or more name parts.
+
+    Normalizes to snake_case for cross-file deduplication: "Gradient Descent"
+    in file A and "gradient descent" in file B both map to "gradient_descent".
+    """
+    combined = "_".join(p.strip("_.") for p in parts if p)
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "_", combined)
+    return cleaned.strip("_").lower()
+
+
+# ── File type detection ──────────────────────────────────────────────────────
+
+_PROSE_EXTENSIONS = {".md", ".txt", ".rst", ".ipynb", ".pdf", ".docx"}
+
+
+def _classify_file_type(path: Path) -> str:
+    """Return the file_type string for a prose file."""
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return "paper"
+    return "document"
+
+
+# ── Document readers ─────────────────────────────────────────────────────────
+
+def _read_markdown(path: Path) -> str:
+    """Read a markdown file, stripping YAML frontmatter."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Strip YAML frontmatter
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3:]
+    return text
+
+
+def _read_plain_text(path: Path) -> str:
+    """Read a plain text or rst file."""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _read_ipynb(path: Path) -> str:
+    """Read a Jupyter notebook, extracting markdown and code cell sources."""
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        nb = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+    parts: list[str] = []
+    for cell in nb.get("cells", []):
+        cell_type = cell.get("cell_type", "")
+        source = "".join(cell.get("source", []))
+        if cell_type == "markdown":
+            parts.append(source)
+        elif cell_type == "code":
+            parts.append(f"```\n{source}\n```")
+    return "\n\n".join(parts)
+
+
+def _read_file(path: Path) -> str:
+    """Read a prose file and return its text content.
+
+    Supports: .md, .txt, .rst, .ipynb
+    For .pdf and .docx, returns empty string (these require external libraries
+    and are handled by the LLM subagent via vision or tool use).
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".md":
+        return _read_markdown(path)
+    if suffix == ".ipynb":
+        return _read_ipynb(path)
+    if suffix in (".txt", ".rst"):
+        return _read_plain_text(path)
+    # PDF and DOCX: structural parsing not possible without external deps.
+    # The LLM subagent handles these via vision/tool use.
+    return ""
+
+
+# ── Structural parsing ───────────────────────────────────────────────────────
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+_RST_HEADING_RE = re.compile(
+    r"^(.+)\n([=\-~^\"\'`]+)$", re.MULTILINE
+)
+
+# RST underline chars ordered by conventional nesting depth
+_RST_LEVELS = {"=": 1, "-": 2, "~": 3, "^": 4, '"': 5, "'": 5, "`": 5}
+
+
+def _extract_headings_md(text: str) -> list[tuple[int, str]]:
+    """Extract (level, title) pairs from markdown headings."""
+    results: list[tuple[int, str]] = []
+    for match in _HEADING_RE.finditer(text):
+        level = len(match.group(1))
+        title = match.group(2).strip()
+        if title:
+            results.append((level, title))
+    return results
+
+
+def _extract_headings_rst(text: str) -> list[tuple[int, str]]:
+    """Extract (level, title) pairs from reStructuredText headings."""
+    results: list[tuple[int, str]] = []
+    for match in _RST_HEADING_RE.finditer(text):
+        title = match.group(1).strip()
+        underline_char = match.group(2)[0]
+        level = _RST_LEVELS.get(underline_char, 3)
+        if title and len(match.group(2)) >= len(title):
+            results.append((level, title))
+    return results
+
+
+def _extract_headings(text: str, suffix: str) -> list[tuple[int, str]]:
+    """Extract headings from document text based on file type."""
+    if suffix == ".rst":
+        return _extract_headings_rst(text)
+    # Default to markdown-style headings (works for .md, .txt, .ipynb)
+    return _extract_headings_md(text)
+
+
+# ── Structural graph builder ─────────────────────────────────────────────────
+
+def _build_file_node(path: Path, file_type: str) -> dict[str, Any]:
+    """Create a node representing the file itself."""
+    stem = path.stem
+    return {
+        "id": _make_id(stem),
+        "label": stem,
+        "file_type": file_type,
+        "source_file": str(path),
+    }
+
+
+def _build_section_nodes(
+    headings: list[tuple[int, str]],
+    path: Path,
+    file_type: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Build nodes for each heading/section and 'contains' edges from parent sections.
+
+    Returns (nodes, edges).
+    """
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    str_path = str(path)
+    file_id = _make_id(path.stem)
+
+    # Stack tracks (level, node_id) for parent resolution
+    stack: list[tuple[int, str]] = [(0, file_id)]
+
+    for level, title in headings:
+        node_id = _make_id(title)
+        node = {
+            "id": node_id,
+            "label": title,
+            "file_type": file_type,
+            "source_file": str_path,
+        }
+        nodes.append(node)
+
+        # Pop stack until we find a parent at a higher level
+        while len(stack) > 1 and stack[-1][0] >= level:
+            stack.pop()
+
+        parent_id = stack[-1][1]
+        # Skip self-referencing edges (e.g., file "ARCHITECTURE" contains heading "Architecture")
+        if parent_id != node_id:
+            edges.append({
+                "source": parent_id,
+                "target": node_id,
+                "relation": "contains",
+                "confidence": "EXTRACTED",
+                "confidence_score": 1.0,
+                "source_file": str_path,
+            })
+
+        stack.append((level, node_id))
+
+    return nodes, edges
+
+
+# ── Main extraction function ─────────────────────────────────────────────────
+
+def extract_prose(paths: list[Path]) -> dict[str, Any]:
+    """Extract structural nodes and edges from a list of prose files.
+
+    Parses document structure (headings, sections) deterministically and builds
+    a structural graph. Does NOT use tree-sitter or LLM calls.
+
+    Each node has: id (snake_case), label, source_file, file_type.
+    Each edge has: source, target, relation, confidence, confidence_score, source_file.
+
+    Cross-file deduplication: concept names are normalized to snake_case, so
+    "Gradient Descent" in file A and "gradient descent" in file B both map to
+    node id "gradient_descent".
+
+    Args:
+        paths: List of file paths to extract from. Supported extensions:
+               .md, .txt, .rst, .ipynb, .pdf, .docx
+
+    Returns:
+        Dict matching the graphify extraction schema:
+        {nodes: [...], edges: [...], input_tokens: 0, output_tokens: 0}
+    """
+    all_nodes: list[dict[str, Any]] = []
+    all_edges: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for path in paths:
+        if not path.exists():
+            continue
+
+        suffix = path.suffix.lower()
+        if suffix not in _PROSE_EXTENSIONS:
+            continue
+
+        file_type = _classify_file_type(path)
+
+        # File-level node
+        file_node = _build_file_node(path, file_type)
+        if file_node["id"] not in seen_ids:
+            all_nodes.append(file_node)
+            seen_ids.add(file_node["id"])
+
+        # Read content and extract structure
+        text = _read_file(path)
+        if not text:
+            continue
+
+        headings = _extract_headings(text, suffix)
+        section_nodes, section_edges = _build_section_nodes(
+            headings, path, file_type,
+        )
+
+        for node in section_nodes:
+            if node["id"] not in seen_ids:
+                all_nodes.append(node)
+                seen_ids.add(node["id"])
+
+        all_edges.extend(section_edges)
+
+    return {
+        "nodes": all_nodes,
+        "edges": all_edges,
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -14,6 +14,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify                                             # full pipeline on current directory → Obsidian vault
 /graphify <path>                                      # full pipeline on specific path
 /graphify <path> --mode deep                          # thorough extraction, richer INFERRED edges
+/graphify <path> --mode prose                         # non-code corpus: skip AST, per-file LLM extraction
 /graphify <path> --update                             # incremental - re-extract only new/changed files
 /graphify <path> --cluster-only                       # rerun clustering on existing graph
 /graphify <path> --no-viz                             # skip visualization, just report + JSON
@@ -106,7 +107,9 @@ Then act on it:
 
 ### Step 3 - Extract entities and relationships
 
-**Before starting:** note whether `--mode deep` was given. You must pass `DEEP_MODE=true` to every subagent in Step B2 if it was. Track this from the original invocation - do not lose it.
+**Before starting:** note whether `--mode deep` or `--mode prose` was given. You must pass `DEEP_MODE=true` to every subagent in Step B2 if deep mode was given. Track this from the original invocation - do not lose it.
+
+**If `--mode prose` was given, skip to [Part P - Prose extraction](#part-p---prose-extraction-mode-prose-only) below.** Prose mode bypasses AST extraction entirely and uses direct per-file LLM extraction with a structured schema.
 
 This step has two parts: **structural extraction** (deterministic, free) and **semantic extraction** (Claude, costs tokens).
 
@@ -333,6 +336,128 @@ edges = len(merged_edges)
 print(f'Merged: {total} nodes, {edges} edges ({len(ast[\"nodes\"])} AST + {len(sem[\"nodes\"])} semantic)')
 "
 ```
+
+#### Part P - Prose extraction (--mode prose only)
+
+**This section replaces Parts A, B, and C when `--mode prose` is given.** It bypasses AST extraction entirely - there is no tree-sitter pass. Instead, it runs deterministic structural parsing followed by LLM-based concept extraction.
+
+**Step P1 - Structural extraction from prose files**
+
+```bash
+$(cat .graphify_python) -c "
+import sys, json
+from graphify.extract_prose import extract_prose
+from pathlib import Path
+
+detect = json.loads(Path('.graphify_detect.json').read_text())
+all_files = []
+for category in detect.get('files', {}).values():
+    all_files.extend(Path(f) for f in category)
+
+result = extract_prose(all_files)
+Path('.graphify_prose_structure.json').write_text(json.dumps(result, indent=2))
+print(f'Prose structure: {len(result[\"nodes\"])} nodes, {len(result[\"edges\"])} edges')
+"
+```
+
+**Step P2 - Semantic extraction via subagents**
+
+Check the extraction cache first (same as Step B0), then dispatch subagents for uncached files. The subagent prompt is different from the standard one - it is optimized for prose corpora.
+
+Run cache check:
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.cache import check_semantic_cache
+from pathlib import Path
+
+detect = json.loads(Path('.graphify_detect.json').read_text())
+all_files = [f for files in detect['files'].values() for f in files]
+
+cached_nodes, cached_edges, cached_hyperedges, uncached = check_semantic_cache(all_files)
+
+if cached_nodes or cached_edges or cached_hyperedges:
+    Path('.graphify_cached.json').write_text(json.dumps({'nodes': cached_nodes, 'edges': cached_edges, 'hyperedges': cached_hyperedges}))
+Path('.graphify_uncached.txt').write_text('\n'.join(uncached))
+print(f'Cache: {len(all_files)-len(uncached)} files hit, {len(uncached)} files need extraction')
+"
+```
+
+Split uncached files into chunks of 20-25. Dispatch ALL subagents in a single message (same parallel rules as Step B2). Each subagent receives this prose-specific prompt:
+
+```
+You are a graphify prose extraction subagent. Read the files listed and extract a knowledge graph fragment optimized for non-code corpora (academic papers, research notes, prose documents).
+
+Output ONLY valid JSON matching the schema below - no explanation, no markdown fences, no preamble.
+
+Files (chunk CHUNK_NUM of TOTAL_CHUNKS):
+FILE_LIST
+
+Extraction rules for prose:
+- Extract key concepts, named entities, topics, methodologies, theorems, and definitions as nodes.
+- Every node MUST have: id (snake_case), label (human readable), source_file, file_type ("document" or "paper").
+- Node IDs use snake_case normalization for cross-file deduplication: "Gradient Descent" becomes "gradient_descent".
+- Extract typed directional edges between concepts. Use these relation types:
+  references, builds_on, applies, derives_from, contrasts_with, exemplifies, contains, prerequisite_for,
+  cites, conceptually_related_to, semantically_similar_to, rationale_for
+- Every edge MUST have: source, target, relation, confidence, confidence_score, source_file.
+- EXTRACTED: relationship explicit in source (citation, "see section X", "based on Y", direct reference)
+- INFERRED: reasonable inference (concepts co-occur in same section, shared terminology, implied dependency)
+- AMBIGUOUS: uncertain - flag for review, do not omit
+- confidence_score is REQUIRED on every edge:
+  EXTRACTED: 1.0 always. INFERRED: 0.6-0.9. AMBIGUOUS: 0.1-0.3.
+- Extract rationale: sections that explain WHY a decision was made or trade-offs chosen become nodes with rationale_for edges.
+- Do NOT attempt code-style extraction (no imports, no function calls, no class hierarchies).
+
+If a file has YAML frontmatter (--- ... ---), copy source_url, captured_at, author, contributor onto every node from that file.
+
+Hyperedges: if 3+ nodes participate in a shared concept or flow not captured by pairwise edges, add a hyperedge. Maximum 3 per chunk.
+
+Output exactly this JSON (no other text):
+{"nodes":[{"id":"snake_case_concept","label":"Human Readable Name","file_type":"document|paper","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"references|builds_on|applies|derives_from|contrasts_with|exemplifies|contains|prerequisite_for|cites|conceptually_related_to|semantically_similar_to|rationale_for","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
+```
+
+**Step P3 - Merge structural + semantic results**
+
+Collect subagent results, cache them (same as Step B3), then merge the structural graph with semantic extractions:
+
+```bash
+$(cat .graphify_python) -c "
+import sys, json
+from pathlib import Path
+
+structure = json.loads(Path('.graphify_prose_structure.json').read_text())
+cached = json.loads(Path('.graphify_cached.json').read_text()) if Path('.graphify_cached.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
+new = json.loads(Path('.graphify_semantic_new.json').read_text()) if Path('.graphify_semantic_new.json').exists() else {'nodes':[],'edges':[],'hyperedges':[]}
+
+# Merge: structural nodes first, then semantic (cached + new), deduplicated by id
+seen = set()
+merged_nodes = []
+for n in structure['nodes'] + cached['nodes'] + new.get('nodes', []):
+    if n['id'] not in seen:
+        merged_nodes.append(n)
+        seen.add(n['id'])
+
+merged_edges = structure['edges'] + cached['edges'] + new.get('edges', [])
+merged_hyperedges = cached.get('hyperedges', []) + new.get('hyperedges', [])
+
+merged = {
+    'nodes': merged_nodes,
+    'edges': merged_edges,
+    'hyperedges': merged_hyperedges,
+    'input_tokens': new.get('input_tokens', 0),
+    'output_tokens': new.get('output_tokens', 0),
+}
+Path('.graphify_extract.json').write_text(json.dumps(merged, indent=2))
+print(f'Prose extraction complete: {len(merged_nodes)} nodes, {len(merged_edges)} edges')
+print(f'  structural: {len(structure[\"nodes\"])} nodes, {len(structure[\"edges\"])} edges')
+print(f'  semantic:   {len(cached[\"nodes\"]) + len(new.get(\"nodes\",[]))} nodes (cached + new)')
+"
+```
+
+Clean up temp files: `rm -f .graphify_cached.json .graphify_uncached.txt .graphify_semantic_new.json .graphify_prose_structure.json`
+
+After Part P completes, proceed directly to Step 4 (the `.graphify_extract.json` file is ready).
 
 ### Step 4 - Build graph, cluster, analyze, generate outputs
 


### PR DESCRIPTION
## Summary

Adds a `--mode prose` flag that bypasses tree-sitter AST parsing for non-code corpora (academic notebooks, prose documents, research papers).

**Problem:** When graphify runs on non-code content, the AST pass produces noise and the semantic pass creates unsourced, unconnected nodes. Tested on an 8-course NYU Courant portfolio: the standard pipeline produced 216 nodes / 216 edges with broken connectivity.

**Solution:**
- New `extract_prose.py` module: deterministic structural parsing of headings/sections for `.md`, `.txt`, `.rst`, `.ipynb` files. Builds a structural graph backbone with file and section nodes connected by `contains` edges. Uses snake_case ID normalization for cross-file concept deduplication.
- Modified `skill.md`: adds `--mode prose` flag detection and a new Part P extraction path. Subagents get a prose-optimized prompt that extracts concepts, entities, and typed directional edges (`references`, `builds_on`, `applies`, `derives_from`, `contrasts_with`, `exemplifies`, `prerequisite_for`).
- No changes to downstream pipeline (build, cluster, analyze, export, report) — they operate on the standard node/edge schema.

## Files changed

- `graphify/extract_prose.py` (new, 269 lines) — prose extraction module
- `graphify/skill.md` (+127 lines) — `--mode prose` flag + Part P extraction path
- `graphify/__init__.py` (+1 line) — lazy import registration

## Test plan

- [x] Module imports cleanly: `from graphify.extract_prose import extract_prose`
- [x] Passes `validate_extraction()` schema validation
- [ ] End-to-end test on prose corpus with `/graphify . --mode prose`
- [ ] Verify graph output matches expected node/edge counts

Co-Authored-By: Claude <noreply@anthropic.com>