### PR TITLE
Add Verilog/SystemVerilog (.v/.sv) language support

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -8,7 +8,7 @@
 
 **AIコーディングアシスタント向けのスキル。** Claude Code、Codex、OpenCode、OpenClaw、Factory Droid で `/graphify` と入力するだけで、ファイルを読み込んでナレッジグラフを構築し、あなたが気づいていなかった構造を返します。コードベースをより速く理解し、アーキテクチャ上の意思決定の「なぜ」を見つけ出します。
 
-完全にマルチモーダル対応。コード、PDF、Markdown、スクリーンショット、図、ホワイトボード写真、他言語の画像まで――graphify は Claude Vision を使ってそれらすべてから概念と関係性を抽出し、1 つのグラフに接続します。tree-sitter AST により 19 言語をサポート（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C）。
+完全にマルチモーダル対応。コード、PDF、Markdown、スクリーンショット、図、ホワイトボード写真、他言語の画像まで――graphify は Claude Vision を使ってそれらすべてから概念と関係性を抽出し、1 つのグラフに接続します。tree-sitter AST により 24 言語をサポート（Python、JS、TS、Go、Rust、Java、C、C++、Ruby、C#、Kotlin、Scala、PHP、Swift、Lua、Zig、PowerShell、Elixir、Objective-C、Julia、Vue、Svelte、Verilog、SystemVerilog）。
 
 > Andrej Karpathy は論文、ツイート、スクリーンショット、メモを放り込む `/raw` フォルダを持っています。graphify はまさにその問題への答えです――生ファイルを読むのに比べて1クエリあたりのトークン数が 71.5 倍少なく、セッションをまたいで永続化され、見つけたものと推測したものを正直に区別します。
 
@@ -174,7 +174,7 @@ graphify query "..." --graph path/to/graph.json
 
 | タイプ | 拡張子 | 抽出方法 |
 |------|-----------|------------|
-| コード | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm` | tree-sitter による AST + コールグラフ + docstring/コメントの根拠 |
+| コード | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .v .sv` | tree-sitter による AST + コールグラフ + docstring/コメントの根拠 |
 | ドキュメント | `.md .txt .rst` | Claude による概念 + 関係性 + 設計根拠 |
 | Office | `.docx .xlsx` | Markdown に変換した後 Claude で抽出（`pip install graphifyy[office]` が必要） |
 | 論文 | `.pdf` | 引用マイニング + 概念抽出 |

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -6,9 +6,9 @@
 [![PyPI](https://img.shields.io/pypi/v/graphifyy)](https://pypi.org/project/graphifyy/)
 [![Sponsor](https://img.shields.io/badge/sponsor-safishamsi-ea4aaa?logo=github-sponsors)](https://github.com/sponsors/safishamsi)
 
-**AI 코딩 어시스턴트를 위한 스킬.** Claude Code, Codex, OpenCode, OpenClaw, Factory Droid, 또는 Trae에서 `/graphify`를 입력하면 파일을 읽고 지식 그래프를 구축하여, 미처 몰랐던 구조를 보여줍니다. 코드베이스를 더 빠르게 이해하고, 아키텍처 결정의 "이유"를 찾아보세요.
+**AI 코딩 어시스턴트를 위한 스킬.** Claude Code, Codex, OpenCode, OpenClaw, Factory Droid, 또는 Trae에서 `/graphify`를 입력하면 파일을 읽고 지식 그래프를 구축하여, 구조화된 구조를 보여줍니다. 코드베이스를 더 빠르게 이해하고, 아키텍처 결정의 "이유"를 찾아보세요.
 
-완전한 멀티모달 지원. 코드, PDF, 마크다운, 스크린샷, 다이어그램, 화이트보드 사진, 심지어 다른 언어로 된 이미지까지 — graphify는 Claude Vision을 사용하여 이 모든 것에서 개념과 관계를 추출하고 하나의 그래프로 연결합니다. tree-sitter AST를 통해 20개 언어를 지원합니다(Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia).
+완전한 멀티모달 지원. 코드, PDF, 마크다운, 스크린샷, 다이어그램, 화이트보드 사진, 심지어 다른 언어로 된 이미지까지 — graphify는 Claude Vision을 사용하여 이 모든 것에서 개념과 관계를 추출하고 하나의 그래프로 연결합니다. tree-sitter AST를 통해 24개 언어를 지원합니다(Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte, Verilog, SystemVerilog).
 
 > Andrej Karpathy는 논문, 트윗, 스크린샷, 메모를 모아두는 `/raw` 폴더를 관리합니다. graphify는 바로 그 문제에 대한 답입니다 — 원본 파일을 직접 읽는 것 대비 쿼리당 토큰 소비가 71.5배 적고, 세션 간에 영속적이며, 발견한 것과 추측한 것을 정직하게 구분합니다.
 
@@ -110,6 +110,7 @@ Codex 사용자는 병렬 추출을 위해 `~/.codex/config.toml`의 `[features]
 ## `graph.json`을 LLM과 함께 사용하기
 
 `graph.json`은 프롬프트에 한 번에 전부 붙여넣기 위한 것이 아닙니다. 유용한 워크플로우는 다음과 같습니다:
+
 
 1. `graphify-out/GRAPH_REPORT.md`로 높은 수준의 개요를 파악합니다.
 2. `graphify query`를 사용하여 답하려는 특정 질문에 대한 더 작은 서브그래프를 가져옵니다.
@@ -214,7 +215,7 @@ graphify query "..." --graph path/to/graph.json
 
 | 유형 | 확장자 | 추출 방식 |
 |------|--------|-----------|
-| 코드 | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl` | tree-sitter AST + 콜 그래프 + docstring/주석 근거 |
+| 코드 | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .v .sv` | tree-sitter AST + 콜 그래프 + docstring/주석 근거 |
 | 문서 | `.md .txt .rst` | Claude를 통한 개념 + 관계 + 설계 근거 |
 | 오피스 | `.docx .xlsx` | 마크다운으로 변환 후 Claude를 통해 추출 (`pip install graphifyy[office]` 필요) |
 | 논문 | `.pdf` | 인용 마이닝 + 개념 추출 |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **An AI coding assistant skill.** Type `/graphify` in Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Aider, OpenClaw, Factory Droid, Trae, or Google Antigravity - it reads your files, builds a knowledge graph, and gives you back structure you didn't know was there. Understand a codebase faster. Find the "why" behind architectural decisions.
 
-Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, images in other languages, or video and audio files - graphify extracts concepts and relationships from all of it and connects them into one graph. Videos are transcribed with Whisper using a domain-aware prompt derived from your corpus. 22 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte).
+Fully multimodal. Drop in code, PDFs, markdown, screenshots, diagrams, whiteboard photos, images in other languages, or video and audio files - graphify extracts concepts and relationships from all of it and connects them into one graph. Videos are transcribed with Whisper using a domain-aware prompt derived from your corpus. 24 languages supported via tree-sitter AST (Python, JS, TS, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia, Vue, Svelte, Verilog, SystemVerilog).
 
 > Andrej Karpathy keeps a `/raw` folder where he drops papers, tweets, screenshots, and notes. graphify is the answer to that problem - 71.5x fewer tokens per query vs reading the raw files, persistent across sessions, honest about what it found vs guessed.
 
@@ -263,7 +263,7 @@ Works with any mix of file types:
 
 | Type | Extensions | Extraction |
 |------|-----------|------------|
-| Code | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte` | AST via tree-sitter + call-graph + docstring/comment rationale |
+| Code | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .v .sv` | AST via tree-sitter + call-graph + docstring/comment rationale |
 | Docs | `.md .txt .rst` | Concepts + relationships + design rationale via Claude |
 | Office | `.docx .xlsx` | Converted to markdown then extracted via Claude (requires `pip install graphifyy[office]`) |
 | Papers | `.pdf` | Citation mining + concept extraction |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,7 +163,7 @@ graphify trae-cn uninstall
 
 | 类型 | 扩展名 | 提取方式 |
 |------|--------|----------|
-| 代码 | `.py .ts .js .go .rs .java .c .cpp .rb .cs .kt .scala .php` | tree-sitter AST + 调用图 + docstring / 注释中的 rationale |
+| 代码 | `.py .ts .js .jsx .tsx .go .rs .java .c .cpp .rb .cs .kt .scala .php .swift .lua .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .v .sv` | tree-sitter AST + 调用图 + docstring / 注释中的 rationale |
 | 文档 | `.md .txt .rst` | 通过 Claude 提取概念、关系和设计动机 |
 | 论文 | `.pdf` | 引文挖掘 + 概念提取 |
 | 图片 | `.png .jpg .webp .gif` | Claude vision —— 截图、图表、任意语言都可以 |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,7 +18,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.v', '.sv'}
 DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1434,6 +1434,183 @@ def extract_julia(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+# ── Verilog / SystemVerilog extractor (custom walk) ──────────────────────────
+
+def _verilog_find_simple_id(node) -> str | None:
+    """Recursively descend to find the first simple_identifier text."""
+    if node.type == "simple_identifier":
+        return node.text.decode("utf-8", errors="replace")
+    for child in node.children:
+        result = _verilog_find_simple_id(child)
+        if result:
+            return result
+    return None
+
+
+def _verilog_find_name_in(node, container_type: str) -> str | None:
+    """Find the simple_identifier inside a specific container type (e.g. function_identifier)."""
+    for child in node.children:
+        if child.type == container_type:
+            return _verilog_find_simple_id(child)
+        result = _verilog_find_name_in(child, container_type)
+        if result:
+            return result
+    return None
+
+
+def extract_verilog(path: Path) -> dict:
+    """Extract modules, functions, tasks, imports, and instantiations from a .v/.sv file."""
+    try:
+        import tree_sitter_verilog as tsverilog
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return {"nodes": [], "edges": [], "error": "tree-sitter-verilog not installed"}
+
+    try:
+        language = Language(tsverilog.language())
+        parser = Parser(language)
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        root = tree.root_node
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    stem = path.stem
+    str_path = str(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+
+    def add_node(nid: str, label: str, line: int) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({
+                "id": nid, "label": label, "file_type": "code",
+                "source_file": str_path, "source_location": f"L{line}",
+            })
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 confidence: str = "EXTRACTED", score: float = 1.0) -> None:
+        edges.append({
+            "source": src, "target": tgt, "relation": relation,
+            "confidence": confidence, "confidence_score": score,
+            "source_file": str_path, "source_location": f"L{line}", "weight": 1.0,
+        })
+
+    file_nid = _make_id(str_path)
+    add_node(file_nid, path.name, 1)
+
+    def _extract_module_name(mod_node) -> str | None:
+        """Get module name from module_header or module_ansi_header."""
+        for child in mod_node.children:
+            if child.type in ("module_header", "module_ansi_header"):
+                # Find the module keyword, then the next simple_identifier sibling
+                for i, sub in enumerate(child.children):
+                    if sub.type == "module_keyword":
+                        for sib in child.children[i + 1:]:
+                            name = _verilog_find_simple_id(sib)
+                            if name:
+                                return name
+                # Fallback: first simple_identifier in header
+                return _verilog_find_simple_id(child)
+        return None
+
+    def _extract_imports_from_header(mod_node, parent_nid: str) -> None:
+        """Extract package_import_declaration nodes from module_ansi_header."""
+        for child in mod_node.children:
+            if child.type in ("module_header", "module_ansi_header"):
+                for sub in child.children:
+                    if sub.type == "package_import_declaration":
+                        pkg = _verilog_find_name_in(sub, "package_identifier")
+                        if pkg:
+                            line = sub.start_point[0] + 1
+                            pkg_nid = _make_id(pkg)
+                            if pkg_nid not in seen_ids:
+                                add_node(pkg_nid, pkg, line)
+                            add_edge(parent_nid, pkg_nid, "imports", line)
+
+    def _walk_module_body(node, mod_nid: str) -> None:
+        """Walk children of a module looking for functions, tasks, instantiations, imports."""
+        for child in node.children:
+            # Unwrap module_or_generate_item and package_or_generate_item_declaration
+            inner = child
+            if inner.type == "module_or_generate_item":
+                if inner.child_count > 0:
+                    inner = inner.children[0]
+            if inner.type == "package_or_generate_item_declaration":
+                if inner.child_count > 0:
+                    inner = inner.children[0]
+
+            line = inner.start_point[0] + 1
+
+            if inner.type == "function_declaration":
+                name = _verilog_find_name_in(inner, "function_identifier")
+                if name:
+                    fnid = _make_id(stem, name)
+                    add_node(fnid, f"{name}()", line)
+                    add_edge(mod_nid, fnid, "method", line)
+
+            elif inner.type == "task_declaration":
+                name = _verilog_find_name_in(inner, "task_identifier")
+                if name:
+                    tnid = _make_id(stem, name)
+                    add_node(tnid, f"{name}()", line)
+                    add_edge(mod_nid, tnid, "method", line)
+
+            elif inner.type in ("module_instantiation", "checker_instantiation"):
+                inst_type = _verilog_find_simple_id(inner)
+                if inst_type:
+                    type_nid = _make_id(inst_type)
+                    if type_nid not in seen_ids:
+                        add_node(type_nid, inst_type, line)
+                    add_edge(mod_nid, type_nid, "instantiates", line)
+
+            elif inner.type == "concurrent_assertion_item":
+                # checker_instantiation can be wrapped in concurrent_assertion_item
+                for sub in inner.children:
+                    if sub.type == "checker_instantiation":
+                        inst_type = _verilog_find_simple_id(sub)
+                        if inst_type:
+                            sub_line = sub.start_point[0] + 1
+                            type_nid = _make_id(inst_type)
+                            if type_nid not in seen_ids:
+                                add_node(type_nid, inst_type, sub_line)
+                            add_edge(mod_nid, type_nid, "instantiates", sub_line)
+
+            elif inner.type == "package_import_declaration":
+                pkg = _verilog_find_name_in(inner, "package_identifier")
+                if pkg:
+                    pkg_nid = _make_id(pkg)
+                    if pkg_nid not in seen_ids:
+                        add_node(pkg_nid, pkg, line)
+                    add_edge(mod_nid, pkg_nid, "imports", line)
+
+    # Walk top-level declarations
+    for child in root.children:
+        if child.type == "module_declaration":
+            mod_name = _extract_module_name(child)
+            if not mod_name:
+                continue
+            line = child.start_point[0] + 1
+            mod_nid = _make_id(stem, mod_name)
+            add_node(mod_nid, mod_name, line)
+            add_edge(file_nid, mod_nid, "contains", line)
+            _extract_imports_from_header(child, mod_nid)
+            _walk_module_body(child, mod_nid)
+
+        elif child.type == "package_import_declaration":
+            # File-scope imports (outside modules)
+            pkg = _verilog_find_simple_id(child)
+            if pkg:
+                line = child.start_point[0] + 1
+                pkg_nid = _make_id(pkg)
+                if pkg_nid not in seen_ids:
+                    add_node(pkg_nid, pkg, line)
+                add_edge(file_nid, pkg_nid, "imports", line)
+
+    return {"nodes": nodes, "edges": edges}
+
+
 # ── Go extractor (custom walk) ────────────────────────────────────────────────
 
 def extract_go(path: Path) -> dict:
@@ -2695,6 +2872,8 @@ def extract(paths: list[Path]) -> dict:
         ".jl": extract_julia,
         ".vue": extract_js,
         ".svelte": extract_js,
+        ".v": extract_verilog,
+        ".sv": extract_verilog,
     }
 
     total = len(paths)
@@ -2754,6 +2933,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
         ".lua", ".toc", ".zig", ".ps1",
         ".m", ".mm",
+        ".v", ".sv",
     }
     from graphify.detect import _load_graphifyignore, _is_ignored
     ignore_root = root if root is not None else target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tree-sitter-elixir",
     "tree-sitter-objc",
     "tree-sitter-julia",
+    "tree-sitter-verilog",
 ]
 
 [project.urls]

--- a/tests/fixtures/sample.sv
+++ b/tests/fixtures/sample.sv
@@ -1,0 +1,33 @@
+// Sample SystemVerilog file for graphify extraction tests
+import some_pkg::*;
+
+module DataProcessor
+  import veer_types::*;
+  #(parameter WIDTH = 32)
+  (
+    input  logic             clk,
+    input  logic             rst_n,
+    output logic [WIDTH-1:0] data_out
+  );
+
+  function automatic logic [WIDTH-1:0] calc_checksum;
+    input logic [WIDTH-1:0] data;
+    calc_checksum = data ^ {WIDTH{1'b1}};
+  endfunction
+
+  task automatic do_reset;
+    data_out <= '0;
+  endtask
+
+  SubModule sub_inst (
+    .clk(clk),
+    .data(data_out)
+  );
+
+endmodule
+
+module SubModule (
+  input  logic        clk,
+  input  logic [31:0] data
+);
+endmodule

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,11 +1,11 @@
-"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia."""
+"""Tests for language extractors: Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Go, Julia, Verilog."""
 from __future__ import annotations
 from pathlib import Path
 import pytest
 from graphify.extract import (
     extract_java, extract_c, extract_cpp, extract_ruby,
     extract_csharp, extract_kotlin, extract_scala, extract_php,
-    extract_swift, extract_go, extract_julia,
+    extract_swift, extract_go, extract_julia, extract_verilog,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -505,6 +505,43 @@ def test_julia_finds_calls():
 
 def test_julia_no_dangling_edges():
     r = extract_julia(FIXTURES / "sample.jl")
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"Dangling source: {e}"
+
+
+# ── Verilog / SystemVerilog ──────────────────────────────────────────────────
+
+def test_verilog_no_error():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    assert "error" not in r
+
+def test_verilog_finds_modules():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    labels = _labels(r)
+    assert any("DataProcessor" in l for l in labels)
+    assert any("SubModule" in l for l in labels)
+
+def test_verilog_finds_functions():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    labels = _labels(r)
+    assert any("calc_checksum" in l for l in labels)
+
+def test_verilog_finds_tasks():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    labels = _labels(r)
+    assert any("do_reset" in l for l in labels)
+
+def test_verilog_finds_imports():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    assert "imports" in _relations(r)
+
+def test_verilog_finds_instantiation():
+    r = extract_verilog(FIXTURES / "sample.sv")
+    assert "instantiates" in _relations(r)
+
+def test_verilog_no_dangling_edges():
+    r = extract_verilog(FIXTURES / "sample.sv")
     node_ids = {n["id"] for n in r["nodes"]}
     for e in r["edges"]:
         assert e["source"] in node_ids, f"Dangling source: {e}"


### PR DESCRIPTION
  ## Summary
  - Add tree-sitter-verilog based extraction for Verilog/SystemVerilog (.v/.sv) files
  - Enables graphify to process hardware design codebases (e.g. RISC-V cores)
  - Extracts: modules, functions, tasks, package imports, module instantiations
  - New "instantiates" edge relation for HDL module hierarchy

  ## What's included
  - Custom walk extractor in `extract.py` (~130 lines, follows Go/Rust pattern)
  - `tree-sitter-verilog` dependency in `pyproject.toml`
  - `.v`/`.sv` registered in `detect.py` and `extract.py`
  - 7 tests + `sample.sv` fixture
  - All 4 READMEs updated with new language count (22 → 24)

  ## Tested on real RTL
  Validated against [VeeR EH1 RISC-V core](https://github.com/chipsalliance/Cores-VeeR-EH1):
  - `veer_wrapper.sv` → veer, mem, dmi_wrapper (3 instantiations)
  - `veer.sv` → ifu, exu, lsu, dec, dbg, dma_ctrl... (12 instantiations)
  - `ifu.sv` → ifu_ifc_ctl, ifu_aln_ctl, ifu_bp_ctl, ifu_mem_ctl (5 instantiations)

  ## Test plan
  - [x] `pytest tests/test_languages.py -k verilog` — 7/7 passed
  - [x] `pytest tests/test_languages.py tests/test_multilang.py` — 110/110 passed (no regression)
  - [x] Manual test on real VeeR EH1 RTL files