### PR TITLE
fix: use cross-platform Python fallback chain in git hooks

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -20,13 +20,21 @@ if [ -n "$GRAPHIFY_BIN" ]; then
     # Allowlist: only keep characters valid in a filesystem path to prevent
     # injection if the shebang contains shell metacharacters
     case "$GRAPHIFY_PYTHON" in
-        *[!a-zA-Z0-9/_.-]*) GRAPHIFY_PYTHON="python3" ;;
+        *[!a-zA-Z0-9/_.-]*) GRAPHIFY_PYTHON="" ;;
     esac
-    if ! "$GRAPHIFY_PYTHON" -c "import graphify" 2>/dev/null; then
-        GRAPHIFY_PYTHON="python3"
+    if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "import graphify" 2>/dev/null; then
+        GRAPHIFY_PYTHON=""
     fi
-else
-    GRAPHIFY_PYTHON="python3"
+fi
+# Fall back: try python3, then python (Windows), else abort silently
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "import graphify" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "import graphify" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        exit 0
+    fi
 fi
 """
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,7 +2,7 @@
 import subprocess
 from pathlib import Path
 import pytest
-from graphify.hooks import install, uninstall, status, _HOOK_MARKER, _CHECKOUT_MARKER
+from graphify.hooks import install, uninstall, status, _HOOK_MARKER, _CHECKOUT_MARKER, _PYTHON_DETECT
 
 
 def _make_git_repo(tmp_path: Path) -> Path:
@@ -110,3 +110,16 @@ def test_status_shows_both_hooks(tmp_path):
     assert "post-commit" in result
     assert "post-checkout" in result
     assert result.count("installed") >= 2
+
+
+def test_python_detect_cross_platform_fallback():
+    """Hook must try 'python' as a fallback so it works on Windows (no python3 shim)."""
+    # The cross-platform fallback chain must be present
+    assert 'command -v python3' in _PYTHON_DETECT
+    assert 'command -v python' in _PYTHON_DETECT
+    # The fallback must appear *after* the python3 attempt (elif / else branch)
+    idx_py3 = _PYTHON_DETECT.index('command -v python3')
+    idx_py = _PYTHON_DETECT.index('command -v python >')
+    assert idx_py > idx_py3, "Windows 'python' fallback must come after python3 attempt"
+    # There must be a silent-exit path so the hook is a no-op rather than noisy on failure
+    assert 'exit 0' in _PYTHON_DETECT


### PR DESCRIPTION

#244 

  On Windows, graphify is installed as a .exe wrapper with no shebang,
  so the interpreter-sniffing logic always fell through to the hardcoded
  GRAPHIFY_PYTHON="python3" fallback. Windows Python installs expose
  python (not python3), so the hook silently exited with
  "python3: command not found" and never rebuilt the graph.

  Replace the three scattered python3 hardcodes with a single unified
  fallback block that probes python3 then python (each verified via
  `import graphify`), and exits 0 silently if neither is usable.