### PR TITLE
fix: normalize edge keys and prevent to_html zero division

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -42,6 +42,13 @@ def build_from_json(extraction: dict, *, directed: bool = False) -> nx.Graph:
         G.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
     node_set = set(G.nodes())
     for edge in extraction.get("edges", []):
+        # Normalize alternate key names that LLM subagents sometimes produce
+        if "from" in edge and "source" not in edge:
+            edge["source"] = edge.pop("from")
+        if "to" in edge and "target" not in edge:
+            edge["target"] = edge.pop("to")
+        if "source" not in edge or "target" not in edge:
+            continue  # skip malformed edges
         src, tgt = edge["source"], edge["target"]
         if src not in node_set or tgt not in node_set:
             continue  # skip edges to external/stdlib nodes - expected, not an error

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -347,6 +347,8 @@ def to_html(
     node_community = _node_community_map(communities)
     degree = dict(G.degree())
     max_deg = max(degree.values()) if degree else 1
+    if max_deg == 0:
+        max_deg = 1  # avoid division by zero on graphs with no edges
 
     # Build nodes list for vis.js
     vis_nodes = []


### PR DESCRIPTION
## Summary

Two small fixes for issues encountered when running graphify with LLM subagents on multi-repo codebases:

- **`build_from_json`**: normalize alternate edge key names (`from`/`to` → `source`/`target`) before processing. LLM subagents (especially smaller models like Sonnet) sometimes produce edges with `from`/`to` instead of the expected `source`/`target`. Previously these edges caused a `KeyError` crash or were silently lost. Now they are normalized transparently, and truly malformed edges (missing both variants) are skipped.

- **`to_html`**: guard against `ZeroDivisionError` when `max_deg` is 0. This happens on graphs where all nodes are isolated (no edges), e.g. very small repos or when all semantic edges were malformed. The node size calculation `deg / max_deg` crashed.

## Files changed

| File | Change |
|---|---|
| `graphify/build.py` | Normalize `from`/`to` → `source`/`target`, skip malformed edges |
| `graphify/export.py` | Guard `max_deg == 0` before division |

## How I found these

While indexing a multi-repo project (13 repos, ~4400 nodes total), I dispatched Sonnet subagents for semantic extraction. Two repos produced edges with `from`/`to` keys, causing `build_from_json` to crash. On one very small repo (5 code files, no docs), all edges were lost, leaving a 0-edge graph that then crashed `to_html`.

## Testing

- Verified both fixes resolve the original crashes
- No behavior change for well-formed inputs (the normalization only triggers when `source`/`target` are absent)
- No logic changes, no new dependencies

Closes #216
Closes #217