### PR TITLE
Harden SSRF validation, fix path traversal in exports, prevent info disclosure

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -479,11 +479,19 @@ def to_obsidian(
 
     # Map node_id → safe filename so wikilinks stay consistent.
     # Deduplicate: if two nodes produce the same filename, append a numeric suffix.
+    resolved_out = out.resolve()
+
     def safe_name(label: str) -> str:
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
         # Strip trailing .md/.mdx/.markdown so "CLAUDE.md" doesn't become "CLAUDE.md.md"
         cleaned = re.sub(r"\.(md|mdx|markdown)$", "", cleaned, flags=re.IGNORECASE)
-        return cleaned or "unnamed"
+        cleaned = cleaned.replace("..", "")
+        return cleaned[:200] or "unnamed"
+
+    def _safe_write(filename: str, content: str) -> None:
+        target = (out / filename).resolve()
+        target.relative_to(resolved_out)  # raises ValueError if path escapes
+        target.write_text(content, encoding="utf-8")
 
     node_filename: dict[str, str] = {}
     seen_names: dict[str, int] = {}
@@ -565,7 +573,7 @@ def to_obsidian(
         lines.append(inline_tags)
 
         fname = node_filename[node_id] + ".md"
-        (out / fname).write_text("\n".join(lines), encoding="utf-8")
+        _safe_write(fname, "\n".join(lines))
 
     # Write one _COMMUNITY_name.md overview note per community
     # Build inter-community edge counts for "Connections to other communities"
@@ -682,7 +690,7 @@ def to_obsidian(
 
         community_safe = safe_name(community_name)
         fname = f"_COMMUNITY_{community_safe}.md"
-        (out / fname).write_text("\n".join(lines), encoding="utf-8")
+        _safe_write(fname, "\n".join(lines))
         community_notes_written += 1
 
     # Improvement 4: write .obsidian/graph.json to color nodes by community in graph view

--- a/graphify/security.py
+++ b/graphify/security.py
@@ -16,7 +16,11 @@ _MAX_FETCH_BYTES = 52_428_800   # 50 MB hard cap for binary downloads
 _MAX_TEXT_BYTES  = 10_485_760   # 10 MB hard cap for HTML / text
 
 # AWS metadata, link-local, and common cloud metadata endpoints
-_BLOCKED_HOSTS = {"metadata.google.internal", "metadata.google.com"}
+_BLOCKED_HOSTS = {
+    "metadata.google.internal", "metadata.google.com",
+    "instance-data.ec2.internal",
+    "metadata.azure.com",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -53,13 +57,19 @@ def validate_url(url: str) -> str:
             for info in infos:
                 addr = info[4][0]
                 ip = ipaddress.ip_address(addr)
+                # Normalize IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+                if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+                    ip = ip.ipv4_mapped
                 if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
                     raise ValueError(
                         f"Blocked private/internal IP {addr} (resolved from '{hostname}'). "
                         f"Got: {url!r}"
                     )
         except socket.gaierror:
-            pass  # DNS failure will surface later during fetch
+            raise ValueError(
+                f"Could not resolve hostname '{hostname}' for URL validation. "
+                f"Got: {url!r}"
+            )
 
     return url
 

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -356,7 +356,8 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         try:
             return [types.TextContent(type="text", text=handler(arguments))]
         except Exception as exc:
-            return [types.TextContent(type="text", text=f"Error executing {name}: {exc}")]
+            print(f"error: tool {name} failed: {exc}", file=sys.stderr)
+            return [types.TextContent(type="text", text=f"Internal error executing {name}. Check server logs.")]
 
     import asyncio
 

--- a/graphify/transcribe.py
+++ b/graphify/transcribe.py
@@ -56,7 +56,7 @@ def download_audio(url: str, output_dir: Path) -> Path:
 
     # yt-dlp uses %(title)s which can be long/weird — use a stable name based on URL hash
     import hashlib
-    url_hash = hashlib.sha1(url.encode()).hexdigest()[:12]
+    url_hash = hashlib.sha256(url.encode()).hexdigest()[:12]
     out_template = str(output_dir / f"yt_{url_hash}.%(ext)s")
 
     # Check for already-downloaded file

--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -7,7 +7,10 @@ import networkx as nx
 
 
 def _safe_filename(name: str) -> str:
-    return name.replace("/", "-").replace(" ", "_").replace(":", "-")
+    cleaned = name.replace("/", "-").replace(" ", "_").replace(":", "-")
+    # Strip path traversal components
+    cleaned = cleaned.replace("..", "")
+    return cleaned[:200] or "unnamed"
 
 
 def _cross_community_links(G: nx.Graph, nodes: list[str], own_cid: int, labels: dict[int, str]) -> list[tuple[str, int]]:
@@ -191,11 +194,18 @@ def to_wiki(
 
     count = 0
 
+    resolved_out = out.resolve()
+
+    def _safe_write(filename: str, content: str) -> None:
+        target = (out / filename).resolve()
+        target.relative_to(resolved_out)  # raises ValueError if path escapes
+        target.write_text(content)
+
     # Community articles
     for cid, nodes in communities.items():
         label = labels.get(cid, f"Community {cid}")
         article = _community_article(G, cid, nodes, label, labels, cohesion.get(cid))
-        (out / f"{_safe_filename(label)}.md").write_text(article)
+        _safe_write(f"{_safe_filename(label)}.md", article)
         count += 1
 
     # God node articles
@@ -203,7 +213,7 @@ def to_wiki(
         nid = node_data.get("id")
         if nid and nid in G:
             article = _god_node_article(G, nid, labels)
-            (out / f"{_safe_filename(node_data['label'])}.md").write_text(article)
+            _safe_write(f"{_safe_filename(node_data['label'])}.md", article)
             count += 1
 
     # Index


### PR DESCRIPTION
## Summary

Security hardening across 5 files (39 insertions, 10 deletions), found via automated audit. All 433 existing tests pass unchanged.

- **SSRF validation (security.py)**: DNS resolution failures now raise `ValueError` (fail-closed) instead of silently passing. Expanded cloud metadata blocklist to cover AWS (`instance-data.ec2.internal`) and Azure (`metadata.azure.com`). IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) are now normalized before private IP range checks.
- **Path traversal (wiki.py, export.py)**: Wiki and Obsidian vault exports now strip `..` from generated filenames, truncate to 200 chars, and enforce `resolve().relative_to()` containment — crafted node labels can no longer write files outside the output directory.
- **Info disclosure (serve.py)**: MCP tool error handler now returns a generic message instead of leaking `str(exc)` (which could expose file paths, library versions, or internal state). Full errors are logged to stderr.
- **Weak hash (transcribe.py)**: Replaced `hashlib.sha1` with `hashlib.sha256` for URL-based audio cache keys, consistent with `cache.py` which already uses SHA-256.

## Test plan

- [x] All 433 tests pass (`pytest tests/ -v` — 0 failures, 0 new failures)
- [x] Verified via independent review agent: all fixes confirmed in place
- [ ] Manual: confirm `graphify add <url>` with an unresolvable hostname now raises instead of passing through
- [ ] Manual: confirm Obsidian/wiki export with adversarial node labels stays contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)