### PR TITLE
fix: add .mjs to AST extractor dispatch table

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3095,6 +3095,7 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
         ".dart": extract_dart,
         ".v": extract_verilog,
         ".sv": extract_verilog,
+        ".mjs": extract_js,
     }
 
     total = len(paths)


### PR DESCRIPTION
Partial fix for #387 (and #365).

`.mjs` was added to `CODE_EXTENSIONS` in `detect.py` (v0.4.15) but not to the `_DISPATCH` table in `extract()`, so `.mjs` files are detected and counted in corpus metrics but silently produce zero nodes/edges during extraction.

## Change

One line: `".mjs": extract_js` added to `_DISPATCH` in `graphify/extract.py`.

`.mjs` is standard ES module JavaScript — same language as `.js`, just with explicit module syntax. tree-sitter-javascript handles both identically.

## Testing

```python
from pathlib import Path
from graphify.extract import extract
import tempfile

tmpdir = Path(tempfile.mkdtemp())
mjs = tmpdir / "app.mjs"
mjs.write_text("""
import { readFile } from "fs/promises";
export function parseConfig(path) {
    return readFile(path, "utf-8").then(JSON.parse);
}
export class AppServer {
    constructor(port) { this.port = port; }
    start() { console.log("started"); }
}
""")
result = extract([mjs], cache_root=tmpdir)
print(f"Nodes: {len(result['nodes'])}")  # 5 (was 0 before fix)
print(f"Edges: {len(result['edges'])}")  # 5 (was 0 before fix)
```

Full test suite: 433 passed, 0 failures.

## Note on .ejs

`.ejs` has the same dispatch gap but EJS is an HTML templating engine, not pure JavaScript. It may be better suited to `DOC_EXTENSIONS` for semantic extraction. Left for separate discussion in #387.