### PR TITLE
fix: recognize .mjs and .ejs files in AST extractor

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,8 +18,8 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv'}
-DOC_EXTENSIONS = {'.md', '.txt', '.rst'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv'}
+DOC_EXTENSIONS = {'.md', '.txt', '.rst', '.ejs'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3063,6 +3063,7 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
         ".py": extract_python,
         ".js": extract_js,
         ".jsx": extract_js,
+        ".mjs": extract_js,
         ".ts": extract_js,
         ".tsx": extract_js,
         ".go": extract_go,
@@ -3180,7 +3181,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
     if target.is_file():
         return [target]
     _EXTENSIONS = {
-        ".py", ".js", ".ts", ".tsx", ".go", ".rs",
+        ".py", ".js", ".mjs", ".ts", ".tsx", ".go", ".rs",
         ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
         ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
         ".lua", ".toc", ".zig", ".ps1",


### PR DESCRIPTION
Fixes #365. Added `.mjs` and `.ejs` file extensions to the AST extractor so modern ES module files and EJS templates are properly parsed.

- `.mjs` added to `CODE_EXTENSIONS`, `_DISPATCH` (mapped to `extract_js`), and `collect_files` `_EXTENSIONS` — treated identically to `.js`
- `.ejs` added to `DOC_EXTENSIONS` for semantic extraction processing

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — session health scoring and CLAUDE.md adherence analysis. Both tools help developers get deeper signal from their codebases and sessions.