### PR TITLE
feat(blade): regex-based extractor for .blade.php templates

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1141,6 +1141,76 @@ def extract_php(path: Path) -> dict:
     return _extract_generic(path, _PHP_CONFIG)
 
 
+# Blade directive patterns. Conservative on purpose: only the three forms that
+# carry the most graph signal, not the full Blade syntax.
+_BLADE_INCLUDE_RE = re.compile(r"""@include\s*\(\s*['"]([^'"]+)['"]""")
+_BLADE_LIVEWIRE_RE = re.compile(r"<livewire:([\w\-\.]+)")
+_BLADE_WIRE_CLICK_RE = re.compile(r"""wire:click\s*=\s*["'](\w+)""")
+
+
+def extract_blade(path: Path) -> dict:
+    """Extract basic Blade template references: @include, <livewire:*>, wire:click.
+
+    Blade has no mature tree-sitter grammar, so this uses regex on three common
+    forms. Every match becomes an edge from the template file to a placeholder
+    node that carries the raw target name. Downstream passes can resolve those
+    names against real nodes; if nothing resolves, the placeholder still keeps
+    the template from looking isolated in the graph.
+    """
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except Exception as e:  # noqa: BLE001
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    str_path = str(path)
+    file_nid = _make_id(str(path))
+    stem = path.name
+
+    nodes: list[dict] = [{
+        "id": file_nid,
+        "label": stem,
+        "file_type": "code",
+        "source_file": str_path,
+        "source_location": "L1",
+    }]
+    edges: list[dict] = []
+    seen_targets: set[tuple[str, str]] = set()
+
+    def _line_for(offset: int) -> int:
+        return source.count("\n", 0, offset) + 1
+
+    def _add(target_label: str, relation: str, offset: int) -> None:
+        target_id = _make_id("blade", target_label)
+        key = (target_id, relation)
+        if key not in seen_targets:
+            seen_targets.add(key)
+            nodes.append({
+                "id": target_id,
+                "label": target_label,
+                "file_type": "code",
+                "source_file": "",
+                "source_location": "",
+            })
+        edges.append({
+            "source": file_nid,
+            "target": target_id,
+            "relation": relation,
+            "confidence": "EXTRACTED",
+            "source_file": str_path,
+            "source_location": f"L{_line_for(offset)}",
+            "weight": 1.0,
+        })
+
+    for m in _BLADE_INCLUDE_RE.finditer(source):
+        _add(m.group(1), "includes", m.start())
+    for m in _BLADE_LIVEWIRE_RE.finditer(source):
+        _add(m.group(1), "uses_component", m.start())
+    for m in _BLADE_WIRE_CLICK_RE.finditer(source):
+        _add(m.group(1), "wire_click", m.start())
+
+    return {"nodes": nodes, "edges": edges}
+
+
 def extract_lua(path: Path) -> dict:
     """Extract functions, methods, require() imports, and calls from a .lua file."""
     return _extract_generic(path, _LUA_CONFIG)
@@ -2629,7 +2699,13 @@ def extract(paths: list[Path]) -> dict:
     for i, path in enumerate(paths):
         if total >= _PROGRESS_INTERVAL and i % _PROGRESS_INTERVAL == 0 and i > 0:
             print(f"  AST extraction: {i}/{total} files ({i * 100 // total}%)", flush=True)
-        extractor = _DISPATCH.get(path.suffix)
+        # .blade.php has to be checked before the suffix lookup because
+        # Path.suffix only returns '.php' for foo.blade.php and we do not
+        # want blade templates to go through the PHP tree-sitter parser.
+        if path.name.endswith(".blade.php"):
+            extractor = extract_blade
+        else:
+            extractor = _DISPATCH.get(path.suffix)
         if extractor is None:
             continue
         cached = load_cached(path, root)

--- a/tests/fixtures/sample.blade.php
+++ b/tests/fixtures/sample.blade.php
@@ -1,0 +1,9 @@
+<div class="panel">
+    <livewire:panel.listings :user="$user" />
+
+    <flux:button wire:click="bulkActivate">Activate selected</flux:button>
+    <flux:button wire:click="bulkDelete">Delete selected</flux:button>
+
+    @include('partials.footer')
+    @include('panel.components.pagination')
+</div>

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -5,7 +5,7 @@ import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
-    extract_swift, extract_go, extract_julia,
+    extract_blade, extract_swift, extract_go, extract_julia,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -233,6 +233,33 @@ def test_php_finds_function():
 def test_php_finds_imports():
     r = extract_php(FIXTURES / "sample.php")
     assert "imports" in _relations(r)
+
+
+# ── Blade ────────────────────────────────────────────────────────────────────
+
+def test_blade_no_error():
+    r = extract_blade(FIXTURES / "sample.blade.php")
+    assert "error" not in r
+
+def test_blade_finds_include():
+    r = extract_blade(FIXTURES / "sample.blade.php")
+    assert "includes" in _relations(r)
+    targets = {n["label"] for n in r["nodes"]}
+    assert "partials.footer" in targets
+    assert "panel.components.pagination" in targets
+
+def test_blade_finds_livewire_component():
+    r = extract_blade(FIXTURES / "sample.blade.php")
+    assert "uses_component" in _relations(r)
+    targets = {n["label"] for n in r["nodes"]}
+    assert "panel.listings" in targets
+
+def test_blade_finds_wire_click():
+    r = extract_blade(FIXTURES / "sample.blade.php")
+    assert "wire_click" in _relations(r)
+    targets = {n["label"] for n in r["nodes"]}
+    assert "bulkActivate" in targets
+    assert "bulkDelete" in targets
 
 
 # ── Swift ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #242

## What

A new `extract_blade()` reads `.blade.php` files and produces edges for the three Blade directive shapes that carry the most graph signal. The `extract()` dispatcher routes templates to it based on filename, which works around the fact that `Path.suffix` returns `.php` for `foo.blade.php`.

The three handled shapes:

- `@include('path.to.partial')` produces `includes`
- `<livewire:component.name />` produces `uses_component`
- `wire:click="methodName"` produces `wire_click`

## Why

Templates often make up a large share of a PHP project's surface area but they were silent in the graph. On a real Laravel project this left hundreds of template files as isolated nodes with no edges, which poisoned community detection and dependency analysis.

Full details and reproducer are in issue #242.

## How

- New `extract_blade(path)` helper alongside the other `extract_*` functions. It reads the source as UTF-8 (with `errors="replace"` to be defensive), creates a file node, and runs three compiled regexes (`_BLADE_INCLUDE_RE`, `_BLADE_LIVEWIRE_RE`, `_BLADE_WIRE_CLICK_RE`).
- Every match creates a placeholder node keyed by a stable id (so duplicate directives do not produce duplicate nodes) and an edge from the file node to the placeholder. The placeholder carries the raw target label. This is enough to stop the template looking isolated in the graph and gives a later resolver something to map to real nodes.
- The `extract()` dispatcher checks `path.name.endswith('.blade.php')` before its suffix lookup and routes matches to `extract_blade` instead of `extract_php`. This is the one piece that has to live in the dispatcher, because `Path.suffix` alone cannot distinguish `foo.blade.php` from `foo.php`.

Blade has no mature tree-sitter grammar, so regex is intentional. The scope is deliberately narrow: only the three most common directive shapes. More advanced Blade features (`@if`, `@foreach`, `@section`/`@yield`, custom directives) are out of scope for this PR and can follow later.

## Tests

- `tests/fixtures/sample.blade.php` exercises all three directive shapes.
- `tests/test_languages.py` gains four tests: `test_blade_no_error`, `test_blade_finds_include`, `test_blade_finds_livewire_component`, `test_blade_finds_wire_click`. Each verifies both the relation and the expected placeholder target labels.
- Full suite stays green: `pytest` reports 429 passed.

## Backwards compatibility

Additive. Projects without `.blade.php` files are unaffected. Existing PHP tests still pass against `tests/fixtures/sample.php`. The dispatcher change does not touch any non-Blade path.

## Follow-ups

Related focused PRs are open or being prepared for the PHP extractor: `class_constant_access_expression`, `scoped_call_expression`, `scoped_property_access_expression`, `config()`, service container bindings, and `$listen` array mapping.

Marked as draft until you have a chance to weigh in on the approach, in particular whether you would rather route Blade through a new `LanguageConfig` entry or keep it as its own bespoke extractor.
