### PR TITLE
fix: add norm_label at build time for diacritic-insensitive search

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -926,9 +926,10 @@ def main() -> None:
         if not scored:
             print("No matching nodes found.")
             sys.exit(0)
+        score_map = {nid: s for s, nid in scored}
         start = [nid for _, nid in scored[:5]]
         nodes, edges = (_dfs if use_dfs else _bfs)(G, start, depth=2)
-        print(_subgraph_to_text(G, nodes, edges, token_budget=budget))
+        print(_subgraph_to_text(G, nodes, edges, token_budget=budget, node_scores=score_map))
     elif cmd == "save-result":
         # graphify save-result --question Q --answer A --type T [--nodes N1 N2 ...]
         import argparse as _ap

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -282,6 +282,13 @@ def attach_hyperedges(G: nx.Graph, hyperedges: list) -> None:
     G.graph["hyperedges"] = existing
 
 
+def _strip_diacritics(text: str) -> str:
+    """Normalize diacritics for search: ćwiczenia → cwiczenia, résumé → resume."""
+    import unicodedata
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
 def to_json(G: nx.Graph, communities: dict[int, list[str]], output_path: str) -> None:
     node_community = _node_community_map(communities)
     try:
@@ -290,6 +297,8 @@ def to_json(G: nx.Graph, communities: dict[int, list[str]], output_path: str) ->
         data = json_graph.node_link_data(G)
     for node in data["nodes"]:
         node["community"] = node_community.get(node["id"])
+        label = node.get("label", "")
+        node["norm_label"] = _strip_diacritics(label).lower()
     for link in data["links"]:
         if "confidence_score" not in link:
             conf = link.get("confidence", "EXTRACTED")

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -39,12 +39,24 @@ def _communities_from_graph(G: nx.Graph) -> dict[int, list[str]]:
     return communities
 
 
+def _strip_diacritics(text: str) -> str:
+    """Fallback diacritic normalization for graphs built before norm_label existed."""
+    import unicodedata
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
 def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
+    """Score nodes by keyword match.  Diacritic-insensitive via norm_label."""
     scored = []
     for nid, data in G.nodes(data=True):
         label = data.get("label", "").lower()
+        norm_label = data.get("norm_label") or _strip_diacritics(label)
         source = data.get("source_file", "").lower()
-        score = sum(1 for t in terms if t in label) + sum(0.5 for t in terms if t in source)
+        score = (
+            sum(1 for t in terms if t in label or t in norm_label)
+            + sum(0.5 for t in terms if t in source)
+        )
         if score > 0:
             scored.append((score, nid))
     return sorted(scored, reverse=True)
@@ -82,11 +94,22 @@ def _dfs(G: nx.Graph, start_nodes: list[str], depth: int) -> tuple[set[str], lis
     return visited, edges_seen
 
 
-def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_budget: int = 2000) -> str:
-    """Render subgraph as text, cutting at token_budget (approx 3 chars/token)."""
+def _subgraph_to_text(
+    G: nx.Graph,
+    nodes: set[str],
+    edges: list[tuple],
+    token_budget: int = 2000,
+    node_scores: dict[str, float] | None = None,
+) -> str:
+    """Render subgraph as text, cutting at token_budget (approx 3 chars/token).
+
+    Nodes are sorted by query relevance score first, then by degree as
+    tiebreaker so that direct matches always appear before traversal neighbors.
+    """
     char_budget = token_budget * 3
+    scores = node_scores or {}
     lines = []
-    for nid in sorted(nodes, key=lambda n: G.degree(n), reverse=True):
+    for nid in sorted(nodes, key=lambda n: (scores.get(n, 0), G.degree(n)), reverse=True):
         d = G.nodes[nid]
         line = f"NODE {sanitize_label(d.get('label', nid))} [src={d.get('source_file', '')} loc={d.get('source_location', '')} community={d.get('community', '')}]"
         lines.append(line)
@@ -102,10 +125,13 @@ def _subgraph_to_text(G: nx.Graph, nodes: set[str], edges: list[tuple], token_bu
 
 
 def _find_node(G: nx.Graph, label: str) -> list[str]:
-    """Return node IDs whose label or ID matches the search term (case-insensitive)."""
+    """Return node IDs whose label or ID matches (case- and diacritic-insensitive)."""
     term = label.lower()
+    norm_term = _strip_diacritics(term)
     return [nid for nid, d in G.nodes(data=True)
-            if term in d.get("label", "").lower() or term == nid.lower()]
+            if term in d.get("label", "").lower()
+            or norm_term in (d.get("norm_label") or _strip_diacritics(d.get("label", "").lower()))
+            or term == nid.lower()]
 
 
 def _filter_blank_stdin() -> None:
@@ -235,17 +261,18 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         start_nodes = [nid for _, nid in scored[:3]]
         if not start_nodes:
             return "No matching nodes found."
+        score_map = {nid: s for s, nid in scored}
         nodes, edges = _dfs(G, start_nodes, depth) if mode == "dfs" else _bfs(G, start_nodes, depth)
         header = f"Traversal: {mode.upper()} depth={depth} | Start: {[G.nodes[n].get('label', n) for n in start_nodes]} | {len(nodes)} nodes found\n\n"
-        return header + _subgraph_to_text(G, nodes, edges, budget)
+        return header + _subgraph_to_text(G, nodes, edges, budget, node_scores=score_map)
 
     def _tool_get_node(arguments: dict) -> str:
-        label = arguments["label"].lower()
-        matches = [(nid, d) for nid, d in G.nodes(data=True)
-                   if label in d.get("label", "").lower() or label == nid.lower()]
-        if not matches:
+        label = arguments["label"]
+        matched_ids = _find_node(G, label)
+        if not matched_ids:
             return f"No node matching '{label}' found."
-        nid, d = matches[0]
+        nid = matched_ids[0]
+        d = G.nodes[nid]
         return "\n".join([
             f"Node: {d.get('label', nid)}",
             f"  ID: {nid}",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -38,6 +38,30 @@ def test_to_json_nodes_have_community():
         for node in data["nodes"]:
             assert "community" in node
 
+def test_to_json_nodes_have_norm_label():
+    G = make_graph()
+    communities = cluster(G)
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.json"
+        to_json(G, communities, str(out))
+        data = json.loads(out.read_text())
+        for node in data["nodes"]:
+            assert "norm_label" in node
+            assert node["norm_label"] == node["norm_label"].lower()
+
+def test_to_json_norm_label_strips_diacritics():
+    """Build a graph with a diacritic label and verify norm_label is stripped."""
+    import networkx as nx
+    G = nx.Graph()
+    G.add_node("x", label="Přehled cvičení", file_type="document",
+               source_file="test.md", source_location=None)
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.json"
+        to_json(G, {}, str(out))
+        data = json.loads(out.read_text())
+        node = data["nodes"][0]
+        assert node["norm_label"] == "prehled cviceni"
+
 def test_to_cypher_creates_file():
     G = make_graph()
     with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -6,7 +6,9 @@ from networkx.readwrite import json_graph
 
 from graphify.serve import (
     _communities_from_graph,
+    _find_node,
     _score_nodes,
+    _strip_diacritics,
     _bfs,
     _dfs,
     _subgraph_to_text,
@@ -151,3 +153,96 @@ def test_load_graph_missing_file(tmp_path):
     graphify_dir.mkdir()
     with pytest.raises(SystemExit):
         _load_graph(str(graphify_dir / "nonexistent.json"))
+
+
+# --- diacritic-insensitive scoring via norm_label ---
+
+def _make_diacritic_graph(with_norm: bool = True) -> nx.Graph:
+    """Graph with diacritic labels.  with_norm=True simulates a rebuilt graph."""
+    G = nx.Graph()
+    attrs = {"source_location": None, "community": 5}
+    G.add_node("d1", label="Přehled základních cvičení",
+               source_file="docs/zakladni-cviceni.md", **attrs)
+    G.add_node("d2", label="Tréninkový plán",
+               source_file="docs/treninkovy-plan.md", **attrs)
+    G.add_node("d3", label="Préparation du résumé",
+               source_file="notes/preparation-resume.md",
+               community=1, source_location=None)
+    if with_norm:
+        for nid, d in G.nodes(data=True):
+            d["norm_label"] = _strip_diacritics(d["label"]).lower()
+    G.add_edge("d1", "d2", relation="related", confidence="INFERRED")
+    return G
+
+
+# --- _strip_diacritics (fallback helper) ---
+
+def test_strip_diacritics_polish():
+    assert _strip_diacritics("ćwiczenia") == "cwiczenia"
+    assert _strip_diacritics("ćwiczenia z lukami") == "cwiczenia z lukami"
+
+def test_strip_diacritics_french():
+    assert _strip_diacritics("résumé") == "resume"
+
+def test_strip_diacritics_ascii_passthrough():
+    assert _strip_diacritics("hello world") == "hello world"
+    assert _strip_diacritics("") == ""
+
+
+# --- _score_nodes with norm_label ---
+
+def test_score_nodes_ascii_matches_diacritic_label():
+    """ASCII query 'prehled cviceni' matches norm_label from 'Přehled základních cvičení'."""
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["prehled", "cviceni"])
+    nids = [nid for _, nid in scored]
+    assert "d1" in nids
+    assert scored[0][1] == "d1"
+
+def test_score_nodes_diacritic_query_still_works():
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["přehled"])
+    assert any(nid == "d1" for _, nid in scored)
+
+def test_score_nodes_french_diacritics():
+    G = _make_diacritic_graph()
+    scored = _score_nodes(G, ["resume"])
+    assert any(nid == "d3" for _, nid in scored)
+
+def test_score_nodes_fallback_without_norm_label():
+    """Old graphs without norm_label still get diacritic matching via fallback."""
+    G = _make_diacritic_graph(with_norm=False)
+    scored = _score_nodes(G, ["prehled"])
+    assert any(nid == "d1" for _, nid in scored)
+
+
+# --- _find_node with norm_label ---
+
+def test_find_node_ascii_query():
+    G = _make_diacritic_graph()
+    assert "d1" in _find_node(G, "prehled")
+
+def test_find_node_diacritic_query():
+    G = _make_diacritic_graph()
+    assert "d1" in _find_node(G, "přehled")
+
+def test_find_node_fallback_without_norm_label():
+    G = _make_diacritic_graph(with_norm=False)
+    assert "d1" in _find_node(G, "prehled")
+
+
+# --- _subgraph_to_text relevance ordering ---
+
+def test_subgraph_to_text_relevance_ordering():
+    G = _make_diacritic_graph()
+    scores = {"d1": 2.0, "d2": 0.5}
+    text = _subgraph_to_text(G, {"d1", "d2"}, [], node_scores=scores)
+    lines = text.strip().split("\n")
+    d1_pos = next(i for i, l in enumerate(lines) if "Přehled" in l)
+    d2_pos = next(i for i, l in enumerate(lines) if "Tréninkový" in l)
+    assert d1_pos < d2_pos
+
+def test_subgraph_to_text_no_scores_falls_back_to_degree():
+    G = _make_diacritic_graph()
+    text = _subgraph_to_text(G, {"d1", "d2"}, [])
+    assert "NODE" in text


### PR DESCRIPTION
## Problem

Queries without diacritics (e.g. `cwiczenia z lukami`) fail to match nodes with diacritics in their labels (e.g. `Ćwiczenia z lukami`). Python's `in` operator does exact byte comparison — `c` (U+0063) ≠ `ć` (U+0107). This affects all languages with diacritics: Polish, French, Czech, German, etc.

Additionally, output nodes are sorted by degree (connection count) rather than query relevance, so even when a node matches it can appear buried behind high-degree but irrelevant neighbors.

## Approach

**Build time (`export.py`):** `to_json()` now generates a `norm_label` field for every node — lowercase, diacritics stripped via `unicodedata.normalize("NFKD")`. This sits alongside the existing `community` field that's already added at export time.

**Query time (`serve.py`):** `_score_nodes()` and `_find_node()` match against `norm_label` instead of normalizing on every query. A runtime fallback (`_strip_diacritics`) handles old graphs that lack the field.

**Output ordering:** `_subgraph_to_text()` accepts optional `node_scores` and sorts by (relevance, degree) so direct matches appear before high-degree traversal neighbors.

**Consistency:** `_tool_get_node` refactored to use `_find_node` instead of duplicating inline matching.

## Backward compatibility

- Old graphs without `norm_label` still work — `_score_nodes` and `_find_node` fall back to runtime normalization
- `node_scores` defaults to `None` → preserves degree-based ordering
- No new dependencies (`unicodedata` is stdlib)

## Tests

15 new tests across `test_serve.py` and `test_export.py`:
- `_strip_diacritics` with Polish, French, ASCII
- `_score_nodes` / `_find_node` with and without `norm_label` (fallback path)
- `to_json` produces `norm_label` on every node
- `_subgraph_to_text` relevance ordering