### PR TITLE
Improve shell-friendly CLI aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ graphify add https://... --author "Name" --contributor "Name"
 # incremental update and maintenance
 graphify watch ./src                         # auto-rebuild on code changes
 graphify update ./src                        # re-extract code files, no LLM needed
+graphify --update ./src                      # same thing, PowerShell/CMD-friendly alias
 graphify cluster-only ./my-project           # rerun clustering on existing graph.json
 ```
 

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -14,6 +14,35 @@ except Exception:
     __version__ = "unknown"
 
 
+_TOP_LEVEL_COMMANDS = {
+    "install",
+    "claude",
+    "gemini",
+    "cursor",
+    "copilot",
+    "kiro",
+    "aider",
+    "codex",
+    "opencode",
+    "claw",
+    "droid",
+    "trae",
+    "trae-cn",
+    "hermes",
+    "antigravity",
+    "hook",
+    "query",
+    "save-result",
+    "path",
+    "explain",
+    "add",
+    "watch",
+    "cluster-only",
+    "update",
+    "benchmark",
+}
+
+
 def _check_skill_version(skill_dst: Path) -> None:
     """Warn if the installed skill is from an older graphify version."""
     version_file = skill_dst.parent / ".graphify_version"
@@ -22,6 +51,17 @@ def _check_skill_version(skill_dst: Path) -> None:
     installed = version_file.read_text(encoding="utf-8").strip()
     if installed != __version__:
         print(f"  warning: skill is from graphify {installed}, package is {__version__}. Run 'graphify install' to update.")
+
+
+def _normalize_command_token(token: str) -> str:
+    """Accept shell-friendly `--command` aliases for top-level graphify commands."""
+    if token in _TOP_LEVEL_COMMANDS:
+        return token
+    if token.startswith("--"):
+        alias = token[2:]
+        if alias in _TOP_LEVEL_COMMANDS:
+            return alias
+    return token
 
 _SETTINGS_HOOK = {
     "matcher": "Glob|Grep",
@@ -829,7 +869,9 @@ def main() -> None:
         print("    --dir <path>            target directory (default: ./raw)")
         print("  watch <path>            watch a folder and rebuild the graph on code changes")
         print("  update <path>           re-extract code files and update the graph (no LLM needed)")
+        print("    alias: --update <path>  shell-friendly form for PowerShell/CMD users")
         print("  cluster-only <path>     rerun clustering on an existing graph.json and regenerate report")
+        print("    alias: --cluster-only <path>")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
         print("    --budget N              cap output at N tokens (default 2000)")
@@ -875,7 +917,7 @@ def main() -> None:
         print()
         return
 
-    cmd = sys.argv[1]
+    cmd = _normalize_command_token(sys.argv[1])
     if cmd == "install":
         # Default to windows platform on Windows, claude elsewhere
         default_platform = "windows" if platform.system() == "Windows" else "claude"
@@ -1176,7 +1218,7 @@ def main() -> None:
         try:
             saved = _ingest(url, target_dir, author=author, contributor=contributor)
             print(f"Saved to {saved}")
-            print("Run /graphify --update in your AI assistant to update the graph.")
+            print("Run graphify --update in your shell, or /graphify --update in your AI assistant, to update the graph.")
         except Exception as exc:
             print(f"error: {exc}", file=sys.stderr)
             sys.exit(1)
@@ -1233,7 +1275,7 @@ def main() -> None:
         print(f"Re-extracting code files in {watch_path} (no LLM needed)...")
         ok = _rebuild_code(watch_path)
         if ok:
-            print("Code graph updated. For doc/paper/image changes run /graphify --update in your AI assistant.")
+            print("Code graph updated. For doc/paper/image changes run graphify --update in your shell, or /graphify --update in your AI assistant.")
         else:
             print("Nothing to update or rebuild failed — check output above.")
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,4 +1,4 @@
-# monitor a folder and auto-trigger --update when files change
+# monitor a folder and auto-trigger graphify --update when files change
 from __future__ import annotations
 import json
 import time
@@ -99,7 +99,7 @@ def _notify_only(watch_path: Path) -> None:
     flag.write_text("1", encoding="utf-8")
     print(f"\n[graphify watch] New or changed files detected in {watch_path}")
     print("[graphify watch] Non-code files changed - semantic re-extraction requires LLM.")
-    print("[graphify watch] Run `/graphify --update` in Claude Code to update the graph.")
+    print("[graphify watch] Run `graphify --update` in your shell, or `/graphify --update` in Claude Code.")
     print(f"[graphify watch] Flag written to {flag}")
 
 
@@ -113,7 +113,7 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
 
     For code-only changes: re-runs AST extraction + rebuild immediately (no LLM).
     For doc/paper/image changes: writes a needs_update flag and notifies the user
-    to run /graphify --update (LLM extraction required).
+    to run graphify --update in your shell, or /graphify --update in Claude Code (LLM extraction required).
 
     debounce: seconds to wait after the last change before triggering (avoids
     running on every keystroke when many files are saved at once).
@@ -151,7 +151,7 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
 
     print(f"[graphify watch] Watching {watch_path.resolve()} - press Ctrl+C to stop")
     print(f"[graphify watch] Code changes rebuild graph automatically. "
-          f"Doc/image changes require /graphify --update.")
+          f"Doc/image changes require graphify --update (or /graphify --update in Claude Code).")
     print(f"[graphify watch] Debounce: {debounce}s")
 
     try:

--- a/progress.txt
+++ b/progress.txt
@@ -5,10 +5,10 @@
 - 2026-04-14: Started a feature branch for the fix: `feature/windows-cli-aliases`.
 - 2026-04-14: Implemented shell-friendly top-level aliases (`--update`, `--cluster-only`) and refreshed shell-facing docs.
 - 2026-04-14: Verification passed: `python -m pytest -q` -> 435 passed.
+- 2026-04-14: Pushed branch to fork `dikotiledon/graphify` and opened PR #340 against upstream.
 
 ## IN PROGRESS
-- Ready to commit and push the branch.
+- None.
 
 ## NEXT
-- Commit the change.
-- Push the branch to origin.
+- Await review / merge.

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,14 @@
+# graphify CLI shell-alias improvement
+
+## DONE
+- 2026-04-14: Confirmed the repo has a working `graphify update` subcommand, but `graphify --update` fails in the current CLI parser.
+- 2026-04-14: Started a feature branch for the fix: `feature/windows-cli-aliases`.
+- 2026-04-14: Implemented shell-friendly top-level aliases (`--update`, `--cluster-only`) and refreshed shell-facing docs.
+- 2026-04-14: Verification passed: `python -m pytest -q` -> 435 passed.
+
+## IN PROGRESS
+- Ready to commit and push the branch.
+
+## NEXT
+- Commit the change.
+- Push the branch to origin.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+"""CLI behaviour tests for shell-friendly command aliases."""
+
+from pathlib import Path
+import sys
+
+
+def test_normalize_command_token_accepts_shell_aliases():
+    from graphify.__main__ import _normalize_command_token
+
+    assert _normalize_command_token("update") == "update"
+    assert _normalize_command_token("--update") == "update"
+    assert _normalize_command_token("--cluster-only") == "cluster-only"
+    assert _normalize_command_token("--unknown") == "--unknown"
+
+
+def test_main_update_accepts_shell_alias(monkeypatch, tmp_path):
+    from graphify.__main__ import main
+    import graphify.watch
+
+    called = {}
+
+    def fake_rebuild(path: Path) -> bool:
+        called["path"] = path
+        return True
+
+    monkeypatch.setattr(graphify.watch, "_rebuild_code", fake_rebuild)
+    monkeypatch.setattr(sys, "argv", ["graphify", "--update", str(tmp_path)])
+
+    main()
+
+    assert called["path"] == tmp_path


### PR DESCRIPTION
## Summary
- Accept shell-friendly top-level aliases like `graphify --update` and `graphify --cluster-only`
- Clarify shell vs assistant update commands in docs and watch output
- Add CLI coverage for the alias normalization path

## Test Plan
- `python -m pytest -q`
- `python -m pytest tests/test_cli.py -q`
