### PR TITLE
fix(hooks): drop stale CODE_EXTS gate from post-commit hook

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -32,8 +32,16 @@ fi
 
 _HOOK_SCRIPT = """\
 # graphify-hook-start
-# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Auto-rebuilds the knowledge graph after each commit (no LLM needed).
 # Installed by: graphify hook install
+#
+# Why no extension filter: _rebuild_code internally calls detect() which
+# rescans the project from scratch using the authoritative CODE_EXTENSIONS
+# set in graphify/detect.py. A hook-side filter would only gate WHETHER the
+# rebuild fires, not WHAT gets rebuilt — and any hardcoded copy here drifts
+# from the real allowlist (.tsx/.jsx/.lua/.ex/.jl/... were missed in the past).
+# The rebuild is cheap (~2s, no LLM), so just always run it. Output is
+# appended to graphify-out/.hook.log so silent failures stay visible.
 
 CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
 if [ -z "$CHANGED" ]; then
@@ -41,32 +49,21 @@ if [ -z "$CHANGED" ]; then
 fi
 
 """ + _PYTHON_DETECT + """
-export GRAPHIFY_CHANGED="$CHANGED"
-$GRAPHIFY_PYTHON -c "
-import os, sys
+mkdir -p graphify-out
+{
+    echo ''
+    echo '[graphify hook] '$(date '+%Y-%m-%dT%H:%M:%S')' - rebuilding...'
+    $GRAPHIFY_PYTHON -c '
+import sys
 from pathlib import Path
-
-CODE_EXTS = {
-    '.py', '.ts', '.js', '.go', '.rs', '.java', '.cpp', '.c', '.rb', '.swift',
-    '.kt', '.cs', '.scala', '.php', '.cc', '.cxx', '.hpp', '.h', '.kts',
-}
-
-changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
-changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
-code_changed = [f for f in changed if f.suffix.lower() in CODE_EXTS and f.exists()]
-
-if not code_changed:
-    sys.exit(0)
-
-print(f'[graphify hook] {len(code_changed)} code file(s) changed - rebuilding graph...')
-
 try:
     from graphify.watch import _rebuild_code
-    _rebuild_code(Path('.'))
+    _rebuild_code(Path("."))
 except Exception as exc:
-    print(f'[graphify hook] Rebuild failed: {exc}')
+    print(f"[graphify hook] Rebuild failed: {exc}", file=sys.stderr)
     sys.exit(1)
-"
+'
+} >> graphify-out/.hook.log 2>&1
 # graphify-hook-end
 """
 


### PR DESCRIPTION
## Summary

- Fixes #222
- Removes the hardcoded `CODE_EXTS` allowlist from the embedded `post-commit` hook script in `graphify/hooks.py`. The list had drifted from the authoritative `CODE_EXTENSIONS` set in `graphify/detect.py` (missing `.tsx .jsx .lua .toc .zig .ps1 .ex .exs .m .mm .jl`), so commits touching only those files exited 0 silently and never rebuilt the graph.
- Routes hook output to `graphify-out/.hook.log` so any future failure stays visible instead of vanishing into git's hook stderr.

## Why drop the filter, not just sync it

`_rebuild_code` already calls `detect()` internally, which rescans the project from scratch using the authoritative `CODE_EXTENSIONS` set. So the hook's filter only ever gated *whether* the rebuild fires, not *what* gets rebuilt — the work it claimed to save was an illusion. Keeping any hardcoded copy here just re-introduces the same drift bug class the next time `detect.py` adds a language.

The rebuild itself is cheap (~2s for ~400 files in my test repos, no LLM cost), so running it on every commit is harmless. The simpler model — "if anything changed, rebuild" — is also easier to reason about and document.

## Test plan

Manually verified on a clean test repo:

- [x] Init repo, install patched hook via `graphify.hooks.install()`.
- [x] Commit a `.tsx` file (the canonical bug case from #222) → hook fires, `graphify-out/graph.json` and `GRAPH_REPORT.md` updated, log line written.
- [x] Commit a markdown-only change → hook fires, rebuild succeeds, log line written.
- [x] Confirmed `graphify-out/.hook.log` accumulates entries across commits with `[graphify hook] <iso-timestamp> - rebuilding...` headers.

```
$ cat graphify-out/.hook.log

[graphify hook] 2026-04-11T23:52:44 - rebuilding...
[graphify watch] Rebuilt: 3 nodes, 1 edges, 2 communities
[graphify watch] graph.json and GRAPH_REPORT.md updated in graphify-out

[graphify hook] 2026-04-11T23:52:51 - rebuilding...
[graphify watch] Rebuilt: 3 nodes, 1 edges, 2 communities
[graphify watch] graph.json and GRAPH_REPORT.md updated in graphify-out
```

## Notes for reviewers

- Switched the inline `python -c` block to use *single*-quoted shell strings so we can drop a layer of escaping. The embedded Python uses double quotes for the `Path(".")` literal, which is now safe.
- The `_PYTHON_DETECT` block is unchanged.
- `_CHECKOUT_SCRIPT` is intentionally not touched in this PR. It already calls `_rebuild_code` directly without an extension gate, so it doesn't have the same bug. Happy to align its logging with the new `.hook.log` pattern in a follow-up if you'd like.