### PR TITLE
fix(extract): Go stdlib imports collide with same-named local files

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1947,15 +1947,20 @@ def extract_go(path: Path) -> dict:
                             path_node = spec.child_by_field_name("path")
                             if path_node:
                                 raw = _read_text(path_node, source).strip('"')
-                                module_name = raw.split("/")[-1]
-                                tgt_nid = _make_id(module_name)
+                                # Use the full import path as node id so stdlib
+                                # packages like "context" don't collide with
+                                # local files also named "context.go".
+                                # E.g. import "context" → "go_pkg_context"
+                                #      import "presto/internal/accounting"
+                                #          → "go_pkg_presto_internal_accounting"
+                                tgt_nid = _make_id("go", "pkg", raw)
                                 add_edge(file_nid, tgt_nid, "imports_from", spec.start_point[0] + 1)
                 elif child.type == "import_spec":
                     path_node = child.child_by_field_name("path")
                     if path_node:
                         raw = _read_text(path_node, source).strip('"')
-                        module_name = raw.split("/")[-1]
-                        tgt_nid = _make_id(module_name)
+                        # Same fix as above (single-line import statement).
+                        tgt_nid = _make_id("go", "pkg", raw)
                         add_edge(file_nid, tgt_nid, "imports_from", child.start_point[0] + 1)
             return
 

--- a/tests/test_go_import_nodeid.py
+++ b/tests/test_go_import_nodeid.py
@@ -1,0 +1,82 @@
+"""Test that Go stdlib imports don't collide with same-named local files.
+
+Regression test for: stdlib package name (e.g. "context") creates a node id
+that collides with a local file of the same name (e.g. accounting/context.go),
+producing spurious edges. See PR for upstream bug report.
+"""
+
+from pathlib import Path
+import pytest
+
+pytest.importorskip("tree_sitter_go")
+
+from graphify.extract import extract_go
+
+
+def _fixture(tmp_path: Path, rel: str, source: str) -> Path:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(source, encoding="utf-8")
+    return p
+
+
+def test_go_stdlib_import_does_not_collide_with_local_file(tmp_path):
+    """Imports of Go stdlib packages (e.g. "context") must not share a
+    node id with local files of the same basename (e.g. context.go).
+    """
+    # Create a local file that has the same basename as a stdlib package.
+    local_ctx = _fixture(
+        tmp_path,
+        "internal/accounting/context.go",
+        "package accounting\n\ntype Context struct{}\n",
+    )
+    # Create another file that only imports stdlib "context".
+    caller = _fixture(
+        tmp_path,
+        "internal/sms/mock.go",
+        'package sms\n\nimport "context"\n\nfunc F(ctx context.Context) {}\n',
+    )
+
+    # Extract both.
+    ctx_result = extract_go(local_ctx)
+    caller_result = extract_go(caller)
+
+    ctx_file_id = next(
+        n["id"] for n in ctx_result["nodes"] if n["label"] == "context.go"
+    )
+
+    # Find the import edge from caller → stdlib "context".
+    import_edges = [
+        e for e in caller_result["edges"] if e.get("relation") == "imports_from"
+    ]
+    assert import_edges, "expected at least one imports_from edge"
+    stdlib_targets = {e["target"] for e in import_edges}
+
+    # Assert the stdlib import target is NOT the same id as the local file.
+    assert ctx_file_id not in stdlib_targets, (
+        f"Go stdlib import 'context' produced target id {stdlib_targets!r} "
+        f"which collides with local file id {ctx_file_id!r}. "
+        f"This causes spurious cross-package 'imports_from' edges."
+    )
+
+
+def test_go_local_import_full_path_in_id(tmp_path):
+    """Local Go imports should use the full import path in node id to
+    avoid collisions between packages with the same final segment.
+
+    E.g. `presto/internal/accounting` and `otherapp/internal/accounting`
+    should produce different target node ids.
+    """
+    caller = _fixture(
+        tmp_path,
+        "main.go",
+        'package main\n\nimport (\n\t"presto/internal/accounting"\n\t"otherapp/internal/accounting"\n)\n\nfunc main() {}\n',
+    )
+    result = extract_go(caller)
+    import_edges = [e for e in result["edges"] if e.get("relation") == "imports_from"]
+    targets = [e["target"] for e in import_edges]
+    # Two distinct imports → two distinct target ids.
+    assert len(set(targets)) == 2, (
+        f"Expected 2 distinct import target ids for two different packages "
+        f"ending in 'accounting', got {targets!r}"
+    )


### PR DESCRIPTION
Problem: Go file importing stdlib package (e.g. "context") produces imports_from edge pointing at a LOCAL file of the same basename, not a separate stdlib node.

Root cause in extract_go (extract.py:1949-1951):

    module_name = raw.split("/")[-1]   # "context" (stdlib)
    tgt_nid = _make_id(module_name)    # same id as context.go file_nid

Impact: In a Presto Go monorepo (~1000 files), this produced 115 false cycle-dependency pairs. Go compiler reported 0 cycles (go build clean); the graph showed 115. All were same-name file collisions.

Fix: Prefix Go import target id with go_pkg_ and use full import path:
- import "context" → go_pkg_context
- import "presto/internal/accounting" → go_pkg_presto_internal_accounting

Tests: Added tests/test_go_import_nodeid.py with 2 regression tests. All 20 existing extract tests still pass.

Happy to iterate on naming if you prefer a different convention.

(NOTE: This replaces my accidentally-filed PR #430 which I targeted at main instead of v4; apologies for the noise.)