### PR TITLE
Fix executable checks for hooks on Windows

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,9 +1,9 @@
 """Tests for hooks.py - git hook install/uninstall."""
+import os
 import subprocess
 from pathlib import Path
 import pytest
 from graphify.hooks import install, uninstall, status, _HOOK_MARKER, _CHECKOUT_MARKER
-
 
 def _make_git_repo(tmp_path: Path) -> Path:
     subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
@@ -23,7 +23,10 @@ def test_install_is_executable(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
     hook = repo / ".git" / "hooks" / "post-commit"
-    assert hook.stat().st_mode & 0o111  # executable bit set
+    if os.name == "nt":
+        assert hook.read_text(encoding="utf-8").startswith("#!/bin/sh\n")
+    else:
+        assert hook.stat().st_mode & 0o111  # executable bit set
 
 
 def test_install_idempotent(tmp_path):
@@ -92,7 +95,10 @@ def test_install_post_checkout_is_executable(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)
     hook = repo / ".git" / "hooks" / "post-checkout"
-    assert hook.stat().st_mode & 0o111
+    if os.name == "nt":
+        assert hook.read_text(encoding="utf-8").startswith("#!/bin/sh\n")
+    else:
+        assert hook.stat().st_mode & 0o111
 
 
 def test_uninstall_removes_post_checkout_hook(tmp_path):


### PR DESCRIPTION
## Summary

Fix #279 the Windows hook tests so they validate a Windows-meaningful invariant instead of relying on POSIX executable bits.

## What changed

- Keep the existing executable-bit assertions on non-Windows platforms
- On Windows, assert that installed git hooks start with `#!/bin/sh`
- Leave production hook behavior unchanged

## Why

`st_mode & 0o111` is not reliable on Windows filesystems, which caused the hook tests to fail even though the generated hooks were valid for Git for Windows.

This keeps the test intent intact:
- POSIX still verifies executable permissions
- Windows verifies the hook script shape Git for Windows expects

## Testing

- `python -m pytest tests\test_hooks.py -q --tb=short`
- `python -m pytest tests\ -q --tb=short`