### PR TITLE
fix: diacritic-insensitive query scoring and relevance-based output ordering

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -926,9 +926,10 @@ def main() -> None:
         if not scored:
             print("No matching nodes found.")
             sys.exit(0)
+        score_map = {nid: s for s, nid in scored}
         start = [nid for _, nid in scored[:5]]
         nodes, edges = (_dfs if use_dfs else _bfs)(G, start, depth=2)
-        print(_subgraph_to_text(G, nodes, edges, token_budget=budget))
+        print(_subgraph_to_text(G, nodes, edges, token_budget=budget, node_scores=score_map))
     elif cmd == "save-result":
         # graphify save-result --question Q --answer A --type T [--nodes N1 N2 ...]
         import argparse as _ap

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 import json
 import sys
+import unicodedata
 from pathlib import Path
 import networkx as nx
 from networkx.readwrite import json_graph
 from graphify.security import sanitize_label
+
+
+def _strip_diacritics(text: str) -> str:
+    """Normalize diacritics: ćwiczenia → cwiczenia, résumé → resume, etc."""
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
 
 
 def _load_graph(graph_path: str) -> nx.Graph:
@@ -40,11 +47,18 @@ def _communities_from_graph(G: nx.Graph) -> dict[int, list[str]]:
 
 
 def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
+    """Score nodes by keyword match. Diacritic-insensitive: 'cwiczenia' matches 'ćwiczenia'."""
+    norm_terms = [_strip_diacritics(t) for t in terms]
     scored = []
     for nid, data in G.nodes(data=True):
         label = data.get("label", "").lower()
         source = data.get("source_file", "").lower()
-        score = sum(1 for t in terms if t in label) + sum(0.5 for t in terms if t in source)
+        norm_label = _strip_diacritics(label)
+        norm_source = _strip_diacritics(source)
+        score = (
+            sum(1 for t, nt in zip(terms, norm_terms) if t in label or nt in norm_label)
+            + sum(0.5 for t, nt in zip(terms, norm_terms) if t in source or nt in norm_source)
+        )
         if score > 0:
             scored.append((score, nid))
     return sorted(scored, reverse=True)
@@ -82,11 +96,22 @@ def _dfs(G: nx.Graph, start_nodes: list[str], depth: int) -> tuple[set[str], lis
     return visited, edges_seen
 
 
-def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_budget: int = 2000) -> str:
-    """Render subgraph as text, cutting at token_budget (approx 3 chars/token)."""
+def _subgraph_to_text(
+    G: nx.Graph,
+    nodes: set[str],
+    edges: list[tuple],
+    token_budget: int = 2000,
+    node_scores: dict[str, float] | None = None,
+) -> str:
+    """Render subgraph as text, cutting at token_budget (approx 3 chars/token).
+
+    Nodes are sorted by query relevance score first, then by degree as
+    tiebreaker so that direct matches always appear before traversal neighbors.
+    """
     char_budget = token_budget * 3
+    scores = node_scores or {}
     lines = []
-    for nid in sorted(nodes, key=lambda n: G.degree(n), reverse=True):
+    for nid in sorted(nodes, key=lambda n: (scores.get(n, 0), G.degree(n)), reverse=True):
         d = G.nodes[nid]
         line = f"NODE {sanitize_label(d.get('label', nid))} [src={d.get('source_file', '')} loc={d.get('source_location', '')} community={d.get('community', '')}]"
         lines.append(line)
@@ -102,10 +127,13 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
 
 
 def _find_node(G: nx.Graph, label: str) -> list[str]:
-    """Return node IDs whose label or ID matches the search term (case-insensitive)."""
+    """Return node IDs whose label or ID matches the search term (case-insensitive, diacritic-insensitive)."""
     term = label.lower()
+    norm_term = _strip_diacritics(term)
     return [nid for nid, d in G.nodes(data=True)
-            if term in d.get("label", "").lower() or term == nid.lower()]
+            if term in d.get("label", "").lower()
+            or norm_term in _strip_diacritics(d.get("label", "").lower())
+            or term == nid.lower()]
 
 
 def _filter_blank_stdin() -> None:
@@ -235,17 +263,18 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         start_nodes = [nid for _, nid in scored[:3]]
         if not start_nodes:
             return "No matching nodes found."
+        score_map = {nid: s for s, nid in scored}
         nodes, edges = _dfs(G, start_nodes, depth) if mode == "dfs" else _bfs(G, start_nodes, depth)
         header = f"Traversal: {mode.upper()} depth={depth} | Start: {[G.nodes[n].get('label', n) for n in start_nodes]} | {len(nodes)} nodes found\n\n"
-        return header + _subgraph_to_text(G, nodes, edges, budget)
+        return header + _subgraph_to_text(G, nodes, edges, budget, node_scores=score_map)
 
     def _tool_get_node(arguments: dict) -> str:
-        label = arguments["label"].lower()
-        matches = [(nid, d) for nid, d in G.nodes(data=True)
-                   if label in d.get("label", "").lower() or label == nid.lower()]
-        if not matches:
+        label = arguments["label"]
+        matched_ids = _find_node(G, label)
+        if not matched_ids:
             return f"No node matching '{label}' found."
-        nid, d = matches[0]
+        nid = matched_ids[0]
+        d = G.nodes[nid]
         return "\n".join([
             f"Node: {d.get('label', nid)}",
             f"  ID: {nid}",

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -6,7 +6,9 @@ from networkx.readwrite import json_graph
 
 from graphify.serve import (
     _communities_from_graph,
+    _find_node,
     _score_nodes,
+    _strip_diacritics,
     _bfs,
     _dfs,
     _subgraph_to_text,
@@ -151,3 +153,92 @@ def test_load_graph_missing_file(tmp_path):
     graphify_dir.mkdir()
     with pytest.raises(SystemExit):
         _load_graph(str(graphify_dir / "nonexistent.json"))
+
+
+# --- _strip_diacritics ---
+
+def test_strip_diacritics_polish():
+    assert _strip_diacritics("ćwiczenia") == "cwiczenia"
+    assert _strip_diacritics("źródło") == "zrodło"  # ł (stroke) is not a combining char
+    # ł stays because NFKD doesn't decompose stroked letters;
+    # ć, ź, ó are accent+base and do decompose correctly.
+    assert _strip_diacritics("ćwiczenia z lukami") == "cwiczenia z lukami"
+
+def test_strip_diacritics_french():
+    assert _strip_diacritics("résumé") == "resume"
+    assert _strip_diacritics("naïve") == "naive"
+
+def test_strip_diacritics_ascii_passthrough():
+    assert _strip_diacritics("hello world") == "hello world"
+    assert _strip_diacritics("") == ""
+
+
+# --- _score_nodes diacritic-insensitive ---
+
+def _make_diacritic_graph() -> nx.Graph:
+    G = nx.Graph()
+    G.add_node("d1", label="Přehled základních cvičení",
+               source_file="docs/zakladni-cviceni.md",
+               source_location=None, community=5)
+    G.add_node("d2", label="Tréninkový plán",
+               source_file="docs/treninkovy-plan.md",
+               source_location=None, community=5)
+    G.add_node("d3", label="Préparation du résumé",
+               source_file="notes/preparation-resume.md",
+               source_location=None, community=1)
+    G.add_edge("d1", "d2", relation="related", confidence="INFERRED")
+    return G
+
+def test_score_nodes_ascii_matches_diacritic_label():
+    """The motivating bug: ASCII 'cviceni' must match 'cvičení' (stripped from 'Přehled základních cvičení')."""
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["prehled", "cviceni"])
+    nids = [nid for _, nid in scored]
+    assert "d1" in nids
+    assert scored[0][1] == "d1"  # highest score
+
+def test_score_nodes_diacritic_query_matches_diacritic_label():
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["přehled"])
+    nids = [nid for _, nid in scored]
+    assert "d1" in nids
+
+def test_score_nodes_french_diacritics():
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["resume"])
+    nids = [nid for _, nid in scored]
+    assert "d3" in nids
+
+
+# --- _find_node diacritic-insensitive ---
+
+def test_find_node_ascii_query_diacritic_label():
+    G = _make_diacritic_graph()
+    matches = _find_node(G, "prehled")
+    assert "d1" in matches
+
+def test_find_node_diacritic_query_diacritic_label():
+    G = _make_diacritic_graph()
+    matches = _find_node(G, "přehled")
+    assert "d1" in matches
+
+
+# --- _subgraph_to_text relevance ordering ---
+
+def test_subgraph_to_text_relevance_ordering():
+    """Nodes with higher scores appear before high-degree but low-score nodes."""
+    G = _make_diacritic_graph()
+    scores = {"d1": 2.0, "d2": 0.5}
+    text = _subgraph_to_text(G, {"d1", "d2"}, [], node_scores=scores)
+    lines = text.strip().split("\n")
+    # d1 (score=2.0) must appear before d2 (score=0.5)
+    d1_pos = next(i for i, l in enumerate(lines) if "Přehled" in l or "cviceni" in l)
+    d2_pos = next(i for i, l in enumerate(lines) if "Tréninkový" in l)
+    assert d1_pos < d2_pos
+
+def test_subgraph_to_text_no_scores_falls_back_to_degree():
+    """Without node_scores, original degree-based ordering is preserved."""
+    G = _make_diacritic_graph()
+    # No node_scores passed — backward-compatible behavior
+    text = _subgraph_to_text(G, {"d1", "d2"}, [])
+    assert "NODE" in text


### PR DESCRIPTION
## Problem

Querying `graphify query "cwiczenia z lukami"` fails to match a node labeled **"Ćwiczenia z lukami – dlaczego są do bani"** because Python's `in` operator does exact byte comparison — `c` (U+0063) ≠ `ć` (U+0107).

Additionally, matched nodes appear at the bottom of results because output is sorted by node degree (connection count) rather than query relevance. A perfectly matching node with few connections gets buried behind high-degree but irrelevant neighbors.

This affects all languages with diacritics: Polish (ć, ź, ó, ą, ę), French (é, è, ê), Czech (ř, ž, č), German (ä, ö, ü), etc.

## Fix

**1. Diacritic-insensitive matching** — `_strip_diacritics()` using `unicodedata.normalize("NFKD")` strips combining characters before comparison. Both the query and node labels are normalized, so `cwiczenia` matches `ćwiczenia`. Zero new dependencies (unicodedata is stdlib).

**2. Relevance-based output ordering** — `_subgraph_to_text()` now accepts optional `node_scores` and sorts by (score, degree) instead of degree alone. Direct query matches always appear before traversal neighbors.

**3. Consistent diacritic support** — Applied to `_score_nodes`, `_find_node`, and refactored `_tool_get_node` to use `_find_node` instead of duplicating inline matching logic.

## Backward compatibility

- `node_scores` defaults to `None` → falls back to degree-based ordering
- Existing exact matches still work (diacritic normalization is additive)
- No new dependencies

## Tests

10 new tests in `test_serve.py` covering:
- `_strip_diacritics` with Polish, French, and ASCII inputs
- `_score_nodes` with ASCII query vs diacritic labels
- `_find_node` diacritic-insensitive lookup
- `_subgraph_to_text` relevance ordering and fallback behavior