### PR TITLE
feat: Add Haskell language support (.hs, .lhs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ graphify-out/
 .graphify_*.json
 .graphify_python
 .claude/
+CLAUDE.md
 skills/
 docs/superpowers/
 .vscode/

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -17,7 +17,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.hs', '.lhs'}
 DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1363,6 +1363,253 @@ def extract_julia(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+# ── Haskell extractor (custom walk) ──────────────────────────────────────────
+
+def _preprocess_lhs(source: bytes) -> bytes:
+    """Convert literate Haskell (.lhs) to plain Haskell, preserving line numbers."""
+    lines = source.decode("utf-8", errors="replace").splitlines()
+    code_lines: list[str] = []
+    in_code_block = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "\\begin{code}":
+            in_code_block = True
+            code_lines.append("")
+        elif stripped == "\\end{code}":
+            in_code_block = False
+            code_lines.append("")
+        elif in_code_block:
+            code_lines.append(line)
+        elif line.startswith("> "):
+            code_lines.append(line[2:])
+        elif line == ">":
+            code_lines.append("")
+        else:
+            code_lines.append("")
+    return "\n".join(code_lines).encode("utf-8")
+
+
+def extract_haskell(path: Path) -> dict:
+    """Extract modules, types, classes, functions, imports, and calls from a .hs/.lhs file."""
+    try:
+        import tree_sitter_haskell as tshaskell
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return {"nodes": [], "edges": [], "error": "tree-sitter-haskell not installed"}
+
+    try:
+        language = Language(tshaskell.language())
+        parser = Parser(language)
+        source = path.read_bytes()
+        if path.suffix == ".lhs":
+            source = _preprocess_lhs(source)
+        tree = parser.parse(source)
+        root = tree.root_node
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    stem = path.stem
+    str_path = str(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+    function_bodies: list[tuple[str, object]] = []
+    seen_functions: set[str] = set()
+
+    def add_node(nid: str, label: str, line: int) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({
+                "id": nid,
+                "label": label,
+                "file_type": "code",
+                "source_file": str_path,
+                "source_location": f"L{line}",
+            })
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 confidence: str = "EXTRACTED", weight: float = 1.0) -> None:
+        edges.append({
+            "source": src,
+            "target": tgt,
+            "relation": relation,
+            "confidence": confidence,
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": weight,
+        })
+
+    file_nid = _make_id(stem)
+    add_node(file_nid, path.name, 1)
+
+    module_nid = file_nid
+
+    def walk(node, scope_nid: str) -> None:
+        nonlocal module_nid
+        t = node.type
+
+        # Module header: haskell > header > module (keyword) + module (name node)
+        if t == "header":
+            for child in node.children:
+                if child.type == "module" and child.child_count > 0:
+                    mod_name = _read_text(child, source).strip()
+                    mod_nid = _make_id(stem, mod_name)
+                    line = child.start_point[0] + 1
+                    add_node(mod_nid, mod_name, line)
+                    add_edge(file_nid, mod_nid, "contains", line)
+                    module_nid = mod_nid
+            return
+
+        # Import declarations
+        if t == "import":
+            line = node.start_point[0] + 1
+            for child in node.children:
+                if child.type == "module" and child.child_count > 0:
+                    mod_name = _read_text(child, source).strip()
+                    imp_nid = _make_id(mod_name)
+                    add_node(imp_nid, mod_name, line)
+                    add_edge(module_nid, imp_nid, "imports", line)
+                    break
+            return
+
+        # data Type = Constructor1 | Constructor2
+        if t == "data_type":
+            line = node.start_point[0] + 1
+            name_node = next((c for c in node.children if c.type == "name"), None)
+            if name_node:
+                type_name = _read_text(name_node, source).strip()
+                type_nid = _make_id(stem, type_name)
+                add_node(type_nid, type_name, line)
+                add_edge(module_nid, type_nid, "contains", line)
+                cons_node = next((c for c in node.children if c.type == "data_constructors"), None)
+                if cons_node:
+                    for dc in cons_node.children:
+                        if dc.type == "data_constructor":
+                            for prefix in dc.children:
+                                if prefix.type == "prefix":
+                                    cn = next((c for c in prefix.children if c.type == "constructor"), None)
+                                    if cn:
+                                        con_name = _read_text(cn, source).strip()
+                                        con_nid = _make_id(stem, type_name, con_name)
+                                        add_node(con_nid, con_name, dc.start_point[0] + 1)
+                                        add_edge(type_nid, con_nid, "contains", dc.start_point[0] + 1)
+            return
+
+        # newtype Wrapper a = Wrapper a
+        if t == "newtype":
+            line = node.start_point[0] + 1
+            name_node = next((c for c in node.children if c.type == "name"), None)
+            if name_node:
+                type_name = _read_text(name_node, source).strip()
+                type_nid = _make_id(stem, type_name)
+                add_node(type_nid, type_name, line)
+                add_edge(module_nid, type_nid, "contains", line)
+            return
+
+        # type Name = String (tree-sitter-haskell spells it "type_synomym")
+        if t == "type_synomym":
+            line = node.start_point[0] + 1
+            name_node = next((c for c in node.children if c.type == "name"), None)
+            if name_node:
+                type_name = _read_text(name_node, source).strip()
+                type_nid = _make_id(stem, type_name)
+                add_node(type_nid, type_name, line)
+                add_edge(module_nid, type_nid, "contains", line)
+            return
+
+        # class Describable a where
+        if t == "class":
+            line = node.start_point[0] + 1
+            name_node = next((c for c in node.children if c.type == "name"), None)
+            if name_node:
+                class_name = _read_text(name_node, source).strip()
+                class_nid = _make_id(stem, class_name)
+                add_node(class_nid, class_name, line)
+                add_edge(module_nid, class_nid, "contains", line)
+            return
+
+        # instance Describable Shape where
+        if t == "instance":
+            line = node.start_point[0] + 1
+            class_name_node = next((c for c in node.children if c.type == "name"), None)
+            type_patterns = next((c for c in node.children if c.type == "type_patterns"), None)
+            if class_name_node and type_patterns:
+                class_name = _read_text(class_name_node, source).strip()
+                type_name_node = next((c for c in type_patterns.children if c.type == "name"), None)
+                if type_name_node:
+                    type_name = _read_text(type_name_node, source).strip()
+                    type_nid = _make_id(stem, type_name)
+                    class_nid = _make_id(stem, class_name)
+                    add_edge(type_nid, class_nid, "inherits", line)
+            return
+
+        # Standalone type signatures — skip (functions cover these)
+        if t == "signature":
+            return
+
+        # Function equation: function > variable (name) + patterns + match(es) + local_binds
+        if t == "function":
+            line = node.start_point[0] + 1
+            name_node = next((c for c in node.children if c.type == "variable"), None)
+            if name_node:
+                func_name = _read_text(name_node, source).strip()
+                func_nid = _make_id(stem, func_name)
+                if func_name not in seen_functions:
+                    seen_functions.add(func_name)
+                    add_node(func_nid, f"{func_name}()", line)
+                    add_edge(module_nid, func_nid, "contains", line)
+                for child in node.children:
+                    if child.type in ("match", "local_binds"):
+                        function_bodies.append((func_nid, child))
+            return
+
+        for child in node.children:
+            walk(child, scope_nid)
+
+    walk(root, file_nid)
+
+    # Call resolution
+    label_to_nid: dict[str, str] = {}
+    for n in nodes:
+        raw = n["label"]
+        normalised = raw.strip("()").lstrip(".")
+        label_to_nid[normalised.lower()] = n["id"]
+
+    seen_call_pairs: set[tuple[str, str]] = set()
+
+    def _get_callee_name(apply_node) -> str | None:
+        """Extract callee name from an apply node (leftmost variable leaf)."""
+        if not apply_node.children:
+            return None
+        first = apply_node.children[0]
+        if first.type == "variable":
+            return _read_text(first, source).strip()
+        if first.type == "apply":
+            return _get_callee_name(first)
+        return None
+
+    def walk_calls(node, caller_nid: str) -> None:
+        if node.type == "function":
+            return
+        if node.type == "apply":
+            callee_name = _get_callee_name(node)
+            if callee_name:
+                tgt_nid = label_to_nid.get(callee_name.lower())
+                if tgt_nid and tgt_nid != caller_nid:
+                    pair = (caller_nid, tgt_nid)
+                    if pair not in seen_call_pairs:
+                        seen_call_pairs.add(pair)
+                        add_edge(caller_nid, tgt_nid, "calls",
+                                 node.start_point[0] + 1, confidence="INFERRED")
+        for child in node.children:
+            walk_calls(child, caller_nid)
+
+    for caller_nid, body_node in function_bodies:
+        walk_calls(body_node, caller_nid)
+
+    return {"nodes": nodes, "edges": edges}
+
+
 # ── Go extractor (custom walk) ────────────────────────────────────────────────
 
 def extract_go(path: Path) -> dict:
@@ -2622,6 +2869,8 @@ def extract(paths: list[Path]) -> dict:
         ".m": extract_objc,
         ".mm": extract_objc,
         ".jl": extract_julia,
+        ".hs": extract_haskell,
+        ".lhs": extract_haskell,
     }
 
     total = len(paths)
@@ -2676,6 +2925,8 @@ def collect_files(target: Path, *, follow_symlinks: bool = False) -> list[Path]:
         ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
         ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
         ".lua", ".toc", ".zig", ".ps1",
+        ".ex", ".exs", ".jl",
+        ".hs", ".lhs",
         ".m", ".mm",
     }
     if not follow_symlinks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tree-sitter-elixir",
     "tree-sitter-objc",
     "tree-sitter-julia",
+    "tree-sitter-haskell",
 ]
 
 [project.urls]

--- a/tests/fixtures/sample.hs
+++ b/tests/fixtures/sample.hs
@@ -1,0 +1,51 @@
+module Sample where
+
+import Data.List
+import qualified Data.Map as Map
+
+-- Algebraic data type with constructors
+data Shape
+  = Circle Double
+  | Rectangle Double Double
+
+-- Newtype wrapper
+newtype Wrapper a = Wrapper a
+
+-- Type alias
+type Name = String
+
+-- Type class
+class Describable a where
+  describe :: a -> String
+
+-- Instance
+instance Describable Shape where
+  describe (Circle r) = "Circle with radius " ++ show r
+  describe (Rectangle w h) = "Rectangle " ++ show w ++ "x" ++ show h
+
+-- Function with type signature
+area :: Shape -> Double
+area (Circle r) = pi * r * r
+area (Rectangle w h) = w * h
+
+-- Function that calls other functions
+perimeter :: Shape -> Double
+perimeter (Circle r) = 2.0 * pi * r
+perimeter (Rectangle w h) = 2.0 * (w + h)
+
+-- Function using guards
+classify :: Shape -> String
+classify shape
+  | a > 100   = "large"
+  | a > 10    = "medium"
+  | otherwise = "small"
+  where
+    a = area shape
+
+-- Function calling multiple others
+summarize :: Shape -> String
+summarize shape = describe shape ++ " area=" ++ show (area shape)
+
+-- Simple helper
+double :: Double -> Double
+double x = x * 2

--- a/tests/fixtures/sample.lhs
+++ b/tests/fixtures/sample.lhs
@@ -1,0 +1,6 @@
+This is a literate Haskell file using bird tracks.
+
+> module SampleLhs where
+
+> greet :: String -> String
+> greet name = "Hello, " ++ name

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -62,7 +62,7 @@ def test_collect_files_from_dir():
                  ".java", ".c", ".cpp", ".cc", ".cxx", ".rb",
                  ".cs", ".kt", ".kts", ".scala", ".php", ".h", ".hpp",
                  ".swift", ".lua", ".toc", ".zig", ".ps1", ".ex", ".exs",
-                 ".m", ".mm"}
+                 ".m", ".mm", ".jl", ".hs", ".lhs"}
     assert all(f.suffix in supported for f in files)
     assert len(files) > 0
 

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -5,7 +5,8 @@ import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
-    extract_swift, extract_go, extract_julia,
+    extract_swift, extract_go, extract_julia, extract_haskell,
+    collect_files,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -508,3 +509,99 @@ def test_julia_no_dangling_edges():
     node_ids = {n["id"] for n in r["nodes"]}
     for e in r["edges"]:
         assert e["source"] in node_ids, f"Dangling source: {e}"
+
+
+# ── Haskell ──────────────────────────────────────────────────────────────────
+
+def test_haskell_no_error():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    assert "error" not in r
+
+
+def test_haskell_finds_module():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert "Sample" in labels
+
+
+def test_haskell_finds_functions():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert any("area" in l for l in labels)
+    assert any("perimeter" in l for l in labels)
+    assert any("classify" in l for l in labels)
+    assert any("summarize" in l for l in labels)
+    assert any("double" in l for l in labels)
+
+
+def test_haskell_finds_data_types():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert "Shape" in labels
+    assert "Wrapper" in labels
+    assert "Name" in labels
+
+
+def test_haskell_finds_constructors():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert "Circle" in labels
+    assert "Rectangle" in labels
+    # Constructors should have contains edges from Shape
+    shape_nid = next(n["id"] for n in r["nodes"] if n["label"] == "Shape")
+    con_edges = [e for e in r["edges"]
+                 if e["source"] == shape_nid and e["relation"] == "contains"]
+    assert len(con_edges) >= 2
+
+
+def test_haskell_finds_typeclass():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    labels = _labels(r)
+    assert "Describable" in labels
+
+
+def test_haskell_finds_imports():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    import_edges = [e for e in r["edges"] if e["relation"] == "imports"]
+    assert len(import_edges) >= 2
+    import_labels = _labels(r)
+    assert any("Data.List" in l for l in import_labels)
+    assert any("Data.Map" in l for l in import_labels)
+
+
+def test_haskell_finds_instance():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    inherits = [e for e in r["edges"] if e["relation"] == "inherits"]
+    assert len(inherits) >= 1
+
+
+def test_haskell_finds_calls():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    call_edges = [e for e in r["edges"] if e["relation"] == "calls"]
+    assert len(call_edges) >= 1
+
+
+def test_haskell_no_dangling_edges():
+    r = extract_haskell(FIXTURES / "sample.hs")
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"Dangling source: {e}"
+        assert e["target"] in node_ids, f"Dangling target: {e}"
+
+
+def test_haskell_lhs_parsing():
+    r = extract_haskell(FIXTURES / "sample.lhs")
+    assert "error" not in r
+    labels = _labels(r)
+    assert "SampleLhs" in labels
+    assert any("greet" in l for l in labels)
+
+
+def test_collect_files_includes_all_extensions(tmp_path):
+    """collect_files should discover .hs, .lhs, .ex, .exs, .jl files."""
+    for ext in (".hs", ".lhs", ".ex", ".exs", ".jl"):
+        (tmp_path / f"test{ext}").write_text("-- placeholder")
+    files = collect_files(tmp_path)
+    found_exts = {p.suffix for p in files}
+    for ext in (".hs", ".lhs", ".ex", ".exs", ".jl"):
+        assert ext in found_exts, f"{ext} not found by collect_files"


### PR DESCRIPTION
Summary
  - Add Haskell as a supported language with a custom tree-sitter extractor, following the pattern used by Go, Rust, and Julia
  - Extracts modules, imports, data types (with constructors), newtypes, type aliases, type classes, instances, functions, and call edges
  - Supports literate Haskell (.lhs) via bird-track preprocessing
  - Fix existing bug: collect_files() was missing .ex, .exs, .jl extensions despite having extractors for Elixir and Julia

  Changes
  - pyproject.toml — Add tree-sitter-haskell dependency
  - graphify/extract.py — Add extract_haskell() custom extractor (~160 lines), register .hs/.lhs in _DISPATCH, fix missing extensions in _EXTENSIONS
  - graphify/detect.py — Add .hs, .lhs to CODE_EXTENSIONS
  - tests/fixtures/sample.hs — Representative Haskell fixture covering all constructs
  - tests/fixtures/sample.lhs — Minimal literate Haskell fixture
  - tests/test_languages.py — 12 new tests (module, functions, data types, constructors, typeclass, imports, instances, calls, dangling edges, .lhs parsing, collect_files coverage)
  - tests/test_extract.py — Update test_collect_files_from_dir to include new extensions

  Test plan
  - All 12 new Haskell tests pass
  - Full test suite passes (422 tests, 0 failures)
  - Tested against a real-world Haskell codebase (215 files, 5058 nodes, 5812 edges, 0 errors)