### PR TITLE
Add Dart/Flutter language support for AST extraction

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,7 +18,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.dart'}
 DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -600,6 +600,48 @@ def _import_swift(node, source: bytes, file_nid: str, stem: str, edges: list, st
             break
 
 
+def _import_dart(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
+    """Extract imports from Dart import_or_export nodes."""
+    for child in node.children:
+        if child.type == "library_import":
+            for sub in child.children:
+                if sub.type == "import_specification":
+                    for part in sub.children:
+                        if part.type == "configurable_uri":
+                            raw = _read_text(part, source).strip("'\"")
+                            # 'package:flutter/material.dart' → material
+                            # 'dart:async' → async
+                            segment = raw.rsplit("/", 1)[-1]
+                            if segment.endswith(".dart"):
+                                segment = segment[:-5]
+                            module_name = segment.split(":")[-1]
+                            if module_name:
+                                tgt_nid = _make_id(module_name)
+                                edges.append({
+                                    "source": file_nid,
+                                    "target": tgt_nid,
+                                    "relation": "imports",
+                                    "confidence": "EXTRACTED",
+                                    "source_file": str_path,
+                                    "source_location": f"L{node.start_point[0] + 1}",
+                                    "weight": 1.0,
+                                })
+                            return
+
+
+_DART_CONFIG = LanguageConfig(
+    ts_module="tree_sitter_dart_orchard",
+    class_types=frozenset({"class_definition", "mixin_declaration", "enum_declaration", "extension_declaration"}),
+    function_types=frozenset({"function_signature"}),
+    import_types=frozenset({"import_or_export"}),
+    call_types=frozenset(),
+    name_fallback_child_types=("identifier",),
+    body_fallback_child_types=("class_body", "enum_body", "extension_body"),
+    function_boundary_types=frozenset({"function_signature"}),
+    import_handler=_import_dart,
+)
+
+
 _SWIFT_CONFIG = LanguageConfig(
     ts_module="tree_sitter_swift",
     class_types=frozenset({"class_declaration", "protocol_declaration"}),
@@ -836,8 +878,10 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                 return
 
         # Default: recurse
+        # Dart: method_signature wraps function_signature — propagate class context
+        propagate_class = parent_class_nid if t == "method_signature" else None
         for child in node.children:
-            walk(child, parent_class_nid=None)
+            walk(child, parent_class_nid=propagate_class)
 
     walk(root)
 
@@ -1144,6 +1188,11 @@ def extract_php(path: Path) -> dict:
 def extract_lua(path: Path) -> dict:
     """Extract functions, methods, require() imports, and calls from a .lua file."""
     return _extract_generic(path, _LUA_CONFIG)
+
+
+def extract_dart(path: Path) -> dict:
+    """Extract classes, mixins, enums, extensions, functions, and imports from a .dart file."""
+    return _extract_generic(path, _DART_CONFIG)
 
 
 def extract_swift(path: Path) -> dict:
@@ -2612,6 +2661,7 @@ def extract(paths: list[Path]) -> dict:
         ".kts": extract_kotlin,
         ".scala": extract_scala,
         ".php": extract_php,
+        ".dart": extract_dart,
         ".swift": extract_swift,
         ".lua": extract_lua,
         ".toc": extract_lua,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tree-sitter-elixir",
     "tree-sitter-objc",
     "tree-sitter-julia",
+    "tree-sitter-dart-orchard",
 ]
 
 [project.urls]

--- a/tests/fixtures/sample.dart
+++ b/tests/fixtures/sample.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  final String title;
+
+  const MyWidget({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(child: Text(title));
+  }
+
+  void _refresh() {
+    print('refreshing');
+  }
+}
+
+mixin Loggable {
+  void log(String message) {
+    print(message);
+  }
+}
+
+enum Status { active, inactive, pending }
+
+extension StringExt on String {
+  bool get isBlank => trim().isEmpty;
+}
+
+void main() {
+  runApp(MyWidget(title: 'Hello'));
+}
+
+Future<int> fetchData(String url) async {
+  await Future.delayed(Duration(seconds: 1));
+  return 42;
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,11 +1,11 @@
-"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia."""
+"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia, Dart."""
 from __future__ import annotations
 from pathlib import Path
 import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
-    extract_swift, extract_go, extract_julia,
+    extract_swift, extract_go, extract_julia, extract_dart,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -505,6 +505,51 @@ def test_julia_finds_calls():
 
 def test_julia_no_dangling_edges():
     r = extract_julia(FIXTURES / "sample.jl")
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"Dangling source: {e}"
+
+
+# ── Dart ────────────────────────────────────────────────────────────────────
+
+def test_dart_no_error():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert "error" not in r
+
+def test_dart_finds_class():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert any("MyWidget" in l for l in _labels(r))
+
+def test_dart_finds_mixin():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert any("Loggable" in l for l in _labels(r))
+
+def test_dart_finds_enum():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert any("Status" in l for l in _labels(r))
+
+def test_dart_finds_extension():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert any("StringExt" in l for l in _labels(r))
+
+def test_dart_finds_methods():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("build" in l for l in labels)
+    assert any("log" in l for l in labels)
+
+def test_dart_finds_function():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("main" in l for l in labels)
+    assert any("fetchData" in l for l in labels)
+
+def test_dart_finds_imports():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert "imports" in _relations(r)
+
+def test_dart_no_dangling_edges():
+    r = extract_dart(FIXTURES / "sample.dart")
     node_ids = {n["id"] for n in r["nodes"]}
     for e in r["edges"]:
         assert e["source"] in node_ids, f"Dangling source: {e}"


### PR DESCRIPTION
## Summary
  - Add tree-sitter-dart-orchard as Dart parser dependency
  - Register `.dart` in CODE_EXTENSIONS and _DISPATCH
  - Extract classes, mixins, enums, extensions, functions, imports and method relationships
  - Propagate class context through Dart's `method_signature` wrapper nodes
  - Add sample.dart fixture and 9 test cases

  ## Test plan
  - [x] `pytest tests/test_languages.py -k dart` — 9 passed
  - [x] `pytest tests/` — 434 passed, no regression
  - [x] Verified on real Flutter production files