### PR TITLE
feat(php): capture static property access as uses_static_prop edges

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -29,6 +29,7 @@ class LanguageConfig:
     function_types: frozenset = frozenset()
     import_types: frozenset = frozenset()
     call_types: frozenset = frozenset()
+    static_prop_types: frozenset = frozenset()
 
     # Name extraction
     name_field: str = "name"
@@ -536,6 +537,7 @@ _PHP_CONFIG = LanguageConfig(
     function_types=frozenset({"function_definition", "method_declaration"}),
     import_types=frozenset({"namespace_use_clause"}),
     call_types=frozenset({"function_call_expression", "member_call_expression"}),
+    static_prop_types=frozenset({"scoped_property_access_expression"}),
     call_function_field="function",
     call_accessor_node_types=frozenset({"member_call_expression"}),
     call_accessor_field="name",
@@ -849,6 +851,7 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
         label_to_nid[normalised.lower()] = n["id"]
 
     seen_call_pairs: set[tuple[str, str]] = set()
+    seen_static_ref_pairs: set[tuple[str, str, str]] = set()
 
     def walk_calls(node, caller_nid: str) -> None:
         if node.type in config.function_boundary_types:
@@ -956,6 +959,32 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             "source": caller_nid,
                             "target": tgt_nid,
                             "relation": "calls",
+                            "confidence": "EXTRACTED",
+                            "source_file": str_path,
+                            "source_location": f"L{line}",
+                            "weight": 1.0,
+                        })
+
+        # Static property access: Foo::$bar, Config::$default
+        if node.type in config.static_prop_types:
+            scope_node = node.child_by_field_name("scope")
+            if scope_node is None:
+                for child in node.children:
+                    if child.is_named and child.type in ("name", "qualified_name", "identifier"):
+                        scope_node = child
+                        break
+            if scope_node is not None:
+                class_name = _read_text(scope_node, source)
+                tgt_nid = label_to_nid.get(class_name.lower())
+                if tgt_nid and tgt_nid != caller_nid:
+                    pair = (caller_nid, tgt_nid, "uses_static_prop")
+                    if pair not in seen_static_ref_pairs:
+                        seen_static_ref_pairs.add(pair)
+                        line = node.start_point[0] + 1
+                        edges.append({
+                            "source": caller_nid,
+                            "target": tgt_nid,
+                            "relation": "uses_static_prop",
                             "confidence": "EXTRACTED",
                             "source_file": str_path,
                             "source_location": f"L{line}",

--- a/tests/fixtures/sample_php_static_prop.php
+++ b/tests/fixtures/sample_php_static_prop.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Theme;
+
+class DefaultPalette
+{
+    public static string $primary = '#3366ff';
+    public static string $accent = '#ff6633';
+}
+
+class ColorResolver
+{
+    public function primary(): string
+    {
+        return DefaultPalette::$primary;
+    }
+
+    public function accent(): string
+    {
+        return DefaultPalette::$accent;
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -234,6 +234,19 @@ def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)
 
+def test_php_finds_static_property_access():
+    r = extract_php(FIXTURES / "sample_php_static_prop.php")
+    assert "uses_static_prop" in _relations(r)
+
+def test_php_static_prop_target_is_holding_class():
+    r = extract_php(FIXTURES / "sample_php_static_prop.php")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    uses_prop = [
+        (node_by_id.get(e["source"], e["source"]), node_by_id.get(e["target"], e["target"]))
+        for e in r["edges"] if e["relation"] == "uses_static_prop"
+    ]
+    assert any("DefaultPalette" in tgt for _, tgt in uses_prop)
+
 
 # ── Swift ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #234

## What

The PHP AST extractor now recognizes `scoped_property_access_expression` nodes and produces a new `uses_static_prop` edge from the enclosing function or method to the class that owns the referenced static property. Previously these reads were silently dropped, so classes that expose configuration or theme defaults through public static properties disappeared from the graph.

## Why

Current PHP handling only wires up `function_call_expression` and `member_call_expression`. A reference like `DefaultPalette::$primary` does not become an edge. On codebases that rely on static configuration holders this loses meaningful coupling.

Full details and reproducer are in issue #234.

## How

- `LanguageConfig` gains an optional `static_prop_types` frozenset with an empty default, so every other language is untouched.
- `_PHP_CONFIG` sets `static_prop_types=frozenset({"scoped_property_access_expression"})`.
- A new branch inside the existing `walk_calls` dispatcher handles the node. It reads the class reference via the `scope` field and falls back to the first named child, because tree-sitter-php has exposed the class name under slightly different field layouts across versions.
- When the class resolves through `label_to_nid`, a `uses_static_prop` edge is emitted. A dedicated `seen_static_ref_pairs` set prevents duplicate static edges while allowing `calls` and `uses_static_prop` to coexist for the same `(caller, target)` pair when legitimate.

## Tests

- `tests/fixtures/sample_php_static_prop.php` is a minimal fixture that declares `DefaultPalette` with two static properties and a `ColorResolver` class whose methods read both of them.
- `tests/test_languages.py` gains two tests: `test_php_finds_static_property_access` checks the relation is present, and `test_php_static_prop_target_is_holding_class` verifies the target is the class that holds the property.
- Full suite stays green: `pytest` reports 427 passed.

## Backwards compatibility

The change is additive. Other language configs never populate `static_prop_types`. Existing PHP tests continue to pass against the unchanged `tests/fixtures/sample.php` fixture.

## Follow-ups

This is the last of three related patches for the PHP extractor. The other two cover `class_constant_access_expression` and `scoped_call_expression`, opened as separate focused PRs.

Marked as draft until you have a chance to weigh in on the approach and the new relation name. I am happy to rename or reshape.
