### PR TITLE
Add Kiro IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Every relationship is tagged `EXTRACTED` (found directly in source), `INFERRED` 
 
 ## Install
 
-**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), [Trae](https://trae.ai), Hermes, or [Google Antigravity](https://antigravity.google)
+**Requires:** Python 3.10+ and one of: [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [OpenCode](https://opencode.ai), [Cursor](https://cursor.com), [Kiro IDE](https://kiro.ai), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), [Aider](https://aider.chat), [OpenClaw](https://openclaw.ai), [Factory Droid](https://factory.ai), [Trae](https://trae.ai), Hermes, or [Google Antigravity](https://antigravity.google)
 
 ```bash
 pip install graphifyy && graphify install
@@ -64,6 +64,7 @@ pip install graphifyy && graphify install
 | Claude Code (Windows) | `graphify install` (auto-detected) or `graphify install --platform windows` |
 | Codex | `graphify install --platform codex` |
 | OpenCode | `graphify install --platform opencode` |
+| Kiro IDE | `graphify install --platform kiro` |
 | GitHub Copilot CLI | `graphify install --platform copilot` |
 | Aider | `graphify install --platform aider` |
 | OpenClaw | `graphify install --platform claw` |
@@ -94,6 +95,7 @@ After building a graph, run this once in your project:
 | Claude Code | `graphify claude install` |
 | Codex | `graphify codex install` |
 | OpenCode | `graphify opencode install` |
+| Kiro IDE | `graphify kiro install` |
 | GitHub Copilot CLI | `graphify copilot install` |
 | Aider | `graphify aider install` |
 | OpenClaw | `graphify claw install` |
@@ -112,6 +114,8 @@ After building a graph, run this once in your project:
 **OpenCode** writes to `AGENTS.md` and also installs a **`tool.execute.before` plugin** (`.opencode/plugins/graphify.js` + `opencode.json` registration) that fires before bash tool calls and injects the graph reminder into tool output when the graph exists.
 
 **Cursor** writes `.cursor/rules/graphify.mdc` with `alwaysApply: true` — Cursor includes it in every conversation automatically, no hook needed.
+
+**Kiro IDE** copies the skill to `~/.kiro/skills/graphify/SKILL.md` and writes a steering file to `.kiro/steering/graphify.md` — Kiro automatically includes steering files in the agent context, providing always-on graph awareness.
 
 **Gemini CLI** copies the skill to `~/.gemini/skills/graphify/SKILL.md`, writes a `GEMINI.md` section, and installs a `BeforeTool` hook in `.gemini/settings.json` that fires before file-read tool calls — same always-on mechanism as Claude Code.
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -107,6 +107,11 @@ _PLATFORM_CONFIG: dict[str, dict] = {
         "skill_dst": Path(".claude") / "skills" / "graphify" / "SKILL.md",
         "claude_md": True,
     },
+    "kiro": {
+        "skill_file": "skill.md",
+        "skill_dst": Path(".kiro") / "skills" / "graphify" / "SKILL.md",
+        "claude_md": False,
+    },
 }
 
 
@@ -116,6 +121,9 @@ def install(platform: str = "claude") -> None:
         return
     if platform == "cursor":
         _cursor_install(Path("."))
+        return
+    if platform == "kiro":
+        _kiro_install(Path("."))
         return
     if platform not in _PLATFORM_CONFIG:
         print(
@@ -445,6 +453,73 @@ def _cursor_uninstall(project_dir: Path) -> None:
         return
     rule_path.unlink()
     print(f"graphify Cursor rule removed from {rule_path.resolve()}")
+
+
+_KIRO_STEERING_PATH = Path(".kiro") / "steering" / "graphify.md"
+_KIRO_STEERING = """\
+# graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+"""
+
+
+def _kiro_install(project_dir: Path) -> None:
+    """Install graphify for Kiro IDE: skill + .kiro/steering/ file."""
+    # 1. Copy skill file to ~/.kiro/skills/graphify/SKILL.md
+    cfg = _PLATFORM_CONFIG["kiro"]
+    skill_src = Path(__file__).parent / cfg["skill_file"]
+    if not skill_src.exists():
+        print(f"error: {cfg['skill_file']} not found in package - reinstall graphify", file=sys.stderr)
+        sys.exit(1)
+
+    skill_dst = Path.home() / cfg["skill_dst"]
+    skill_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(skill_src, skill_dst)
+    (skill_dst.parent / ".graphify_version").write_text(__version__, encoding="utf-8")
+    print(f"  skill installed  ->  {skill_dst}")
+
+    # 2. Write .kiro/steering/graphify.md
+    steering_path = project_dir / _KIRO_STEERING_PATH
+    steering_path.parent.mkdir(parents=True, exist_ok=True)
+    if steering_path.exists():
+        print(f"graphify steering already exists at {steering_path} (no change)")
+    else:
+        steering_path.write_text(_KIRO_STEERING, encoding="utf-8")
+        print(f"graphify steering written to {steering_path.resolve()}")
+
+    print()
+    print("Kiro IDE will now check the knowledge graph before answering")
+    print("codebase questions. Run /graphify first to build the graph.")
+
+
+def _kiro_uninstall(project_dir: Path) -> None:
+    """Remove graphify steering file and skill for Kiro IDE."""
+    # Remove steering file
+    steering_path = project_dir / _KIRO_STEERING_PATH
+    if steering_path.exists():
+        steering_path.unlink()
+        print(f"graphify steering removed from {steering_path.resolve()}")
+    else:
+        print("No graphify steering file found - nothing to do")
+
+    # Remove skill file
+    skill_dst = Path.home() / _PLATFORM_CONFIG["kiro"]["skill_dst"]
+    if skill_dst.exists():
+        skill_dst.unlink()
+        print(f"graphify skill removed from {skill_dst}")
+    version_file = skill_dst.parent / ".graphify_version"
+    if version_file.exists():
+        version_file.unlink()
+    for d in (skill_dst.parent, skill_dst.parent.parent, skill_dst.parent.parent.parent):
+        try:
+            d.rmdir()
+        except OSError:
+            break
 
 
 # OpenCode tool.execute.before plugin — fires before every tool call.
@@ -802,6 +877,8 @@ def main() -> None:
         print("  antigravity uninstall   remove .agent/rules, .agent/workflows, and skill")
         print("  hermes install          write skill to ~/.hermes/skills/graphify/ (Hermes)")
         print("  hermes uninstall        remove skill from ~/.hermes/skills/graphify/")
+        print("  kiro install            write skill to ~/.kiro/skills + steering file (Kiro IDE)")
+        print("  kiro uninstall          remove skill and steering file (Kiro IDE)")
         print()
         return
 
@@ -890,6 +967,15 @@ def main() -> None:
             _antigravity_uninstall(Path("."))
         else:
             print("Usage: graphify antigravity [install|uninstall]", file=sys.stderr)
+            sys.exit(1)
+    elif cmd == "kiro":
+        subcmd = sys.argv[2] if len(sys.argv) > 2 else ""
+        if subcmd == "install":
+            _kiro_install(Path("."))
+        elif subcmd == "uninstall":
+            _kiro_uninstall(Path("."))
+        else:
+            print("Usage: graphify kiro [install|uninstall]", file=sys.stderr)
             sys.exit(1)
     elif cmd == "hook":
         from graphify.hooks import install as hook_install, uninstall as hook_uninstall, status as hook_status


### PR DESCRIPTION
# Add Kiro IDE Support

## Summary
This PR adds support for [Kiro IDE](https://kiro.ai) to graphify, enabling seamless integration with Kiro's steering file system for always-on knowledge graph awareness.

## Changes

### Core Implementation
- **Added Kiro platform configuration** to `_PLATFORM_CONFIG` in `graphify/__main__.py`
- **Implemented `_kiro_install()` function** that:
  - Copies skill file to `~/.kiro/skills/graphify/SKILL.md`
  - Creates steering file at `.kiro/steering/graphify.md`
  - Includes version tracking via `.graphify_version`
- **Implemented `_kiro_uninstall()` function** for clean removal
- **Added CLI commands**: `graphify kiro install` and `graphify kiro uninstall`
- **Updated help text** to include Kiro commands

### Documentation
- Added Kiro IDE to supported platforms list in README.md
- Added installation instructions for Kiro
- Documented how Kiro integration works using steering files

## How It Works

Kiro IDE uses **steering files** - a Kiro-specific feature that automatically includes context in all agent interactions. The integration:

1. Installs the graphify skill globally in `~/.kiro/skills/graphify/SKILL.md`
2. Creates a project-specific steering file at `.kiro/steering/graphify.md`
3. The steering file instructs Kiro to:
   - Read `graphify-out/GRAPH_REPORT.md` before answering architecture questions
   - Navigate `graphify-out/wiki/index.md` if it exists
   - Keep the graph current after code modifications

## Usage

```bash
# Install Kiro support
graphify install --platform kiro
# or
graphify kiro install

# Build a knowledge graph
graphify .

# Uninstall (if needed)
graphify kiro uninstall
```

## Testing

- ✅ Verified `graphify kiro install` creates skill and steering files
- ✅ Verified `graphify kiro uninstall` removes all files cleanly
- ✅ Verified commands appear in `graphify --help`
- ✅ No Python diagnostics/errors
- ✅ Package installs successfully with `pip install -e .`

## Consistency with Other Platforms

This implementation follows the same pattern as other platform integrations:
- **Cursor**: Uses `.cursor/rules/graphify.mdc` with `alwaysApply: true`
- **Gemini CLI**: Uses `GEMINI.md` + BeforeTool hook
- **Kiro IDE**: Uses `.kiro/steering/graphify.md` (auto-included)

Each platform uses its native "always-on" mechanism for persistent context.

## Related

This addresses the need for Kiro IDE support as discussed in the community. Kiro's steering file system provides a clean, native way to integrate graphify's knowledge graph awareness without requiring hooks or manual configuration.
