### PR TITLE
feat: add Dart/Flutter language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Sponsor](https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors)](https://github.com/sponsors/safishamsi)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Safi%20Shamsi-0077B5?logo=linkedin)](https://www.linkedin.com/in/safi-shamsi)
 
-**An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Aider, OpenClaw, Factory Droid, or Trae - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
+**An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Aider, OpenClaw, Factory Droid, Trae, or Google Antigravity - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
 
 Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, images in other languages, or video and audio files - graphify extracts concepts and relationships from all of it and connects them into one graph. Videos are transcribed with Whisper using a domain-aware prompt derived from your corpus. 23 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte, Dart/Flutter).
 
@@ -48,7 +48,7 @@ Every relationship is tagged `EXTRACTED` (found directly in source), `INFERRED` 
 
 ## Install
 
-**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
+**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), [Trae](https://trae.ai), or [Google Antigravity](https://antigravity.google)
 
 ```bash
 pip install graphifyy && graphify install
@@ -72,6 +72,7 @@ pip install graphifyy && graphify install
 | Trae CN | `graphify install --platform trae-cn` |
 | Gemini CLI | `graphify install --platform gemini` |
 | Cursor | `graphify cursor install` |
+| Google Antigravity | `graphify antigravity install` |
 
 Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw and Aider use sequential extraction (parallel agent support is still early on those platforms). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism.
 
@@ -100,6 +101,7 @@ After building a graph, run this once in your project:
 | Trae CN | `graphify trae-cn install` |
 | Cursor | `graphify cursor install` |
 | Gemini CLI | `graphify gemini install` |
+| Google Antigravity | `graphify antigravity install` |
 
 **Claude Code** does two things: writes a `CLAUDE.md` section telling Claude to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs a **PreToolUse hook** (`settings.json`) that fires before every Glob and Grep call. If a knowledge graph exists, Claude sees: _"graphify: Knowledge graph exists. Read GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ — so Claude navigates via the graph instead of grepping through every file.
 
@@ -112,6 +114,8 @@ After building a graph, run this once in your project:
 **Gemini CLI** copies the skill to `~/.gemini/skills/graphify/SKILL.md`, writes a `GEMINI.md` section, and installs a `BeforeTool` hook in `.gemini/settings.json` that fires before file-read tool calls — same always-on mechanism as Claude Code.
 
 **Aider and OpenClaw, Factory Droid, Trae** write the same rules to `AGENTS.md` in your project root. These platforms don't support tool hooks, so AGENTS.md is the always-on mechanism.
+
+**Google Antigravity** writes `.agent/rules/graphify.md` (always-on rules) and `.agent/workflows/graphify.md` (registers `/graphify` as a slash command). No hook equivalent exists in Antigravity — rules are the always-on mechanism.
 
 **GitHub Copilot CLI** copies the skill to `~/.copilot/skills/graphify/SKILL.md`. Run `graphify copilot install` to set it up.
 
@@ -160,6 +164,15 @@ python -m graphify.serve graphify-out/graph.json
 
 That gives the assistant structured graph access for repeated queries such as
 `query_graph`, `get_node`, `get_neighbors`, and `shortest_path`.
+
+> **WSL / Linux note:** Ubuntu ships `python3`, not `python`. Install into a project venv to avoid PEP 668 conflicts, and use the full venv path in your `.mcp.json`:
+> ```bash
+> python3 -m venv .venv && .venv/bin/pip install "graphifyy[mcp]"
+> ```
+> ```json
+> { "mcpServers": { "graphify": { "type": "stdio", "command": ".venv/bin/python3", "args": ["-m", "graphify.serve", "graphify-out/graph.json"] } } }
+> ```
+> Also note: the PyPI package is `graphifyy` (double-y) — `pip install graphify` installs an unrelated package.
 
 <details>
 <summary>Manual install (curl)</summary>
@@ -236,6 +249,8 @@ graphify trae install              # AGENTS.md (Trae)
 graphify trae uninstall
 graphify trae-cn install           # AGENTS.md (Trae CN)
 graphify trae-cn uninstall
+graphify antigravity install       # .agent/rules + .agent/workflows (Google Antigravity)
+graphify antigravity uninstall
 
 # query the graph directly from the terminal (no AI assistant needed)
 graphify query "what connects attention to the optimizer?"
@@ -323,9 +338,25 @@ graphify sends file contents to your AI coding assistant's underlying model API 
 
 NetworkX + Leiden (graspologic) + tree-sitter + vis.js. Semantic extraction via Claude (Claude Code), GPT-4 (Codex), or whichever model your platform runs. Video transcription via faster-whisper + yt-dlp (optional, `pip install graphifyy[video]`). No Neo4j required, no server, runs entirely locally.
 
+## Built on graphify — Penpax
+
+[**Penpax**](https://safishamsi.github.io/penpax.ai) is the enterprise layer on top of graphify. Where graphify turns a folder of files into a knowledge graph, Penpax applies the same graph to your entire working life — continuously.
+
+| | graphify | Penpax |
+|---|---|---|
+| Input | A folder of files | Browser history, meetings, emails, files, code — everything |
+| Runs | On demand | Continuously in the background |
+| Scope | A project | Your entire working life |
+| Query | CLI / MCP / AI skill | Natural language, always on |
+| Privacy | Local by default | Fully on-device, no cloud |
+
+Built for lawyers, consultants, executives, doctors, researchers — anyone whose work lives across hundreds of conversations and documents they can never fully reconstruct.
+
+**Free trial launching soon.** [Join the waitlist →](https://safishamsi.github.io/penpax.ai)
+
 ## What we are building next
 
-graphify is the graph layer. We are building [Penpax](https://safishamsi.github.io/penpax.ai) on top of it — an on-device digital twin that connects your meetings, browser history, files, emails, and code into one continuously updating knowledge graph. No cloud, no training on your data. [Join the waitlist.](https://safishamsi.github.io/penpax.ai)
+graphify is the graph layer. Penpax is the always-on layer on top of it — an on-device digital twin that connects your meetings, browser history, files, emails, and code into one continuously updating knowledge graph. No cloud, no training on your data. [Join the waitlist.](https://safishamsi.github.io/penpax.ai)
 
 ## Star history
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Sponsor](https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors)](https://github.com/sponsors/safishamsi)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Safi%20Shamsi-0077B5?logo=linkedin)](https://www.linkedin.com/in/safi-shamsi)
 
-**An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Aider, OpenClaw, Factory Droid, Trae, or Google Antigravity - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
+**An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Aider, OpenClaw, Factory Droid, or Trae - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
 
-Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, images in other languages, or video and audio files - graphify extracts concepts and relationships from all of it and connects them into one graph. Videos are transcribed with Whisper using a domain-aware prompt derived from your corpus. 22 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte).
+Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, images in other languages, or video and audio files - graphify extracts concepts and relationships from all of it and connects them into one graph. Videos are transcribed with Whisper using a domain-aware prompt derived from your corpus. 23 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte, Dart/Flutter).
 
 > Andrej Karpathy keeps a `/raw` folder where he drops papers, tweets, screenshots, and notes. graphify is the answer to that problem - 71.5x fewer tokens per query vs reading the raw files, persistent across sessions, honest about what it found vs guessed.
 
@@ -48,7 +48,7 @@ Every relationship is tagged `EXTRACTED` (found directly in source), `INFERRED` 
 
 ## Install
 
-**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), [Trae](https://trae.ai), or [Google Antigravity](https://antigravity.google)
+**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), or [Trae](https://trae.ai)
 
 ```bash
 pip install graphifyy && graphify install
@@ -72,7 +72,6 @@ pip install graphifyy && graphify install
 | Trae CN | `graphify install --platform trae-cn` |
 | Gemini CLI | `graphify install --platform gemini` |
 | Cursor | `graphify cursor install` |
-| Google Antigravity | `graphify antigravity install` |
 
 Codex users also need `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction. Factory Droid uses the `Task` tool for parallel subagent dispatch. OpenClaw and Aider use sequential extraction (parallel agent support is still early on those platforms). Trae uses the Agent tool for parallel subagent dispatch and does **not** support PreToolUse hooks — AGENTS.md is the always-on mechanism.
 
@@ -101,7 +100,6 @@ After building a graph, run this once in your project:
 | Trae CN | `graphify trae-cn install` |
 | Cursor | `graphify cursor install` |
 | Gemini CLI | `graphify gemini install` |
-| Google Antigravity | `graphify antigravity install` |
 
 **Claude Code** does two things: writes a `CLAUDE.md` section telling Claude to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs a **PreToolUse hook** (`settings.json`) that fires before every Glob and Grep call. If a knowledge graph exists, Claude sees: _"graphify: Knowledge graph exists. Read GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ — so Claude navigates via the graph instead of grepping through every file.
 
@@ -114,8 +112,6 @@ After building a graph, run this once in your project:
 **Gemini CLI** copies the skill to `~/.gemini/skills/graphify/SKILL.md`, writes a `GEMINI.md` section, and installs a `BeforeTool` hook in `.gemini/settings.json` that fires before file-read tool calls — same always-on mechanism as Claude Code.
 
 **Aider and OpenClaw, Factory Droid, Trae** write the same rules to `AGENTS.md` in your project root. These platforms don't support tool hooks, so AGENTS.md is the always-on mechanism.
-
-**Google Antigravity** writes `.agent/rules/graphify.md` (always-on rules) and `.agent/workflows/graphify.md` (registers `/graphify` as a slash command). No hook equivalent exists in Antigravity — rules are the always-on mechanism.
 
 **GitHub Copilot CLI** copies the skill to `~/.copilot/skills/graphify/SKILL.md`. Run `graphify copilot install` to set it up.
 
@@ -164,15 +160,6 @@ python -m graphify.serve graphify-out/graph.json
 
 That gives the assistant structured graph access for repeated queries such as
 `query_graph`, `get_node`, `get_neighbors`, and `shortest_path`.
-
-> **WSL / Linux note:** Ubuntu ships `python3`, not `python`. Install into a project venv to avoid PEP 668 conflicts, and use the full venv path in your `.mcp.json`:
-> ```bash
-> python3 -m venv .venv && .venv/bin/pip install "graphifyy[mcp]"
-> ```
-> ```json
-> { "mcpServers": { "graphify": { "type": "stdio", "command": ".venv/bin/python3", "args": ["-m", "graphify.serve", "graphify-out/graph.json"] } } }
-> ```
-> Also note: the PyPI package is `graphifyy` (double-y) — `pip install graphify` installs an unrelated package.
 
 <details>
 <summary>Manual install (curl)</summary>
@@ -249,8 +236,6 @@ graphify trae install              # AGENTS.md (Trae)
 graphify trae uninstall
 graphify trae-cn install           # AGENTS.md (Trae CN)
 graphify trae-cn uninstall
-graphify antigravity install       # .agent/rules + .agent/workflows (Google Antigravity)
-graphify antigravity uninstall
 
 # query the graph directly from the terminal (no AI assistant needed)
 graphify query "what connects attention to the optimizer?"
@@ -263,7 +248,7 @@ Works with any mix of file types:
 
 | Type | Extensions | Extraction |
 |------|-----------|------------|
-| Code | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte` | AST via tree-sitter + call-graph + docstring/comment rationale |
+| Code | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .dart` | AST via tree-sitter + call-graph + docstring/comment rationale |
 | Docs | `.md .txt .rst` | Concepts + relationships + design rationale via Claude |
 | Office | `.docx .xlsx` | Converted to markdown then extracted via Claude (requires `pip install graphifyy[office]`) |
 | Papers | `.pdf` | Citation mining + concept extraction |
@@ -338,25 +323,9 @@ graphify sends file contents to your AI coding assistant's underlying model API 
 
 NetworkX + Leiden (graspologic) + tree-sitter + vis.js. Semantic extraction via Claude (Claude Code), GPT-4 (Codex), or whichever model your platform runs. Video transcription via faster-whisper + yt-dlp (optional, `pip install graphifyy[video]`). No Neo4j required, no server, runs entirely locally.
 
-## Built on graphify — Penpax
-
-[**Penpax**](https://safishamsi.github.io/penpax.ai) is the enterprise layer on top of graphify. Where graphify turns a folder of files into a knowledge graph, Penpax applies the same graph to your entire working life — continuously.
-
-| | graphify | Penpax |
-|---|---|---|
-| Input | A folder of files | Browser history, meetings, emails, files, code — everything |
-| Runs | On demand | Continuously in the background |
-| Scope | A project | Your entire working life |
-| Query | CLI / MCP / AI skill | Natural language, always on |
-| Privacy | Local by default | Fully on-device, no cloud |
-
-Built for lawyers, consultants, executives, doctors, researchers — anyone whose work lives across hundreds of conversations and documents they can never fully reconstruct.
-
-**Free trial launching soon.** [Join the waitlist →](https://safishamsi.github.io/penpax.ai)
-
 ## What we are building next
 
-graphify is the graph layer. Penpax is the always-on layer on top of it — an on-device digital twin that connects your meetings, browser history, files, emails, and code into one continuously updating knowledge graph. No cloud, no training on your data. [Join the waitlist.](https://safishamsi.github.io/penpax.ai)
+graphify is the graph layer. We are building [Penpax](https://safishamsi.github.io/penpax.ai) on top of it — an on-device digital twin that connects your meetings, browser history, files, emails, and code into one continuously updating knowledge graph. No cloud, no training on your data. [Join the waitlist.](https://safishamsi.github.io/penpax.ai)
 
 ## Star history
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,7 +18,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart'}
 DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
@@ -80,9 +80,6 @@ _ASSET_DIR_MARKERS = {".imageset", ".xcassets", ".appiconset", ".colorset", ".la
 
 
 def classify_file(path: Path) -> FileType | None:
-    # Compound extensions must be checked before simple suffix lookup
-    if path.name.lower().endswith(".blade.php"):
-        return FileType.CODE
     ext = path.suffix.lower()
     if ext in CODE_EXTENSIONS:
         return FileType.CODE
@@ -244,13 +241,6 @@ _SKIP_DIRS = {
     ".tox", ".eggs", "*.egg-info",
 }
 
-# Large generated files that are never useful to extract
-_SKIP_FILES = {
-    "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
-    "Cargo.lock", "poetry.lock", "Gemfile.lock",
-    "composer.lock", "go.sum", "go.work.sum",
-}
-
 def _is_noise_dir(part: str) -> bool:
     """Return True if this directory name looks like a venv, cache, or dep dir."""
     if part in _SKIP_DIRS:
@@ -367,8 +357,6 @@ def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
                     and not _is_ignored(dp / d, root, ignore_patterns)
                 ]
             for fname in filenames:
-                if fname in _SKIP_FILES:
-                    continue
                 p = dp / fname
                 if p not in seen:
                     seen.add(p)

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -80,6 +80,9 @@ _ASSET_DIR_MARKERS = {".imageset", ".xcassets", ".appiconset", ".colorset", ".la
 
 
 def classify_file(path: Path) -> FileType | None:
+    # Compound extensions must be checked before simple suffix lookup
+    if path.name.lower().endswith(".blade.php"):
+        return FileType.CODE
     ext = path.suffix.lower()
     if ext in CODE_EXTENSIONS:
         return FileType.CODE
@@ -241,6 +244,13 @@ _SKIP_DIRS = {
     ".tox", ".eggs", "*.egg-info",
 }
 
+# Large generated files that are never useful to extract
+_SKIP_FILES = {
+    "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
+    "Cargo.lock", "poetry.lock", "Gemfile.lock",
+    "composer.lock", "go.sum", "go.work.sum",
+}
+
 def _is_noise_dir(part: str) -> bool:
     """Return True if this directory name looks like a venv, cache, or dep dir."""
     if part in _SKIP_DIRS:
@@ -357,6 +367,8 @@ def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
                     and not _is_ignored(dp / d, root, ignore_patterns)
                 ]
             for fname in filenames:
+                if fname in _SKIP_FILES:
+                    continue
                 p = dp / fname
                 if p not in seen:
                     seen.add(p)

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2803,6 +2803,7 @@ def extract_dart(path: Path) -> dict:
 
 
 
+
 # ── Main extract and collect_files ────────────────────────────────────────────
 
 
@@ -2891,7 +2892,11 @@ def extract(paths: list[Path]) -> dict:
     for i, path in enumerate(paths):
         if total >= _PROGRESS_INTERVAL and i % _PROGRESS_INTERVAL == 0 and i > 0:
             print(f"  AST extraction: {i}/{total} files ({i * 100 // total}%)", flush=True)
-        extractor = _DISPATCH.get(path.suffix)
+        # .blade.php must be checked before suffix lookup since Path.suffix returns .php
+        if path.name.endswith(".blade.php"):
+            extractor = extract_blade
+        else:
+            extractor = _DISPATCH.get(path.suffix)
         if extractor is None:
             continue
         cached = load_cached(path, root)

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1165,53 +1165,6 @@ def extract_php(path: Path) -> dict:
     return _extract_generic(path, _PHP_CONFIG)
 
 
-def extract_blade(path: Path) -> dict:
-    """Extract @include, <livewire:> components, and wire:click bindings from Blade templates."""
-    import re
-    try:
-        src = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return {"error": f"cannot read {path}"}
-
-    file_nid = _make_id(str(path))
-    nodes = [{"id": file_nid, "label": path.name, "file_type": "code",
-              "source_file": str(path), "source_location": None}]
-    edges = []
-
-    # @include('path.to.partial') or @include("path.to.partial")
-    for m in re.finditer(r"@include\(['\"]([^'\"]+)['\"]", src):
-        tgt = m.group(1).replace(".", "/")
-        tgt_nid = _make_id(tgt)
-        if tgt_nid not in {n["id"] for n in nodes}:
-            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
-                          "source_file": str(path), "source_location": None})
-        edges.append({"source": file_nid, "target": tgt_nid, "relation": "includes",
-                      "confidence": "EXTRACTED", "confidence_score": 1.0,
-                      "source_file": str(path), "source_location": None, "weight": 1.0})
-
-    # <livewire:component.name /> or <livewire:component.name>
-    for m in re.finditer(r"<livewire:([\w.\-]+)", src):
-        tgt_nid = _make_id(m.group(1))
-        if tgt_nid not in {n["id"] for n in nodes}:
-            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
-                          "source_file": str(path), "source_location": None})
-        edges.append({"source": file_nid, "target": tgt_nid, "relation": "uses_component",
-                      "confidence": "EXTRACTED", "confidence_score": 1.0,
-                      "source_file": str(path), "source_location": None, "weight": 1.0})
-
-    # wire:click="methodName"
-    for m in re.finditer(r'wire:click=["\']([^"\']+)["\']', src):
-        tgt_nid = _make_id(m.group(1))
-        if tgt_nid not in {n["id"] for n in nodes}:
-            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
-                          "source_file": str(path), "source_location": None})
-        edges.append({"source": file_nid, "target": tgt_nid, "relation": "binds_method",
-                      "confidence": "EXTRACTED", "confidence_score": 1.0,
-                      "source_file": str(path), "source_location": None, "weight": 1.0})
-
-    return {"nodes": nodes, "edges": edges}
-
-
 def extract_lua(path: Path) -> dict:
     """Extract functions, methods, require() imports, and calls from a .lua file."""
     return _extract_generic(path, _LUA_CONFIG)
@@ -2615,6 +2568,194 @@ def extract_elixir(path: Path) -> dict:
     return {"nodes": nodes, "edges": clean_edges, "input_tokens": 0, "output_tokens": 0}
 
 
+# ── Dart extractor (regex-based, no tree-sitter-dart on PyPI) ────────────────
+
+def extract_dart(path: Path) -> dict:
+    """Extract classes, mixins, enums, functions, imports, and calls from a .dart file.
+
+    Uses regex-based parsing because no tree-sitter-dart package is available on
+    PyPI with the new Language API (>=0.23). Handles Flutter-specific patterns:
+    StatelessWidget / StatefulWidget subclasses, State<T>, abstract classes,
+    mixins, enums, typedefs, and package imports.
+    """
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    stem = path.stem
+    str_path = str(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+
+    def add_node(nid: str, label: str, line: int, kind: str = "code") -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({
+                "id": nid,
+                "label": label,
+                "file_type": kind,
+                "source_file": str_path,
+                "source_location": f"L{line}",
+            })
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 confidence: str = "EXTRACTED", weight: float = 1.0) -> None:
+        edges.append({
+            "source": src,
+            "target": tgt,
+            "relation": relation,
+            "confidence": confidence,
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": weight,
+        })
+
+    src_lines = source.splitlines()
+
+    # ── File node ────────────────────────────────────────────────────────────
+    file_nid = _make_id(str_path)
+    add_node(file_nid, path.name, 1)
+
+    # ── Imports ──────────────────────────────────────────────────────────────
+    # Matches: import 'package:flutter/material.dart'; or import 'dart:async';
+    _RE_IMPORT = re.compile(
+        r"""^import\s+['"](?:package:)?(?P<scheme>dart:)?(?P<pkg>[^/'"]+)""",
+        re.MULTILINE,
+    )
+    for m in _RE_IMPORT.finditer(source):
+        raw_pkg = m.group("pkg").split("/")[0]
+        # Keep "dart:" prefix to avoid collision with keywords like "async"
+        pkg = f"dart:{raw_pkg}" if m.group("scheme") else raw_pkg
+        tgt_nid = _make_id(pkg)
+        line = source[: m.start()].count("\n") + 1
+        add_node(tgt_nid, pkg, line)
+        add_edge(file_nid, tgt_nid, "imports", line)
+
+    # ── Class / mixin / enum / abstract class ────────────────────────────────
+    _RE_CLASS = re.compile(
+        r"^(?:abstract\s+)?(?:base\s+|final\s+|sealed\s+|interface\s+)?"
+        r"(?P<kind>class|mixin|enum|extension)\s+(?P<cls_name>\w+)"
+        r"(?:<[^{]*?>)?"
+        r"(?:\s+extends\s+(?P<extends>\w+))?"
+        r"(?:\s+with\s+(?P<with>[^{]+?))?"
+        r"(?:\s+implements\s+(?P<impl>[^{]+?))?(?=\s*[{<]|\s*$)",
+        re.MULTILINE,
+    )
+    for m in _RE_CLASS.finditer(source):
+        cls_name = m.group("cls_name")
+        kind = m.group("kind")
+        line = source[: m.start()].count("\n") + 1
+        cls_nid = _make_id(stem, cls_name)
+        label = cls_name if kind == "class" else f"{kind} {cls_name}"
+        add_node(cls_nid, label, line)
+        add_edge(file_nid, cls_nid, "defines", line)
+
+        if m.group("extends"):
+            parent = m.group("extends").strip()
+            add_edge(cls_nid, _make_id(stem, parent), "inherits", line, confidence="EXTRACTED")
+
+        if m.group("with"):
+            for mixin_name in re.split(r"[,\s]+", m.group("with").strip()):
+                mixin_name = mixin_name.strip()
+                if mixin_name:
+                    add_edge(cls_nid, _make_id(stem, mixin_name), "uses", line, confidence="EXTRACTED")
+
+        if m.group("impl"):
+            for iface in re.split(r"[,\s]+", m.group("impl").strip()):
+                iface = iface.strip()
+                if iface:
+                    add_edge(cls_nid, _make_id(stem, iface), "implements", line, confidence="EXTRACTED")
+
+    # ── typedef ──────────────────────────────────────────────────────────────
+    _RE_TYPEDEF = re.compile(r"^typedef\s+(\w+)", re.MULTILINE)
+    for m in _RE_TYPEDEF.finditer(source):
+        td_name = m.group(1)
+        line = source[: m.start()].count("\n") + 1
+        nid = _make_id(stem, td_name)
+        add_node(nid, f"typedef {td_name}", line)
+        add_edge(file_nid, nid, "defines", line)
+
+    # ── Build class start-line map for scope resolution ──────────────────────
+    class_lines: list[tuple[int, str]] = []
+    for m in _RE_CLASS.finditer(source):
+        line = source[: m.start()].count("\n") + 1
+        cls_nid = _make_id(stem, m.group("cls_name"))
+        if cls_nid in seen_ids:
+            class_lines.append((line, cls_nid))
+    class_lines.sort()
+
+    def _scope_nid(func_line: int) -> str:
+        owner = file_nid
+        for cls_line, cls_nid in class_lines:
+            if cls_line <= func_line:
+                owner = cls_nid
+            else:
+                break
+        return owner
+
+    # ── Functions and methods ─────────────────────────────────────────────────
+    _SKIP_NAMES = frozenset({
+        "if", "else", "for", "while", "switch", "do", "try", "catch",
+        "return", "throw", "assert", "await", "yield", "new", "super",
+        "this", "print", "get", "set",
+    })
+
+    _RE_FUNC = re.compile(
+        r"^[ \t]*(?:(?:@\w+\s+)*)"
+        r"(?:(?:static|async|override|abstract|external|factory|const|late|final)\s+)*"
+        r"(?:Future<[^>]+>|Stream<[^>]+>|[\w<>\[\]?]+)\s+"
+        r"(?P<func_name>_?\w+)\s*\(",
+        re.MULTILINE,
+    )
+
+    func_records: list[tuple[str, int]] = []
+    for m in _RE_FUNC.finditer(source):
+        fn_name = m.group("func_name")
+        if fn_name in _SKIP_NAMES:
+            continue
+        line = source[: m.start()].count("\n") + 1
+        scope = _scope_nid(line)
+        if scope == file_nid:
+            func_nid = _make_id(stem, fn_name)
+        else:
+            scope_suffix = scope.split("_")[-1]
+            func_nid = _make_id(stem, scope_suffix, fn_name)
+        label = f"{fn_name}()"
+        add_node(func_nid, label, line)
+        rel = "defines" if scope == file_nid else "has_method"
+        add_edge(scope, func_nid, rel, line)
+        func_records.append((func_nid, line))
+
+    # ── Call extraction ───────────────────────────────────────────────────────
+    _RE_CALL = re.compile(r"(?:(\w+)\.)?(?P<callee>\w+)\s*\(", re.MULTILINE)
+    known_funcs: dict[str, str] = {
+        n["label"].rstrip("()"): n["id"]
+        for n in nodes
+        if n["label"].endswith("()")
+    }
+
+    for func_nid, func_line in func_records:
+        body = "\n".join(src_lines[func_line: func_line + 30])
+        for cm in _RE_CALL.finditer(body):
+            callee = cm.group("callee")
+            if callee in _SKIP_NAMES:
+                continue
+            if callee in known_funcs:
+                call_line = func_line + body[: cm.start()].count("\n")
+                add_edge(func_nid, known_funcs[callee], "calls", call_line, confidence="EXTRACTED")
+
+    # ── Clean edges ───────────────────────────────────────────────────────────
+    _EXTERNAL_OK = {"imports", "inherits", "implements", "uses"}
+    clean_edges = [
+        e for e in edges
+        if e["source"] in seen_ids and (e["target"] in seen_ids or e["relation"] in _EXTERNAL_OK)
+    ]
+    return {"nodes": nodes, "edges": clean_edges, "input_tokens": 0, "output_tokens": 0}
+
+
+
 # ── Main extract and collect_files ────────────────────────────────────────────
 
 
@@ -2693,6 +2834,7 @@ def extract(paths: list[Path]) -> dict:
         ".m": extract_objc,
         ".mm": extract_objc,
         ".jl": extract_julia,
+        ".dart": extract_dart,
         ".vue": extract_js,
         ".svelte": extract_js,
     }
@@ -2702,11 +2844,7 @@ def extract(paths: list[Path]) -> dict:
     for i, path in enumerate(paths):
         if total >= _PROGRESS_INTERVAL and i % _PROGRESS_INTERVAL == 0 and i > 0:
             print(f"  AST extraction: {i}/{total} files ({i * 100 // total}%)", flush=True)
-        # .blade.php must be checked before suffix lookup since Path.suffix returns .php
-        if path.name.endswith(".blade.php"):
-            extractor = extract_blade
-        else:
-            extractor = _DISPATCH.get(path.suffix)
+        extractor = _DISPATCH.get(path.suffix)
         if extractor is None:
             continue
         cached = load_cached(path, root)
@@ -2753,7 +2891,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
         ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
         ".lua", ".toc", ".zig", ".ps1",
-        ".m", ".mm",
+        ".m", ".mm", ".dart",
     }
     from graphify.detect import _load_graphifyignore, _is_ignored
     ignore_root = root if root is not None else target

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1165,6 +1165,53 @@ def extract_php(path: Path) -> dict:
     return _extract_generic(path, _PHP_CONFIG)
 
 
+def extract_blade(path: Path) -> dict:
+    """Extract @include, <livewire:> components, and wire:click bindings from Blade templates."""
+    import re
+    try:
+        src = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {"error": f"cannot read {path}"}
+
+    file_nid = _make_id(str(path))
+    nodes = [{"id": file_nid, "label": path.name, "file_type": "code",
+              "source_file": str(path), "source_location": None}]
+    edges = []
+
+    # @include('path.to.partial') or @include("path.to.partial")
+    for m in re.finditer(r"@include\(['\"]([^'\"]+)['\"]", src):
+        tgt = m.group(1).replace(".", "/")
+        tgt_nid = _make_id(tgt)
+        if tgt_nid not in {n["id"] for n in nodes}:
+            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
+                          "source_file": str(path), "source_location": None})
+        edges.append({"source": file_nid, "target": tgt_nid, "relation": "includes",
+                      "confidence": "EXTRACTED", "confidence_score": 1.0,
+                      "source_file": str(path), "source_location": None, "weight": 1.0})
+
+    # <livewire:component.name /> or <livewire:component.name>
+    for m in re.finditer(r"<livewire:([\w.\-]+)", src):
+        tgt_nid = _make_id(m.group(1))
+        if tgt_nid not in {n["id"] for n in nodes}:
+            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
+                          "source_file": str(path), "source_location": None})
+        edges.append({"source": file_nid, "target": tgt_nid, "relation": "uses_component",
+                      "confidence": "EXTRACTED", "confidence_score": 1.0,
+                      "source_file": str(path), "source_location": None, "weight": 1.0})
+
+    # wire:click="methodName"
+    for m in re.finditer(r'wire:click=["\']([^"\']+)["\']', src):
+        tgt_nid = _make_id(m.group(1))
+        if tgt_nid not in {n["id"] for n in nodes}:
+            nodes.append({"id": tgt_nid, "label": m.group(1), "file_type": "code",
+                          "source_file": str(path), "source_location": None})
+        edges.append({"source": file_nid, "target": tgt_nid, "relation": "binds_method",
+                      "confidence": "EXTRACTED", "confidence_score": 1.0,
+                      "source_file": str(path), "source_location": None, "weight": 1.0})
+
+    return {"nodes": nodes, "edges": edges}
+
+
 def extract_lua(path: Path) -> dict:
     """Extract functions, methods, require() imports, and calls from a .lua file."""
     return _extract_generic(path, _LUA_CONFIG)

--- a/tests/fixtures/sample.dart
+++ b/tests/fixtures/sample.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'dart:async';
+import 'dart:convert';
+
+// WHY: Base interface for all data processors in the app
+abstract class DataProcessor<T> {
+  Future<List<T>> process(List<T> items);
+  void reset();
+}
+
+mixin Loggable {
+  void log(String message) {
+    debugPrint('[LOG] $message');
+  }
+}
+
+// NOTE: Stateless widget for displaying a list of items
+class ItemListWidget extends StatelessWidget with Loggable {
+  final List<String> items;
+  final ValueChanged<String>? onSelected;
+
+  const ItemListWidget({
+    super.key,
+    required this.items,
+    this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    log('Building ItemListWidget with ${items.length} items');
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (context, index) => _buildTile(context, index),
+    );
+  }
+
+  Widget _buildTile(BuildContext context, int index) {
+    return ListTile(
+      title: Text(items[index]),
+      onTap: () => onSelected?.call(items[index]),
+    );
+  }
+}
+
+class ItemController extends StatefulWidget {
+  final String title;
+
+  const ItemController({super.key, required this.title});
+
+  @override
+  State<ItemController> createState() => _ItemControllerState();
+}
+
+class _ItemControllerState extends State<ItemController> with Loggable {
+  final List<String> _items = [];
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadItems();
+  }
+
+  Future<void> _loadItems() async {
+    setState(() => _isLoading = true);
+    try {
+      final data = await fetchItems();
+      setState(() {
+        _items.addAll(data);
+        _isLoading = false;
+      });
+      log('Loaded ${data.length} items');
+    } catch (e) {
+      setState(() => _isLoading = false);
+    }
+  }
+
+  Future<List<String>> fetchItems() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    return ['Alpha', 'Beta', 'Gamma'];
+  }
+
+  void addItem(String item) {
+    setState(() => _items.add(item));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: _isLoading
+          ? const CircularProgressIndicator()
+          : ItemListWidget(items: _items, onSelected: addItem),
+    );
+  }
+}
+
+// IMPORTANT: Implements DataProcessor with JSON parsing
+class JsonDataProcessor implements DataProcessor<Map<String, dynamic>> {
+  final String endpoint;
+
+  JsonDataProcessor({required this.endpoint});
+
+  @override
+  Future<List<Map<String, dynamic>>> process(
+      List<Map<String, dynamic>> items) async {
+    return items.where((item) => item.containsKey('id')).toList();
+  }
+
+  @override
+  void reset() {
+    debugPrint('Resetting JsonDataProcessor for $endpoint');
+  }
+
+  Map<String, dynamic> decode(String raw) => json.decode(raw);
+}
+
+enum AppState { idle, loading, error, success }
+
+typedef ItemCallback = void Function(String item);

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -508,3 +508,110 @@ def test_julia_no_dangling_edges():
     node_ids = {n["id"] for n in r["nodes"]}
     for e in r["edges"]:
         assert e["source"] in node_ids, f"Dangling source: {e}"
+
+
+# ── Dart / Flutter ────────────────────────────────────────────────────────────
+
+from graphify.extract import extract_dart
+
+
+def test_dart_no_error():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert "error" not in r, r.get("error")
+
+
+def test_dart_finds_classes():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("ItemListWidget" in l for l in labels)
+    assert any("ItemController" in l for l in labels)
+    assert any("JsonDataProcessor" in l for l in labels)
+
+
+def test_dart_finds_abstract_class():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("DataProcessor" in l for l in labels)
+
+
+def test_dart_finds_mixin():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("Loggable" in l for l in labels)
+
+
+def test_dart_finds_enum():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("AppState" in l for l in labels)
+
+
+def test_dart_finds_typedef():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("ItemCallback" in l for l in labels)
+
+
+def test_dart_finds_methods():
+    r = extract_dart(FIXTURES / "sample.dart")
+    labels = _labels(r)
+    assert any("build()" in l for l in labels)
+    assert any("addItem()" in l for l in labels)
+
+
+def test_dart_finds_imports():
+    r = extract_dart(FIXTURES / "sample.dart")
+    assert "imports" in _relations(r)
+    import_targets = [
+        e["target"] for e in r["edges"] if e["relation"] == "imports"
+    ]
+    # flutter and dart packages
+    node_labels = {n["id"]: n["label"] for n in r["nodes"]}
+    imported_labels = [node_labels.get(t, t) for t in import_targets]
+    assert any("flutter" in l for l in imported_labels)
+    assert any("dart" in l for l in imported_labels)
+
+
+def test_dart_finds_inherits():
+    r = extract_dart(FIXTURES / "sample.dart")
+    inherits = [e for e in r["edges"] if e["relation"] == "inherits"]
+    assert len(inherits) >= 1
+
+
+def test_dart_finds_implements():
+    r = extract_dart(FIXTURES / "sample.dart")
+    impl_edges = [e for e in r["edges"] if e["relation"] == "implements"]
+    assert len(impl_edges) >= 1
+
+
+def test_dart_finds_mixin_usage():
+    r = extract_dart(FIXTURES / "sample.dart")
+    uses_edges = [e for e in r["edges"] if e["relation"] == "uses"]
+    assert len(uses_edges) >= 1
+
+
+def test_dart_no_dangling_edges():
+    r = extract_dart(FIXTURES / "sample.dart")
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"Dangling source: {e}"
+
+
+def test_dart_has_source_location():
+    r = extract_dart(FIXTURES / "sample.dart")
+    for n in r["nodes"]:
+        assert "source_location" in n
+        assert n["source_location"].startswith("L")
+
+
+def test_dart_collect_files_includes_dart(tmp_path):
+    from graphify.extract import collect_files
+    dart_file = tmp_path / "main.dart"
+    dart_file.write_text("void main() {}")
+    files = collect_files(tmp_path)
+    assert any(f.suffix == ".dart" for f in files)
+
+
+def test_dart_in_detect_code_extensions():
+    from graphify.detect import CODE_EXTENSIONS
+    assert ".dart" in CODE_EXTENSIONS


### PR DESCRIPTION
## Summary

Adds Dart/Flutter language support to graphify's AST extraction pipeline.

## What's extracted

- Classes, abstract classes, mixins, enums, extensions, typedefs
- Flutter-specific patterns: StatelessWidget, StatefulWidget, State<T>
- Relationships: `inherits`, `implements`, `uses` (mixins), `defines`, `has_method`
- Package imports (`package:flutter/...`) and Dart builtins (`dart:async`, etc.)
- Method calls between known functions in the same file

## Why regex, not tree-sitter

`tree-sitter-dart` does not exist on PyPI with the new Language API (>=0.23)
that graphify requires. The regex-based approach covers all Flutter-specific
patterns without adding external dependencies.

## Changes

- `graphify/extract.py` — added `extract_dart()` + registered `.dart` in dispatch table and `collect_files()`
- `graphify/detect.py` — added `.dart` to `CODE_EXTENSIONS`
- `tests/fixtures/sample.dart` — realistic Flutter fixture with widgets, mixins, enums
- `tests/test_languages.py` — 15 tests for Dart extraction
- `README.md` — updated language count (22 → 23) and extensions table

## Tests

15/15 passing