### PR TITLE
fix: use polling observer by default on macOS watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Audio never leaves your machine. All transcription runs locally.
 
 **Token benchmark** - printed automatically after every run. On a mixed corpus (Karpathy repos + papers + images): **71.5x** fewer tokens per query vs reading raw files. The first run extracts and builds the graph (this costs tokens). Every subsequent query reads the compact graph instead of raw files — that's where the savings compound. The SHA256 cache means re-runs only re-process changed files.
 
-**Auto-sync** (`--watch`) - run in a background terminal and the graph updates itself as your codebase changes. Code file saves trigger an instant rebuild (AST only, no LLM). Doc/image changes notify you to run `--update` for the LLM re-pass.
+**Auto-sync** (`--watch`) - run in a background terminal and the graph updates itself as your codebase changes. Code file saves trigger an instant rebuild (AST only, no LLM). Doc/image changes notify you to run `--update` for the LLM re-pass. On macOS, watch mode now defaults to `PollingObserver` for better stability; set `GRAPHIFY_WATCH_OBSERVER=native` if you want to force the platform watcher.
 
 **Git hooks** (`graphify hook install`) - installs post-commit and post-checkout hooks. Graph rebuilds automatically after every commit and every branch switch. If a rebuild fails, the hook exits with a non-zero code so git surfaces the error instead of silently continuing. No background process needed.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -186,7 +186,7 @@ graphify trae-cn uninstall
 
 **Token 基准** —— 每次运行后都会自动打印。对混合语料（Karpathy 的仓库 + 论文 + 图片），每次查询的 token 消耗可以比直接读原文件少 **71.5 倍**。第一次运行需要先提取并建图，这一步会花 token；后续查询直接读取压缩后的图谱，节省会越来越明显。SHA256 缓存保证重复运行时只重新处理变更文件。
 
-**自动同步**（`--watch`）—— 在后台终端里跑着，代码库一变化，图谱就会跟着更新。代码文件保存会立刻触发重建（只走 AST，不用 LLM）；文档/图片变更则会提醒你跑 `--update` 进行 LLM 再提取。
+**自动同步**（`--watch`）—— 在后台终端里跑着，代码库一变化，图谱就会跟着更新。代码文件保存会立刻触发重建（只走 AST，不用 LLM）；文档/图片变更则会提醒你跑 `--update` 进行 LLM 再提取。macOS 下为了稳定性默认使用 `PollingObserver`；如果你想强制使用系统原生 watcher，可以设置 `GRAPHIFY_WATCH_OBSERVER=native`。
 
 **Git hooks**（`graphify hook install`）—— 安装 `post-commit` 和 `post-checkout` hook。每次 commit 后、每次切分支后都会自动重建图谱，不需要额外开一个后台进程。
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,6 +1,8 @@
 # monitor a folder and auto-trigger --update when files change
 from __future__ import annotations
 import json
+import os
+import platform
 import time
 from pathlib import Path
 
@@ -9,6 +11,38 @@ from graphify.detect import CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, I
 
 _WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAGE_EXTENSIONS
 _CODE_EXTENSIONS = CODE_EXTENSIONS
+
+
+def _observer_mode() -> str:
+    """
+    Choose which watchdog observer to use.
+
+    Modes:
+    - auto    : PollingObserver on macOS, native Observer elsewhere
+    - native  : always use native Observer
+    - polling : always use PollingObserver
+    """
+    mode = os.environ.get("GRAPHIFY_WATCH_OBSERVER", "auto").strip().lower()
+    if mode not in {"auto", "native", "polling"}:
+        mode = "auto"
+    return mode
+
+
+def _observer_class():
+    try:
+        from watchdog.observers import Observer
+        from watchdog.observers.polling import PollingObserver
+    except ImportError as e:
+        raise ImportError("watchdog not installed. Run: pip install watchdog") from e
+
+    mode = _observer_mode()
+    if mode == "polling":
+        return PollingObserver, "polling"
+    if mode == "native":
+        return Observer, "native"
+    if platform.system() == "Darwin":
+        return PollingObserver, "polling"
+    return Observer, "native"
 
 
 def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
@@ -119,7 +153,6 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
     running on every keystroke when many files are saved at once).
     """
     try:
-        from watchdog.observers import Observer
         from watchdog.events import FileSystemEventHandler
     except ImportError as e:
         raise ImportError("watchdog not installed. Run: pip install watchdog") from e
@@ -145,11 +178,13 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
             changed.add(path)
 
     handler = Handler()
-    observer = Observer()
+    ObserverClass, observer_kind = _observer_class()
+    observer = ObserverClass()
     observer.schedule(handler, str(watch_path), recursive=True)
     observer.start()
 
     print(f"[graphify watch] Watching {watch_path.resolve()} - press Ctrl+C to stop")
+    print(f"[graphify watch] Observer: {observer_kind}")
     print(f"[graphify watch] Code changes rebuild graph automatically. "
           f"Doc/image changes require /graphify --update.")
     print(f"[graphify watch] Debounce: {debounce}s")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,9 +1,8 @@
 """Tests for watch.py - file watcher helpers (no watchdog required)."""
-import time
 from pathlib import Path
 import pytest
 
-from graphify.watch import _notify_only, _WATCHED_EXTENSIONS
+from graphify.watch import _notify_only, _WATCHED_EXTENSIONS, _observer_mode
 
 
 # --- _notify_only ---
@@ -66,3 +65,23 @@ def test_watch_raises_without_watchdog(tmp_path, monkeypatch):
     from graphify.watch import watch
     with pytest.raises(ImportError, match="watchdog not installed"):
         watch(tmp_path)
+
+
+def test_observer_mode_defaults_to_auto(monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_WATCH_OBSERVER", raising=False)
+    assert _observer_mode() == "auto"
+
+
+def test_observer_mode_invalid_falls_back_to_auto(monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_WATCH_OBSERVER", "banana")
+    assert _observer_mode() == "auto"
+
+
+def test_observer_mode_accepts_native(monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_WATCH_OBSERVER", "native")
+    assert _observer_mode() == "native"
+
+
+def test_observer_mode_accepts_polling(monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_WATCH_OBSERVER", "polling")
+    assert _observer_mode() == "polling"


### PR DESCRIPTION
## Summary\n- use  by default on macOS watch mode for better stability\n- allow override via \n- document the behavior in README + README.zh-CN\n- add tests for observer mode parsing\n\n## Why\nOn macOS, the native watchdog observer can fail to start reliably in some environments with errors like . This patch makes watch mode more stable out of the box on macOS while still letting advanced users opt back into the native observer.\n\n## Testing\n- ............                                                             [100%]
12 passed in 0.01s