### PR TITLE
feat(php): capture service container bindings as bound_to edges

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -29,6 +29,7 @@ class LanguageConfig:
     function_types: frozenset = frozenset()
     import_types: frozenset = frozenset()
     call_types: frozenset = frozenset()
+    container_bind_methods: frozenset = frozenset()
 
     # Name extraction
     name_field: str = "name"
@@ -536,6 +537,7 @@ _PHP_CONFIG = LanguageConfig(
     function_types=frozenset({"function_definition", "method_declaration"}),
     import_types=frozenset({"namespace_use_clause"}),
     call_types=frozenset({"function_call_expression", "member_call_expression"}),
+    container_bind_methods=frozenset({"bind", "singleton", "scoped", "instance"}),
     call_function_field="function",
     call_accessor_node_types=frozenset({"member_call_expression"}),
     call_accessor_field="name",
@@ -849,6 +851,18 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
         label_to_nid[normalised.lower()] = n["id"]
 
     seen_call_pairs: set[tuple[str, str]] = set()
+    seen_bind_pairs: set[tuple[str, str, str]] = set()
+
+    def _php_class_const_scope(n) -> str | None:
+        scope = n.child_by_field_name("scope")
+        if scope is None:
+            for c in n.children:
+                if c.is_named and c.type in ("name", "qualified_name", "identifier"):
+                    scope = c
+                    break
+        if scope is None:
+            return None
+        return _read_text(scope, source)
 
     def walk_calls(node, caller_nid: str) -> None:
         if node.type in config.function_boundary_types:
@@ -961,6 +975,43 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                             "source_location": f"L{line}",
                             "weight": 1.0,
                         })
+
+            # Service container bindings: $this->app->bind(Foo::class, Bar::class)
+            if (node.type == "member_call_expression"
+                    and callee_name
+                    and callee_name in config.container_bind_methods):
+                args_node = node.child_by_field_name("arguments")
+                class_args: list[str] = []
+                if args_node:
+                    for arg in args_node.children:
+                        if arg.type != "argument":
+                            continue
+                        for inner in arg.children:
+                            if inner.type == "class_constant_access_expression":
+                                cls = _php_class_const_scope(inner)
+                                if cls:
+                                    class_args.append(cls)
+                                break
+                        if len(class_args) >= 2:
+                            break
+                if len(class_args) == 2:
+                    contract_name, impl_name = class_args
+                    contract_nid = label_to_nid.get(contract_name.lower())
+                    impl_nid = label_to_nid.get(impl_name.lower())
+                    if contract_nid and impl_nid and contract_nid != impl_nid:
+                        pair = (contract_nid, impl_nid, "bound_to")
+                        if pair not in seen_bind_pairs:
+                            seen_bind_pairs.add(pair)
+                            line = node.start_point[0] + 1
+                            edges.append({
+                                "source": contract_nid,
+                                "target": impl_nid,
+                                "relation": "bound_to",
+                                "confidence": "EXTRACTED",
+                                "source_file": str_path,
+                                "source_location": f"L{line}",
+                                "weight": 1.0,
+                            })
 
         for child in node.children:
             walk_calls(child, caller_nid)

--- a/tests/fixtures/sample_php_container.php
+++ b/tests/fixtures/sample_php_container.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Providers;
+
+class PaymentGateway {}
+class StripeGateway {}
+class CashierGateway {}
+
+class AppServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(PaymentGateway::class, StripeGateway::class);
+        $this->app->singleton(CashierGateway::class, StripeGateway::class);
+    }
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -234,6 +234,21 @@ def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)
 
+def test_php_finds_container_bind():
+    r = extract_php(FIXTURES / "sample_php_container.php")
+    assert "bound_to" in _relations(r)
+
+def test_php_container_bind_links_contract_to_implementation():
+    r = extract_php(FIXTURES / "sample_php_container.php")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    bound = [
+        (node_by_id.get(e["source"], e["source"]), node_by_id.get(e["target"], e["target"]))
+        for e in r["edges"] if e["relation"] == "bound_to"
+    ]
+    pairs = {pair for pair in bound}
+    assert ("PaymentGateway", "StripeGateway") in pairs
+    assert ("CashierGateway", "StripeGateway") in pairs
+
 
 # ── Swift ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #238

## What

The PHP AST extractor now recognizes service container binding calls like `$this->app->bind(FooContract::class, BarImpl::class)` and produces a new `bound_to` edge from the contract class to the implementation class. The same handling applies to `singleton`, `scoped`, and `instance`. Before this change there was no way to see a project's DI wiring in the graph.

## Why

Dependency injection container calls express which implementation a contract resolves to at runtime. Without these edges, the graph is silent about a whole layer of coupling that drives actual program behavior.

Full details and reproducer are in issue #238.

## How

- `LanguageConfig` gains an optional `container_bind_methods` frozenset with an empty default, so every other language is untouched.
- `_PHP_CONFIG` sets `container_bind_methods=frozenset({"bind", "singleton", "scoped", "instance"})`.
- A small helper, `_php_class_const_scope`, pulls the class name out of a `class_constant_access_expression`, handling both the `scope` field and the positional name fallback used by older tree-sitter-php layouts.
- A new branch inside the `walk_calls` dispatcher runs on `member_call_expression` nodes. When the callee name matches one of `container_bind_methods`, it walks the first two `argument` children, extracts a class name from each if the inner shape is `Foo::class`, and emits a `bound_to` edge from the contract node to the implementation node when both resolve through `label_to_nid`.
- A dedicated `seen_bind_pairs` set prevents duplicates and keeps this pathway independent from `seen_call_pairs`.

## Tests

- `tests/fixtures/sample_php_container.php` declares `PaymentGateway`, `StripeGateway`, `CashierGateway`, and an `AppServiceProvider` that issues both a `bind()` and a `singleton()` call.
- `tests/test_languages.py` gains two tests: `test_php_finds_container_bind` checks the relation is present, and `test_php_container_bind_links_contract_to_implementation` verifies the exact contract-to-implementation pairs appear.
- Full suite stays green: `pytest` reports 427 passed.

## Backwards compatibility

The change is additive. Other language configs never populate `container_bind_methods`. Existing PHP tests still pass against the unchanged `tests/fixtures/sample.php` fixture. Closures and factory callbacks that do not pass two class literals are silently skipped.

## Follow-ups

Related focused PRs are open or being prepared for `class_constant_access_expression`, `scoped_call_expression`, `scoped_property_access_expression`, `config()`, `$listen` array mapping, and `.blade.php` handling.

Marked as draft until you weigh in on the approach, in particular the new relation name `bound_to` and the choice to emit a single contract-to-implementation edge instead of two provider-to-class edges.
