### PR TITLE
fix(hooks): force UTF-8 stdio so Windows post-commit/post-checkout don't crash

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -40,11 +40,27 @@ if [ -z "$CHANGED" ]; then
     exit 0
 fi
 
+# Force UTF-8 for Python I/O so Unicode characters in graph output (e.g. the
+# arrows, checkmarks, and math symbols that appear in generated reports) do
+# not crash the encoder on Windows, where stdio and file I/O default to
+# cp1252 when not attached to a TTY. Git hooks always run detached.
+export PYTHONIOENCODING=utf-8
+export PYTHONUTF8=1
+
 """ + _PYTHON_DETECT + """
 export GRAPHIFY_CHANGED="$CHANGED"
 $GRAPHIFY_PYTHON -c "
 import os, sys
 from pathlib import Path
+
+# Belt and suspenders: even if the env vars above get dropped by some exotic
+# shell wrapper, reconfigure stdio to UTF-8 with a 'replace' fallback so a
+# stray non-Latin-1 character never crashes the hook.
+try:
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+except Exception:
+    pass
 
 changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
 changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
@@ -84,12 +100,22 @@ if [ ! -d "graphify-out" ]; then
     exit 0
 fi
 
+# Force UTF-8 for Python I/O (see post-commit hook for the same rationale).
+export PYTHONIOENCODING=utf-8
+export PYTHONUTF8=1
+
 """ + _PYTHON_DETECT + """
 echo "[graphify] Branch switched - rebuilding knowledge graph (code files)..."
 $GRAPHIFY_PYTHON -c "
+import sys
+# Belt and suspenders stdio reconfigure in case env vars get dropped.
+try:
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+except Exception:
+    pass
 from graphify.watch import _rebuild_code
 from pathlib import Path
-import sys
 try:
     _rebuild_code(Path('.'))
 except Exception as exc:


### PR DESCRIPTION
## Summary

On Windows, graphify's post-commit and post-checkout hooks silently fail any time the generated knowledge graph contains a non-Latin-1 character (U+2264 \`≤\`, arrows, checkmarks, box-drawing, etc.). The error is:

\`\`\`
[graphify hook] Rebuild failed: 'charmap' codec can't encode character '\u2264' in position N: character maps to <undefined>
\`\`\`

The root cause is that Python defaults to \`cp1252\` for \`sys.stdout\`, \`sys.stderr\`, and \`open()\` when not attached to a TTY. Git hooks always run detached. As soon as graphify tries to \`print()\` a status line or write a Markdown file containing a common Unicode symbol, the encoder raises and the rebuild exits 1. The graph then stays stale until the user runs graphify manually, which defeats the whole point of the hook.

## Reproduction

1. On a Windows machine with graphify installed, create a knowledge graph in any repo whose output contains a \`≤\` or similar char. This happens naturally with most technical docs.
2. \`graphify hook install\`
3. Commit any file. The hook prints \`[graphify hook] Rebuild failed: 'charmap' codec can't encode...\` and exits 1. Graph is not updated.

## Fix

In both \`_HOOK_SCRIPT\` and \`_CHECKOUT_SCRIPT\` templates in \`graphify/hooks.py\`:

1. **Shell-level:** set \`PYTHONIOENCODING=utf-8\` and \`PYTHONUTF8=1\` before invoking the Python interpreter. \`PYTHONUTF8=1\` is the Python 3.7+ UTF-8 mode, which covers both stdio AND file I/O (so file writes inside \`graphify.watch\` become UTF-8 as well).
2. **Python-level belt and suspenders:** inside the inline Python block, call \`sys.stdout.reconfigure(encoding='utf-8', errors='replace')\` and the same for \`sys.stderr\`. This covers the edge case where some exotic shell wrapper drops the env vars before Python starts. The \`errors='replace'\` fallback means any truly unmappable char becomes \`?\` instead of raising, so the rebuild always completes.

**No behavior change on macOS/Linux**, where stdio is already UTF-8 by default and the env vars are no-ops.

## Verification

On Python 3.12 / Windows 10, running the exact failing code path manually:

\`\`\`bash
PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python -c \"from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))\"
\`\`\`

Before the fix: crashes with the charmap error.
After the fix: prints \`[graphify watch] Rebuilt: 10 nodes, 11 edges, 3 communities\` and cleanly regenerates \`graph.json\` and \`GRAPH_REPORT.md\`.

After applying the same change to an existing \`.git/hooks/post-commit\` file on disk, subsequent commits run the hook without error for the first time since the bug started.

## Test plan

- [x] Manual reproduction on Python 3.12 / Windows 10
- [x] Direct \`_rebuild_code\` call succeeds under the new env vars
- [x] Post-commit hook no longer exits 1 on real commits after the patch
- [ ] CI: no new CI added. The existing test suite (if any covers hook generation) should still pass since the change is additive and the templates remain valid shell + Python syntax.

## Out of scope

- Not touching \`graphify.watch\` internals. The fix is at the shell wrapper boundary so any future code paths inside graphify also benefit without changes.
- Not adding Python version checks. \`PYTHONUTF8\` is supported on Python 3.7+; the minimum Python required by graphify is already newer.

Thanks for graphify. This bug was cascading through every commit in a 244-note Obsidian vault using graphify for its knowledge graph, and the fix was simple enough to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)