### PR TITLE
fix: resolve Kotlin call edges by accepting 'identifier' node type

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -970,14 +970,16 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                                     if sc.type == "simple_identifier":
                                         callee_name = _read_text(sc, source)
             elif config.ts_module == "tree_sitter_kotlin":
-                # Kotlin: first child may be simple_identifier or navigation_expression
+                # Kotlin: first child may be simple_identifier/identifier or navigation_expression
+                # tree-sitter-kotlin uses "identifier" (not "simple_identifier") in call
+                # positions, so we accept both to avoid silently dropping all call edges.
                 first = node.children[0] if node.children else None
                 if first:
-                    if first.type == "simple_identifier":
+                    if first.type in ("simple_identifier", "identifier"):
                         callee_name = _read_text(first, source)
                     elif first.type == "navigation_expression":
                         for child in reversed(first.children):
-                            if child.type == "simple_identifier":
+                            if child.type in ("simple_identifier", "identifier"):
                                 callee_name = _read_text(child, source)
                                 break
             elif config.ts_module == "tree_sitter_scala":

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -188,6 +188,42 @@ def test_kotlin_finds_function():
     r = extract_kotlin(FIXTURES / "sample.kt")
     assert any("createClient" in l for l in _labels(r))
 
+def test_kotlin_call_edges_direct():
+    """Direct calls (simple_identifier / identifier) must produce 'calls' edges.
+
+    sample.kt: get() and post() both call buildRequest() — a same-file callee.
+    tree-sitter-kotlin emits "identifier" nodes here, not "simple_identifier",
+    so this test would produce zero call edges before the fix.
+    """
+    r = extract_kotlin(FIXTURES / "sample.kt")
+    call_edges = [e for e in r["edges"] if e["relation"] == "calls"]
+    callees = [e["target"] for e in call_edges]
+    assert any("buildrequest" in t for t in callees), (
+        "buildRequest call not found — Kotlin 'identifier' node type not handled"
+    )
+
+def test_kotlin_call_edges_navigation_expression():
+    """navigation_expression calls (obj.method()) must also produce 'calls' edges.
+
+    sample.kt: createClient() calls Config(...) and HttpClient(...).
+    The last 'identifier' child of the navigation_expression is the callee.
+    """
+    r = extract_kotlin(FIXTURES / "sample.kt")
+    call_edges = [e for e in r["edges"] if e["relation"] == "calls"]
+    callees = [e["target"] for e in call_edges]
+    assert any("httpclient" in t for t in callees), (
+        "HttpClient call not found — navigation_expression identifier not handled"
+    )
+
+def test_kotlin_call_count():
+    """All four expected calls in sample.kt must be resolved: get→buildRequest,
+    post→buildRequest, createClient→Config, createClient→HttpClient."""
+    r = extract_kotlin(FIXTURES / "sample.kt")
+    call_edges = [e for e in r["edges"] if e["relation"] == "calls"]
+    assert len(call_edges) >= 4, (
+        f"Expected ≥4 call edges, got {len(call_edges)}: {[e['target'] for e in call_edges]}"
+    )
+
 
 # ── Scala ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The Kotlin branch of `walk_calls` in `extract.py` checks for `"simple_identifier"` when inspecting children of `call_expression` nodes. However, `tree-sitter-kotlin` emits `"identifier"` (not `"simple_identifier"`) in call positions — both for direct calls (`foo()`) and the final segment of a navigation expression (`obj.foo()`).

The result: `callee_name` is never assigned, every Kotlin call goes unresolved, and **zero `calls` edges are produced** for any `.kt` file. The graph ends up with only `method` and `contains` edges, classes appear as isolated islands, and community detection over-fragments the graph.

Verified on a real Spring Boot / Kotlin service (179 files):
| | Before | After |
|---|---|---|
| `calls` edges | 0 | **332** |
| Communities | 179 | **89** |

## Approach

Accept both `"identifier"` and `"simple_identifier"` in the two type-checks inside the Kotlin branch of `walk_calls`:

1. **Direct callee** — `if first.type in ("simple_identifier", "identifier")`
2. **Navigation expression** — `if child.type in ("simple_identifier", "identifier")`

No other languages are affected; the change is scoped entirely to the `tree_sitter_kotlin` branch.

## Backward compatibility

- Purely additive — graphs that previously had 0 call edges will now get the correct edges on re-extraction
- No new dependencies
- No change to output schema

## Tests

3 new tests in `tests/test_languages.py` (existing Kotlin fixture `sample.kt`):

- `test_kotlin_call_edges_direct` — `get()` and `post()` must produce `calls → buildRequest` edges
- `test_kotlin_call_edges_navigation_expression` — `createClient()` must produce `calls → HttpClient` edge
- `test_kotlin_call_count` — all 4 expected call edges are present (guards against regression)