### PR TITLE
fix: add missing sys import in watch.py

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,6 +1,7 @@
 # monitor a folder and auto-trigger --update when files change
 from __future__ import annotations
 import json
+import sys
 import time
 from pathlib import Path
 


### PR DESCRIPTION
Fixes #386.

`watch()` references `sys.platform` at line 150 to select `PollingObserver` on macOS, but `sys` was never imported. This causes `NameError` on all platforms when running `graphify watch`.

Introduced in v0.4.15 by #373 (macOS PollingObserver change).

## Change

One line: `import sys` added to module imports in `graphify/watch.py`.

## Testing

```bash
# Before fix:
python -c "from graphify.watch import watch; from pathlib import Path; watch(Path('.'))"
# NameError: name 'sys' is not defined

# After fix:
python -c "from graphify.watch import watch; from pathlib import Path; watch(Path('.'))"
# [graphify watch] Watching /path - press Ctrl+C to stop
```

Full test suite: 433 passed, 0 failures.