### PR TITLE
feat(php): capture config() helper calls as uses_config edges

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -29,6 +29,7 @@ class LanguageConfig:
     function_types: frozenset = frozenset()
     import_types: frozenset = frozenset()
     call_types: frozenset = frozenset()
+    helper_fn_names: frozenset = frozenset()
 
     # Name extraction
     name_field: str = "name"
@@ -536,6 +537,7 @@ _PHP_CONFIG = LanguageConfig(
     function_types=frozenset({"function_definition", "method_declaration"}),
     import_types=frozenset({"namespace_use_clause"}),
     call_types=frozenset({"function_call_expression", "member_call_expression"}),
+    helper_fn_names=frozenset({"config"}),
     call_function_field="function",
     call_accessor_node_types=frozenset({"member_call_expression"}),
     call_accessor_field="name",
@@ -849,6 +851,7 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
         label_to_nid[normalised.lower()] = n["id"]
 
     seen_call_pairs: set[tuple[str, str]] = set()
+    seen_helper_ref_pairs: set[tuple[str, str, str]] = set()
 
     def walk_calls(node, caller_nid: str) -> None:
         if node.type in config.function_boundary_types:
@@ -961,6 +964,44 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             "source_location": f"L{line}",
                             "weight": 1.0,
                         })
+
+            # Helper function calls: config('foo.bar') -> edge to "foo"
+            if (node.type == "function_call_expression"
+                    and callee_name and callee_name in config.helper_fn_names):
+                args_node = node.child_by_field_name("arguments")
+                first_key: str | None = None
+                if args_node:
+                    for arg in args_node.children:
+                        if arg.type != "argument":
+                            continue
+                        for inner in arg.children:
+                            if inner.type == "string":
+                                for sc in inner.children:
+                                    if sc.type == "string_content":
+                                        first_key = _read_text(sc, source)
+                                        break
+                                break
+                        if first_key:
+                            break
+                if first_key:
+                    segment = first_key.split(".")[0]
+                    tgt_nid = (label_to_nid.get(segment.lower())
+                               or label_to_nid.get(f"{segment}.php".lower()))
+                    if tgt_nid and tgt_nid != caller_nid:
+                        relation = f"uses_{callee_name}"
+                        pair = (caller_nid, tgt_nid, relation)
+                        if pair not in seen_helper_ref_pairs:
+                            seen_helper_ref_pairs.add(pair)
+                            line = node.start_point[0] + 1
+                            edges.append({
+                                "source": caller_nid,
+                                "target": tgt_nid,
+                                "relation": relation,
+                                "confidence": "EXTRACTED",
+                                "source_file": str_path,
+                                "source_location": f"L{line}",
+                                "weight": 1.0,
+                            })
 
         for child in node.children:
             walk_calls(child, caller_nid)

--- a/tests/fixtures/sample_php_config.php
+++ b/tests/fixtures/sample_php_config.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Support;
+
+class Throttle
+{
+    public const int DEFAULT_PER_SECOND = 60;
+    public const int DEFAULT_PER_DAY = 10000;
+}
+
+class RateLimiter
+{
+    public function perSecond(): int
+    {
+        return (int) config('throttle.api.per_second', 60);
+    }
+
+    public function perDay(): int
+    {
+        return (int) config('throttle.api.per_day', 10000);
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -234,6 +234,19 @@ def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)
 
+def test_php_finds_config_helper_call():
+    r = extract_php(FIXTURES / "sample_php_config.php")
+    assert "uses_config" in _relations(r)
+
+def test_php_config_helper_target_matches_first_segment():
+    r = extract_php(FIXTURES / "sample_php_config.php")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    uses_cfg = [
+        (node_by_id.get(e["source"], e["source"]), node_by_id.get(e["target"], e["target"]))
+        for e in r["edges"] if e["relation"] == "uses_config"
+    ]
+    assert any("Throttle" in tgt for _, tgt in uses_cfg)
+
 
 # ── Swift ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #236

## What

The PHP extractor now recognizes helper function calls whose first argument is a dot-notation string literal and produces a new `uses_{helper}` edge pointing from the caller to the target indicated by the first segment of that string. The first helper handled out of the box is `config()`, which emits `uses_config` edges.

## Why

Global helper calls like `config('throttle.api.per_second')` carry real coupling between the caller and the configuration holder that owns the key, but the graph loses that signal entirely. The extractor sees `config` as an unknown name and drops the edge.

Full details and reproducer are in issue #236.

## How

- `LanguageConfig` gains an optional `helper_fn_names` frozenset with an empty default, so every other language is untouched.
- `_PHP_CONFIG` sets `helper_fn_names=frozenset({"config"})`.
- A new branch inside `walk_calls` runs after the regular call dispatch. When the current node is a `function_call_expression` whose callee name matches one of `helper_fn_names`, the first `argument` child is walked and its first `string_content` payload is captured.
- The first dot-separated segment of that payload is used as the lookup key. The extractor tries both the bare name and a `.php` suffix against `label_to_nid` before giving up. When a target is resolved, a `uses_{callee_name}` edge is emitted (so `config('throttle.foo')` becomes `uses_config`).
- A dedicated `seen_helper_ref_pairs` set prevents duplicates and keeps this pathway independent from `seen_call_pairs`, which is scoped to `calls` edges.

The design is extensible. Adding more helpers later (for example `route()`, `view()`, `env()`, `asset()`) only requires widening `helper_fn_names` and, if needed, teaching the segment-resolution step about helper-specific targets.

## Tests

- `tests/fixtures/sample_php_config.php` declares a `Throttle` class and a `RateLimiter` class that calls `config('throttle.api.per_second', ...)` and `config('throttle.api.per_day', ...)`.
- `tests/test_languages.py` gains two tests: `test_php_finds_config_helper_call` verifies the relation is present, and `test_php_config_helper_target_matches_first_segment` checks the target is the `Throttle` class (first dot segment).
- Full suite stays green: `pytest` reports 427 passed.

## Backwards compatibility

The change is additive. Other languages never set `helper_fn_names`. Existing PHP tests still pass against the unchanged `tests/fixtures/sample.php` fixture. Emitted edges use a new relation label, so any downstream tooling that filters on `calls` or the older relations is unaffected.

## Follow-ups

Related focused PRs are open or being prepared for `class_constant_access_expression`, `scoped_call_expression`, `scoped_property_access_expression`, service container `bind()` calls, `$listen` array mapping, and `.blade.php` file handling.

Marked as draft until you have a chance to weigh in on the approach, in particular the relation name `uses_config` and the extensibility shape of `helper_fn_names`.
