### PR TITLE
docs: fix Codex tool name from  to 

### DIFF
--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -230,7 +230,7 @@ Load files from `.graphify_uncached.txt`. Split into chunks of 20-25 files each.
 
 **Step B2 - Dispatch ALL subagents in a single message (Codex)**
 
-> **Codex platform:** Uses `spawn_agent` + `wait` + `close_agent` instead of the Agent tool.
+> **Codex platform:** Uses `spawn_agent` + `wait_agent` + `close_agent` instead of the Agent tool.
 > Requires `multi_agent = true` under `[features]` in `~/.codex/config.toml`.
 > If `spawn_agent` is unavailable, tell the user to add that config and restart Codex.
 


### PR DESCRIPTION
Hi @safishamsi 👋

First off, love the project! The knowledge graph approach for code understanding is really innovative 🔥

I noticed a small typo in the Codex platform documentation while reading through . The doc mentions  tool, but looking at the latest Codex API schema, it should be  (same pattern as  and ).

**Changes:**
- Line 233:  → 

This is a tiny docs fix, but figured it might save someone a bit of confusion when implementing the multi-agent workflow on Codex.

Keep up the great work! 🙏

---
*Fixes #273*