### PR TITLE
fix: filter blank stdin lines to prevent MCP JSONRPCMessage parse errors

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -108,6 +108,29 @@ def _find_node(G: nx.Graph, label: str) -> list[str]:
             if term in d.get("label", "").lower() or term == nid.lower()]
 
 
+def _filter_blank_stdin() -> None:
+    import os
+    import threading
+
+    r_fd, w_fd = os.pipe()
+    saved_fd = os.dup(sys.stdin.fileno())
+
+    def _relay() -> None:
+        try:
+            with open(saved_fd, "rb") as src, open(w_fd, "wb") as dst:
+                for line in src:
+                    if line.strip():
+                        dst.write(line)
+                        dst.flush()
+        except Exception:
+            pass
+
+    threading.Thread(target=_relay, daemon=True).start()
+    os.dup2(r_fd, sys.stdin.fileno())
+    os.close(r_fd)
+    sys.stdin = open(0, "r", closefd=False)
+
+
 def serve(graph_path: str = "graphify-out/graph.json") -> None:
     """Start the MCP server. Requires pip install mcp."""
     try:
@@ -325,6 +348,7 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         async with stdio_server() as streams:
             await server.run(streams[0], streams[1], server.create_initialization_options())
 
+    _filter_blank_stdin()
     asyncio.run(main())
 
 


### PR DESCRIPTION
Fixes #201.

Some MCP clients send blank lines between JSON messages. The MCP stdio transport tries to parse every line as a `JSONRPCMessage`, so a bare `\n` triggers a Pydantic `ValidationError`.

`_filter_blank_stdin()` installs an OS-level pipe that relays stdin while silently dropping blank lines. Because it operates at the file-descriptor level, it is transparent to anyio regardless of how it wraps stdin.