### PR TITLE
Bugfix/Add missing `--wiki` guide to all skill files

### DIFF
--- a/graphify/skill-aider.md
+++ b/graphify/skill-aider.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -582,6 +583,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
 ```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)

--- a/graphify/skill-claw.md
+++ b/graphify/skill-claw.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -582,6 +583,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
 ```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -640,6 +641,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
 ```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)

--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -642,6 +642,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
 }
 ```
 
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text())
+analysis   = json.loads(Path('graphify-out/.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('graphify-out/.graphify_labels.json').read_text()) if Path('graphify-out/.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
+```
+
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 If `total_words` from `graphify-out/.graphify_detect.json` is greater than 5,000, run:

--- a/graphify/skill-droid.md
+++ b/graphify/skill-droid.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -637,6 +638,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
 ```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -636,6 +637,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
 ```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)

--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -24,6 +24,7 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 /graphify <path> --neo4j-push bolt://localhost:7687   # push directly to Neo4j
 /graphify <path> --mcp                                # start MCP stdio server for agent access
 /graphify <path> --watch                              # watch folder, auto-rebuild on code changes (no LLM needed)
+/graphify <path> --wiki                               # build agent-crawlable wiki (index.md + one article per community)
 /graphify add <url>                                   # fetch URL, save to ./raw, update graph
 /graphify add <url> --author "Name"                   # tag who wrote it
 /graphify add <url> --contributor "Name"              # tag who added it to the corpus
@@ -618,6 +619,29 @@ python3 -m graphify.serve graphify-out/graph.json
 ```
 
 This starts a stdio MCP server that exposes tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`, `god_nodes`, `graph_stats`, `shortest_path`.
+
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat .graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
+```
 
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)
 

--- a/graphify/skill-windows.md
+++ b/graphify/skill-windows.md
@@ -632,6 +632,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
 }
 ```
 
+### Step 7e - Wiki export (only if --wiki flag)
+
+```powershell
+python -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('.graphify_extract.json').read_text())
+analysis   = json.loads(Path('.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('.graphify_labels.json').read_text()) if Path('.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ - entry point: graphify-out/wiki/index.md')
+"
+```
+
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 If `total_words` from `.graphify_detect.json` is greater than 5,000, run:

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -649,6 +649,29 @@ To configure in Claude Desktop, add to `claude_desktop_config.json`:
 }
 ```
 
+### Step 7e - Wiki export (only if --wiki flag)
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json
+from graphify.build import build_from_json
+from graphify.wiki import to_wiki
+from pathlib import Path
+
+extraction = json.loads(Path('graphify-out/.graphify_extract.json').read_text())
+analysis   = json.loads(Path('graphify-out/.graphify_analysis.json').read_text())
+labels_raw = json.loads(Path('graphify-out/.graphify_labels.json').read_text()) if Path('graphify-out/.graphify_labels.json').exists() else {}
+
+G = build_from_json(extraction)
+communities = {int(k): v for k, v in analysis['communities'].items()}
+cohesion    = {int(k): v for k, v in analysis['cohesion'].items()}
+labels      = {int(k): v for k, v in labels_raw.items()}
+
+n = to_wiki(G, communities, 'graphify-out/wiki', community_labels=labels or None, cohesion=cohesion, god_nodes_data=analysis.get('gods', []))
+print(f'Wiki: {n} articles in graphify-out/wiki/ — entry point: graphify-out/wiki/index.md')
+"
+```
+
 ### Step 8 - Token reduction benchmark (only if total_words > 5000)
 
 If `total_words` from `graphify-out/.graphify_detect.json` is greater than 5,000, run:


### PR DESCRIPTION
## Problem

`--wiki` was listed in the flags cheatsheet of all 9 skill files but had no corresponding execution step. When an agent encountered `--wiki`, it had no instructions and would likely attempt `from graphify.export import to_wiki`, which fails — `to_wiki` lives in `graphify.wiki`, not `graphify.export`.

## Changes

Added **Step 7e - Wiki export** to all 9 skill files:

- `skill.md`, `skill-copilot.md` — `$(cat graphify-out/.graphify_python)`, absolute paths
- `skill-windows.md` — `python`, relative paths, `powershell` code fence
- `skill-aider.md`, `skill-claw.md`, `skill-codex.md`, `skill-droid.md`,
  `skill-opencode.md`, `skill-trae.md` — `$(cat .graphify_python)`, relative paths

For the 6 platform files that were also missing `--wiki` from the cheatsheet, that entry was added as well.

Each Step 7e correctly imports `from graphify.wiki import to_wiki` and passes all three optional enrichment args: `community_labels`, `cohesion`, and `god_nodes_data` (from `analysis['gods']`).

## Related issues

- #229
