### PR TITLE
fix(watch): rebuild continues when HTML viz exceeds MAX_NODES_FOR_VIZ

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -78,7 +78,22 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
                           {"input": 0, "output": 0}, str(watch_path), suggested_questions=questions)
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         to_json(G, communities, str(out / "graph.json"))
-        to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
+
+        # HTML viz is optional: it raises ValueError when the graph exceeds
+        # MAX_NODES_FOR_VIZ (5000). For large repos where the visualization
+        # is infeasible, we still want core products (graph.json + GRAPH_REPORT.md)
+        # to be written. Without this try/except the entire rebuild fails and
+        # returns False even though the AST/cluster work succeeded.
+        html_written = False
+        try:
+            to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
+            html_written = True
+        except ValueError as viz_err:
+            print(f"[graphify watch] Skipped graph.html: {viz_err}")
+            # Remove any stale graph.html from a previous smaller run.
+            stale_html = out / "graph.html"
+            if stale_html.exists():
+                stale_html.unlink()
 
         # clear stale needs_update flag if present
         flag = out / "needs_update"
@@ -87,7 +102,8 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
 
         print(f"[graphify watch] Rebuilt: {G.number_of_nodes()} nodes, "
               f"{G.number_of_edges()} edges, {len(communities)} communities")
-        print(f"[graphify watch] graph.json, graph.html and GRAPH_REPORT.md updated in {out}")
+        products = "graph.json" + (", graph.html" if html_written else "") + " and GRAPH_REPORT.md"
+        print(f"[graphify watch] {products} updated in {out}")
         return True
 
     except Exception as exc:

--- a/tests/test_watch_rebuild_large_graph.py
+++ b/tests/test_watch_rebuild_large_graph.py
@@ -1,0 +1,63 @@
+"""Regression test: _rebuild_code should not fail when the graph is too
+large for HTML visualization. Core products (graph.json, GRAPH_REPORT.md)
+must still be written.
+
+Before the fix:
+- `to_html` raised ValueError for graphs > MAX_NODES_FOR_VIZ (5000).
+- _rebuild_code wrapped everything in one try/except and returned False.
+- graph.json was also not written (it happened before to_html but the
+  outer exception handler still prevented completion reporting).
+
+After the fix:
+- to_html is wrapped in its own try/except.
+- graph.json + GRAPH_REPORT.md are always written regardless of size.
+- graph.html is silently skipped with a warning when too big.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import networkx as nx
+import pytest
+
+from graphify.watch import _rebuild_code
+
+
+def test_rebuild_succeeds_when_html_viz_fails(tmp_path, monkeypatch):
+    """Core artifacts must be produced even when to_html raises."""
+
+    # Create a minimal code file so collect_files has something to extract.
+    src = tmp_path / "sample.py"
+    src.write_text("def f(): return 1\n")
+
+    # Patch graphify.export.to_html at the source module (lazy-imported by watch).
+    import graphify.export as export_mod
+
+    def fake_to_html(*args, **kwargs):
+        raise ValueError("Graph has 99999 nodes - too large for HTML viz. Use --no-viz or reduce input size.")
+
+    monkeypatch.setattr(export_mod, "to_html", fake_to_html)
+
+    ok = _rebuild_code(tmp_path)
+    assert ok is True, "_rebuild_code should succeed even when to_html fails"
+
+    out = tmp_path / "graphify-out"
+    assert (out / "graph.json").exists(), "graph.json must always be written"
+    assert (out / "GRAPH_REPORT.md").exists(), "GRAPH_REPORT.md must always be written"
+    # graph.html should NOT exist when to_html failed.
+    assert not (out / "graph.html").exists(), "graph.html should be skipped when to_html raises"
+
+
+def test_rebuild_still_writes_graph_html_when_viz_succeeds(tmp_path):
+    """Normal-sized graphs should still produce graph.html."""
+    src = tmp_path / "sample.py"
+    src.write_text("def f(): return 1\n")
+
+    ok = _rebuild_code(tmp_path)
+    assert ok is True
+
+    out = tmp_path / "graphify-out"
+    # All three core products present for a small graph.
+    assert (out / "graph.json").exists()
+    assert (out / "GRAPH_REPORT.md").exists()
+    assert (out / "graph.html").exists(), "graph.html should be written for small graphs"


### PR DESCRIPTION
Problem: _rebuild_code calls to_html() unconditionally, which raises ValueError for graphs exceeding MAX_NODES_FOR_VIZ (5000). The entire rebuild fails and returns False, even though AST extraction, clustering, and report generation all succeeded. Users with medium-to-large codebases can't use _rebuild_code at all; no graph.json / GRAPH_REPORT.md is produced.

Real-world impact: In a Presto Go monorepo (~1000 files), _rebuild_code reliably produces 5574 nodes (above 5000). This made the git post-commit hook a no-op: every code change raised the HTML-viz error, graph.json never got written, AI tools read 9-day-old stale data.

Fix: Wrap to_html() in its own try/except. When it raises:
1. Log a warning (don't fail the rebuild)
2. Delete stale graph.html from prev smaller run
3. Continue returning True - core products (graph.json + GRAPH_REPORT.md) are already written

Tests: Added tests/test_watch_rebuild_large_graph.py with 2 tests. All existing tests pass.

Alternative considered: --no-viz parameter; rejected because it requires callers (post-commit hook, CI) to know the threshold. Caller-agnostic fix is cleaner.