### PR TITLE
fix: rename god_nodes 'edges' field to 'degree'

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -51,7 +51,7 @@ def god_nodes(G: nx.Graph, top_n: int = 10) -> list[dict]:
         result.append({
             "id": node_id,
             "label": G.nodes[node_id].get("label", node_id),
-            "edges": deg,
+            "degree": deg,
         })
         if len(result) >= top_n:
             break

--- a/graphify/report.py
+++ b/graphify/report.py
@@ -72,7 +72,7 @@ def generate(
         "## God Nodes (most connected - your core abstractions)",
     ]
     for i, node in enumerate(god_node_list, 1):
-        lines.append(f"{i}. `{node['label']}` - {node['edges']} edges")
+        lines.append(f"{i}. `{node['label']}` - {node['degree']} edges")
 
     lines += ["", "## Surprising Connections (you probably didn't know these)"]
     if surprise_list:

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -295,7 +295,7 @@ def serve(graph_path: str = "graphify-out/graph.json") -> None:
         from .analyze import god_nodes as _god_nodes
         nodes = _god_nodes(G, top_n=int(arguments.get("top_n", 10)))
         lines = ["God nodes (most connected):"]
-        lines += [f"  {i}. {n['label']} - {n['edges']} edges" for i, n in enumerate(nodes, 1)]
+        lines += [f"  {i}. {n['label']} - {n['degree']} edges" for i, n in enumerate(nodes, 1)]
         return "\n".join(lines)
 
     def _tool_graph_stats(_: dict) -> str:

--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -154,7 +154,7 @@ def _index_md(
     if god_nodes_data:
         lines += ["## God Nodes", "(most connected concepts — the load-bearing abstractions)", ""]
         for node in god_nodes_data:
-            lines.append(f"- [[{node['label']}]] — {node['edges']} connections")
+            lines.append(f"- [[{node['label']}]] — {node['degree']} connections")
         lines.append("")
 
     lines += [

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -23,7 +23,7 @@ def test_god_nodes_returns_list():
 def test_god_nodes_sorted_by_degree():
     G = make_graph()
     result = god_nodes(G, top_n=10)
-    degrees = [r["edges"] for r in result]
+    degrees = [r["degree"] for r in result]
     assert degrees == sorted(degrees, reverse=True)
 
 
@@ -32,7 +32,7 @@ def test_god_nodes_have_required_keys():
     result = god_nodes(G, top_n=1)
     assert "id" in result[0]
     assert "label" in result[0]
-    assert "edges" in result[0]
+    assert "degree" in result[0]
 
 
 def test_surprising_connections_cross_source_multi_file():

--- a/tests/test_hypergraph.py
+++ b/tests/test_hypergraph.py
@@ -166,7 +166,7 @@ def _make_report(G):
     communities = {0: list(G.nodes())}
     cohesion = {0: 1.0}
     labels = {0: "All"}
-    gods = [{"label": "BasicAuth", "edges": 2}]
+    gods = [{"label": "BasicAuth", "degree": 2}]
     surprises = []
     return generate(G, communities, cohesion, labels, gods, surprises, SAMPLE_DETECTION, {"input": 10, "output": 5}, ".")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,7 +51,7 @@ def run_pipeline(tmp_path: Path) -> dict:
     # Step 5: analyze
     gods = god_nodes(G)
     assert len(gods) > 0
-    assert all("id" in g and "edges" in g for g in gods)
+    assert all("id" in g and "degree" in g for g in gods)
 
     surprises = surprising_connections(G, communities)
     assert isinstance(surprises, list)

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -20,7 +20,7 @@ def _make_graph():
 COMMUNITIES = {0: ["n1", "n2"], 1: ["n3", "n4"]}
 LABELS = {0: "Parsing Layer", 1: "Rendering Layer"}
 COHESION = {0: 0.85, 1: 0.72}
-GOD_NODES = [{"id": "n1", "label": "parse", "edges": 2}]
+GOD_NODES = [{"id": "n1", "label": "parse", "degree": 2}]
 
 
 def test_to_wiki_writes_index(tmp_path):
@@ -105,7 +105,7 @@ def test_god_node_article_links_community(tmp_path):
 def test_to_wiki_skips_missing_god_node_ids(tmp_path):
     """God node with bad ID should not crash."""
     G = _make_graph()
-    bad_gods = [{"id": "nonexistent", "label": "ghost", "edges": 99}]
+    bad_gods = [{"id": "nonexistent", "label": "ghost", "degree": 99}]
     n = to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS, god_nodes_data=bad_gods)
     # 2 communities + 0 god nodes (nonexistent skipped) = 2
     assert n == 2


### PR DESCRIPTION
god_nodes() returned a dict with key 'edges' for the degree count, but all consumers (report, serve, wiki, skill scripts) referenced it as 'degree', causing KeyError at runtime.

detail info 
```
$ $(cat graphify-out/.graphify_python) -c "
import json
from pathlib import Path

analysis = json.loads(Path('graphify-out/.graphify_analysis.json').read_text())

# 只显示 GOD 节点和问题
print('=== GOD NODES ===')
for node in analysis['gods'][:10]:  # 前10个
    print(f\"  {node['label']} (degree={node['degree']})\")

print('\n=== SUGGESTED QUESTIONS ===')
for q in analysis['questions'][:5]:  # 前5个
    print(f\"  {q}\")

print('\n=== COMMUNITY COUNT ===')
print(f\"  Total communities: {len(analysis['communities'])}\")

# 查看前几个社区的规模
print('\n=== TOP COMMUNITIES BY SIZE ===')
sorted_comms = sorted(analysis['communities'].items(), key=lambda x: len(x[1]), reverse=True)[:10]
for cid, nodes in sorted_comms:
    print(f\"  Community {cid}: {len(nodes)} nodes\")
"
=== GOD NODES ===
Traceback (most recent call last):
  File "<string>", line 10, in <module>
KeyError: 'degree'
```
fix policy
 ```
 god_nodes() in analyze.py:51-55 returns nodes with the field named "edges", not "degree":

  result.append({
      "id": node_id,
      "label": G.nodes[node_id].get("label", node_id),
      "edges": deg,   # <-- field is "edges", not "degree"
  })

  The "degree" field at export.py:385 belongs to the vis.js node payload and is unrelated to the gods array written to .graphify_analysis.json.

  Fix options:
  1. Rename "edges" → "degree" in analyze.py:54 (preferred — degree is the standard graph theory term)
  2. Update consuming code to use node['edges'] instead of node['degree']
```