### PR TITLE
Fix uninstall logic to be platform-aware

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -566,7 +566,7 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
 
 
 def _agents_install(project_dir: Path, platform: str) -> None:
-    """Write the graphify section to the local AGENTS.md (Codex/OpenCode/OpenClaw)."""
+    """Write the graphify section to the local AGENTS.md for AGENTS-based platforms."""
     target = (project_dir or Path(".")) / "AGENTS.md"
 
     if target.exists():
@@ -594,33 +594,35 @@ def _agents_install(project_dir: Path, platform: str) -> None:
         print(f"{platform.capitalize()} — the AGENTS.md rules are the always-on mechanism.")
 
 
-def _agents_uninstall(project_dir: Path) -> None:
-    """Remove the graphify section from the local AGENTS.md."""
-    target = (project_dir or Path(".")) / "AGENTS.md"
+def _agents_uninstall(project_dir: Path, platform: str) -> None:
+    """Remove the graphify section from AGENTS.md and any platform-owned state."""
+    base_dir = project_dir or Path(".")
+    target = base_dir / "AGENTS.md"
 
     if not target.exists():
         print("No AGENTS.md found in current directory - nothing to do")
-        return
-
-    content = target.read_text(encoding="utf-8")
-    if _AGENTS_MD_MARKER not in content:
-        print("graphify section not found in AGENTS.md - nothing to do")
-        return
-
-    cleaned = re.sub(
-        r"\n*## graphify\n.*?(?=\n## |\Z)",
-        "",
-        content,
-        flags=re.DOTALL,
-    ).rstrip()
-    if cleaned:
-        target.write_text(cleaned + "\n", encoding="utf-8")
-        print(f"graphify section removed from {target.resolve()}")
     else:
-        target.unlink()
-        print(f"AGENTS.md was empty after removal - deleted {target.resolve()}")
+        content = target.read_text(encoding="utf-8")
+        if _AGENTS_MD_MARKER not in content:
+            print("graphify section not found in AGENTS.md - nothing to do")
+        else:
+            cleaned = re.sub(
+                r"\n*## graphify\n.*?(?=\n## |\Z)",
+                "",
+                content,
+                flags=re.DOTALL,
+            ).rstrip()
+            if cleaned:
+                target.write_text(cleaned + "\n", encoding="utf-8")
+                print(f"graphify section removed from {target.resolve()}")
+            else:
+                target.unlink()
+                print(f"AGENTS.md was empty after removal - deleted {target.resolve()}")
 
-    _uninstall_opencode_plugin(project_dir or Path("."))
+    if platform == "opencode":
+        _uninstall_opencode_plugin(base_dir)
+    elif platform == "codex":
+        _uninstall_codex_hook(base_dir)
 
 
 def claude_install(project_dir: Path | None = None) -> None:
@@ -842,9 +844,7 @@ def main() -> None:
         if subcmd == "install":
             _agents_install(Path("."), cmd)
         elif subcmd == "uninstall":
-            _agents_uninstall(Path("."))
-            if cmd == "codex":
-                _uninstall_codex_hook(Path("."))
+            _agents_uninstall(Path("."), cmd)
         else:
             print(f"Usage: graphify {cmd} [install|uninstall]", file=sys.stderr)
             sys.exit(1)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -484,20 +484,22 @@ def _install_opencode_plugin(project_dir: Path) -> None:
         print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin already registered (no change)")
 
 
-def _uninstall_opencode_plugin(project_dir: Path) -> None:
+def _uninstall_opencode_plugin(project_dir: Path) -> bool:
     """Remove graphify.js plugin and deregister from opencode.json."""
+    changed = False
     plugin_file = project_dir / _OPENCODE_PLUGIN_PATH
     if plugin_file.exists():
         plugin_file.unlink()
+        changed = True
         print(f"  {_OPENCODE_PLUGIN_PATH}  ->  removed")
 
     config_file = project_dir / _OPENCODE_CONFIG_PATH
     if not config_file.exists():
-        return
+        return changed
     try:
         config = json.loads(config_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
-        return
+        return changed
     plugins = config.get("plugin", [])
     entry = str(_OPENCODE_PLUGIN_PATH)
     if entry in plugins:
@@ -505,7 +507,9 @@ def _uninstall_opencode_plugin(project_dir: Path) -> None:
         if not plugins:
             config.pop("plugin")
         config_file.write_text(json.dumps(config, indent=2), encoding="utf-8")
+        changed = True
         print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin deregistered")
+    return changed
 
 
 _CODEX_HOOK = {
@@ -549,20 +553,23 @@ def _install_codex_hook(project_dir: Path) -> None:
     print(f"  .codex/hooks.json  ->  PreToolUse hook registered")
 
 
-def _uninstall_codex_hook(project_dir: Path) -> None:
+def _uninstall_codex_hook(project_dir: Path) -> bool:
     """Remove graphify PreToolUse hook from .codex/hooks.json."""
     hooks_path = project_dir / ".codex" / "hooks.json"
     if not hooks_path.exists():
-        return
+        return False
     try:
         existing = json.loads(hooks_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
-        return
+        return False
     pre_tool = existing.get("hooks", {}).get("PreToolUse", [])
     filtered = [h for h in pre_tool if "graphify" not in str(h)]
+    if len(filtered) == len(pre_tool):
+        return False
     existing["hooks"]["PreToolUse"] = filtered
     hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
+    return True
 
 
 def _agents_install(project_dir: Path, platform: str) -> None:
@@ -598,13 +605,15 @@ def _agents_uninstall(project_dir: Path, platform: str) -> None:
     """Remove the graphify section from AGENTS.md and any platform-owned state."""
     base_dir = project_dir or Path(".")
     target = base_dir / "AGENTS.md"
+    agents_status = ""
+    agents_changed = False
 
     if not target.exists():
-        print("No AGENTS.md found in current directory - nothing to do")
+        agents_status = "No AGENTS.md found in current directory"
     else:
         content = target.read_text(encoding="utf-8")
         if _AGENTS_MD_MARKER not in content:
-            print("graphify section not found in AGENTS.md - nothing to do")
+            agents_status = "graphify section not found in AGENTS.md"
         else:
             cleaned = re.sub(
                 r"\n*## graphify\n.*?(?=\n## |\Z)",
@@ -614,15 +623,24 @@ def _agents_uninstall(project_dir: Path, platform: str) -> None:
             ).rstrip()
             if cleaned:
                 target.write_text(cleaned + "\n", encoding="utf-8")
+                agents_changed = True
                 print(f"graphify section removed from {target.resolve()}")
             else:
                 target.unlink()
+                agents_changed = True
                 print(f"AGENTS.md was empty after removal - deleted {target.resolve()}")
 
+    platform_changed = False
     if platform == "opencode":
-        _uninstall_opencode_plugin(base_dir)
+        platform_changed = _uninstall_opencode_plugin(base_dir)
     elif platform == "codex":
-        _uninstall_codex_hook(base_dir)
+        platform_changed = _uninstall_codex_hook(base_dir)
+
+    if agents_status:
+        if not agents_changed and not platform_changed:
+            print(f"{agents_status} - nothing to do")
+        else:
+            print(agents_status)
 
 
 def claude_install(project_dir: Path | None = None) -> None:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -181,7 +181,7 @@ def test_agents_uninstall_preserves_other_content(tmp_path):
 def test_agents_uninstall_no_op_when_not_installed(tmp_path, capsys):
     _agents_uninstall(tmp_path, "codex")
     out = capsys.readouterr().out
-    assert "nothing to do" in out
+    assert "No AGENTS.md found in current directory - nothing to do" in out
 
 
 @pytest.mark.parametrize("platform", ["codex", "aider", "claw", "droid", "trae", "trae-cn"])
@@ -268,6 +268,62 @@ def test_opencode_agents_uninstall_cleans_plugin_without_graphify_section(tmp_pa
     if config_file.exists():
         config = json.loads(config_file.read_text())
         assert not any("graphify.js" in p for p in config.get("plugin", []))
+
+
+def test_codex_agents_uninstall_missing_agents_reports_cleanup_not_noop(tmp_path, capsys):
+    """codex uninstall should not claim no-op when it still removes its hook."""
+    _agents_install(tmp_path, "codex")
+    (tmp_path / "AGENTS.md").unlink()
+
+    _agents_uninstall(tmp_path, "codex")
+
+    out = capsys.readouterr().out
+    assert "No AGENTS.md found in current directory" in out
+    assert "nothing to do" not in out
+    assert ".codex/hooks.json  ->  PreToolUse hook removed" in out
+
+
+def test_opencode_agents_uninstall_missing_agents_reports_cleanup_not_noop(tmp_path, capsys):
+    """opencode uninstall should not claim no-op when it still removes plugin state."""
+    _agents_install(tmp_path, "opencode")
+    (tmp_path / "AGENTS.md").unlink()
+
+    _agents_uninstall(tmp_path, "opencode")
+
+    out = capsys.readouterr().out
+    assert "No AGENTS.md found in current directory" in out
+    assert "nothing to do" not in out
+    assert "graphify.js  ->  removed" in out
+    assert "opencode.json  ->  plugin deregistered" in out
+
+
+def test_opencode_agents_uninstall_missing_marker_reports_cleanup_not_noop(tmp_path, capsys):
+    """opencode uninstall should not claim no-op when AGENTS.md lacks the marker but plugin state exists."""
+    _agents_install(tmp_path, "opencode")
+    (tmp_path / "AGENTS.md").write_text("# Existing rules\n", encoding="utf-8")
+
+    _agents_uninstall(tmp_path, "opencode")
+
+    out = capsys.readouterr().out
+    assert "graphify section not found in AGENTS.md" in out
+    assert "nothing to do" not in out
+    assert "graphify.js  ->  removed" in out
+
+
+def test_opencode_agents_uninstall_true_noop_reports_nothing_to_do(tmp_path, capsys):
+    """opencode uninstall should report no-op only when neither AGENTS nor plugin state exists."""
+    _agents_uninstall(tmp_path, "opencode")
+
+    out = capsys.readouterr().out
+    assert "No AGENTS.md found in current directory - nothing to do" in out
+
+
+def test_codex_agents_uninstall_true_noop_reports_nothing_to_do(tmp_path, capsys):
+    """codex uninstall should report no-op only when neither AGENTS nor hook state exists."""
+    _agents_uninstall(tmp_path, "codex")
+
+    out = capsys.readouterr().out
+    assert "No AGENTS.md found in current directory - nothing to do" in out
 
 
 # ── Cursor ────────────────────────────────────────────────────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 """Tests for graphify install --platform routing."""
+import json
 from pathlib import Path
 from unittest.mock import patch
 import pytest
@@ -116,9 +117,9 @@ def _agents_install(tmp_path, platform):
     _install_fn(tmp_path, platform)
 
 
-def _agents_uninstall(tmp_path):
+def _agents_uninstall(tmp_path, platform):
     from graphify.__main__ import _agents_uninstall as _uninstall_fn
-    _uninstall_fn(tmp_path)
+    _uninstall_fn(tmp_path, platform)
 
 
 def test_codex_agents_install_writes_agents_md(tmp_path):
@@ -159,7 +160,7 @@ def test_agents_install_appends_to_existing(tmp_path):
 
 def test_agents_uninstall_removes_section(tmp_path):
     _agents_install(tmp_path, "codex")
-    _agents_uninstall(tmp_path)
+    _agents_uninstall(tmp_path, "codex")
     agents_md = tmp_path / "AGENTS.md"
     # File deleted when it only contained graphify section
     assert not agents_md.exists()
@@ -170,7 +171,7 @@ def test_agents_uninstall_preserves_other_content(tmp_path):
     agents_md = tmp_path / "AGENTS.md"
     agents_md.write_text("# Existing rules\n\nDo not break things.\n")
     _agents_install(tmp_path, "codex")
-    _agents_uninstall(tmp_path)
+    _agents_uninstall(tmp_path, "codex")
     assert agents_md.exists()
     content = agents_md.read_text()
     assert "Do not break things." in content
@@ -178,9 +179,33 @@ def test_agents_uninstall_preserves_other_content(tmp_path):
 
 
 def test_agents_uninstall_no_op_when_not_installed(tmp_path, capsys):
-    _agents_uninstall(tmp_path)
+    _agents_uninstall(tmp_path, "codex")
     out = capsys.readouterr().out
     assert "nothing to do" in out
+
+
+@pytest.mark.parametrize("platform", ["codex", "aider", "claw", "droid", "trae", "trae-cn"])
+def test_non_opencode_agents_uninstall_preserves_opencode_plugin(tmp_path, platform):
+    """Only opencode uninstall should remove opencode plugin state."""
+    _agents_install(tmp_path, "opencode")
+    _agents_uninstall(tmp_path, platform)
+
+    plugin = tmp_path / ".opencode" / "plugins" / "graphify.js"
+    assert plugin.exists()
+
+    config_file = tmp_path / "opencode.json"
+    config = json.loads(config_file.read_text())
+    assert any("graphify.js" in p for p in config.get("plugin", []))
+
+
+def test_codex_agents_uninstall_removes_codex_hook(tmp_path):
+    """codex uninstall removes the PreToolUse hook it owns."""
+    _agents_install(tmp_path, "codex")
+    _agents_uninstall(tmp_path, "codex")
+
+    hooks_file = tmp_path / ".codex" / "hooks.json"
+    hooks = json.loads(hooks_file.read_text())
+    assert not any("graphify" in str(h) for h in hooks.get("hooks", {}).get("PreToolUse", []))
 
 
 # --- OpenCode plugin tests ---
@@ -198,32 +223,50 @@ def test_opencode_agents_install_registers_plugin_in_config(tmp_path):
     _agents_install(tmp_path, "opencode")
     config_file = tmp_path / "opencode.json"
     assert config_file.exists()
-    import json as _json
-    config = _json.loads(config_file.read_text())
+    config = json.loads(config_file.read_text())
     assert any("graphify.js" in p for p in config.get("plugin", []))
 
 
 def test_opencode_agents_install_merges_existing_config(tmp_path):
     """opencode install preserves existing opencode.json keys."""
-    import json as _json
     config_file = tmp_path / "opencode.json"
-    config_file.write_text(_json.dumps({"model": "claude-opus-4-5", "plugin": []}))
+    config_file.write_text(json.dumps({"model": "claude-opus-4-5", "plugin": []}))
     _agents_install(tmp_path, "opencode")
-    config = _json.loads(config_file.read_text())
+    config = json.loads(config_file.read_text())
     assert config["model"] == "claude-opus-4-5"
     assert any("graphify.js" in p for p in config["plugin"])
 
 
 def test_opencode_agents_uninstall_removes_plugin(tmp_path):
     """opencode uninstall removes the plugin file and deregisters from opencode.json."""
-    import json as _json
     _agents_install(tmp_path, "opencode")
-    _agents_uninstall(tmp_path)
+    _agents_uninstall(tmp_path, "opencode")
     plugin = tmp_path / ".opencode" / "plugins" / "graphify.js"
     assert not plugin.exists()
     config_file = tmp_path / "opencode.json"
     if config_file.exists():
-        config = _json.loads(config_file.read_text())
+        config = json.loads(config_file.read_text())
+        assert not any("graphify.js" in p for p in config.get("plugin", []))
+
+
+@pytest.mark.parametrize("agents_state", ["missing", "no_marker"])
+def test_opencode_agents_uninstall_cleans_plugin_without_graphify_section(tmp_path, agents_state):
+    """opencode uninstall still removes plugin state without a graphify AGENTS.md section."""
+    _agents_install(tmp_path, "opencode")
+    agents_md = tmp_path / "AGENTS.md"
+    if agents_state == "missing":
+        agents_md.unlink()
+    else:
+        agents_md.write_text("# Existing rules\n", encoding="utf-8")
+
+    _agents_uninstall(tmp_path, "opencode")
+
+    plugin = tmp_path / ".opencode" / "plugins" / "graphify.js"
+    assert not plugin.exists()
+
+    config_file = tmp_path / "opencode.json"
+    if config_file.exists():
+        config = json.loads(config_file.read_text())
         assert not any("graphify.js" in p for p in config.get("plugin", []))
 
 


### PR DESCRIPTION
## Summary

Fix #276 AGENTS-based uninstall behavior so platform-specific cleanup only runs for the owning platform.

## What changed

- Made the shared AGENTS uninstall path platform-aware
- Limited OpenCode plugin removal to `graphify opencode uninstall`
- Moved Codex hook removal into the same platform-aware uninstall flow
- Left other AGENTS-based platforms (`aider`, `claw`, `droid`, `trae`, `trae-cn`) to remove only the `AGENTS.md` section they own

## Why

Uninstalling one AGENTS-based platform could remove OpenCode plugin state from the repo, even when OpenCode was not the platform being uninstalled. This broke multi-platform setups and made uninstall behavior unsafe across shared AGENTS.md integrations.

## Tests

- Added regression coverage to ensure non-OpenCode AGENTS uninstalls preserve OpenCode plugin state
- Added coverage to ensure Codex uninstall still removes its hook
- Added coverage for OpenCode uninstall when `AGENTS.md` is missing or no longer contains the graphify section

## Validation

- `python -m pytest tests/test_install.py -q --tb=short`
- `python -m graphify --help`
- Temp-dir smoke tests for:
  - `python -m graphify codex uninstall`
  - `python -m graphify opencode uninstall`