### PR TITLE
fix: escape colon in SKILL.md description for Kiro compatibility

### DIFF
--- a/graphify/skill-kiro.md
+++ b/graphify/skill-kiro.md
@@ -1,6 +1,6 @@
 ---
 name: graphify
-description: Turn any folder of files (code, docs, papers, images, video) into a queryable knowledge graph with community detection, an honest audit trail, and three outputs: interactive HTML, GraphRAG-ready JSON, and a plain-language GRAPH_REPORT.md. Use when asked to analyze a codebase, understand architecture, map dependencies, or build a knowledge graph.
+description: "Turn any folder of files (code, docs, papers, images, video) into a queryable knowledge graph with community detection, an honest audit trail, and three outputs - interactive HTML, GraphRAG-ready JSON, and a plain-language GRAPH_REPORT.md. Use when asked to analyze a codebase, understand architecture, map dependencies, or build a knowledge graph."
 ---
 
 # /graphify


### PR DESCRIPTION
## Problem
  The \`description\` field in SKILL.md contains unquoted colons (\`:\`), which is a YAML special character. This causes YAML parsing to fail in Kiro, making the skill
  unrecognizable.

  ## Fix
  Wrap the description value in double quotes and replace the problematic colon with a dash.

  ## Before
  \`\`\`yaml
  description: ...three outputs: interactive HTML...
  \`\`\`

  ## After
  \`\`\`yaml
  description: \"...three outputs - interactive HTML...\"
  \`\`\`