### PR TITLE
fix(watch): keep update outputs project-relative

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -12,12 +12,35 @@ _WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAG
 _CODE_EXTENSIONS = CODE_EXTENSIONS
 
 
+def _report_root_label(watch_path: Path) -> str:
+    if watch_path.is_absolute():
+        return watch_path.name or str(watch_path)
+    return Path.cwd().name if watch_path == Path(".") else str(watch_path)
+
+
+def _relativize_source_files(payload: dict, root: Path) -> None:
+    for bucket in ("nodes", "edges", "hyperedges"):
+        for item in payload.get(bucket, []):
+            source = item.get("source_file")
+            if not source:
+                continue
+            source_path = Path(source)
+            if not source_path.is_absolute():
+                continue
+            try:
+                item["source_file"] = str(source_path.resolve().relative_to(root))
+            except ValueError:
+                continue
+
+
 def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
     """Re-run AST extraction + build + cluster + report for code files. No LLM needed.
 
     Returns True on success, False on error.
     """
-    watch_path = watch_path.resolve()
+    watch_root = watch_path.resolve()
+    project_root = Path.cwd().resolve() if not watch_path.is_absolute() else watch_root
+    report_root = _report_root_label(watch_path)
     try:
         from graphify.extract import extract
         from graphify.detect import detect
@@ -34,7 +57,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
             print("[graphify watch] No code files found - nothing to rebuild.")
             return False
 
-        result = extract(code_files, cache_root=watch_path)
+        result = extract(code_files, cache_root=watch_root)
 
         # Preserve semantic nodes/edges from a previous full run.
         # AST-only rebuild replaces code nodes; doc/paper/image nodes are kept.
@@ -58,6 +81,8 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
             except Exception:
                 pass  # corrupt graph.json - proceed with AST-only
 
+        _relativize_source_files(result, project_root)
+
         detection = {
             "files": {"code": [str(f) for f in code_files], "document": [], "paper": [], "image": []},
             "total_files": len(code_files),
@@ -75,7 +100,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
         out.mkdir(exist_ok=True)
 
         report = generate(G, communities, cohesion, labels, gods, surprises, detection,
-                          {"input": 0, "output": 0}, str(watch_path), suggested_questions=questions)
+                          {"input": 0, "output": 0}, report_root, suggested_questions=questions)
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         to_json(G, communities, str(out / "graph.json"))
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 import pytest
 
-from graphify.watch import _notify_only, _WATCHED_EXTENSIONS
+from graphify.watch import _notify_only, _rebuild_code, _WATCHED_EXTENSIONS
 
 
 # --- _notify_only ---
@@ -25,6 +25,41 @@ def test_notify_only_idempotent(tmp_path):
     _notify_only(tmp_path)
     flag = tmp_path / "graphify-out" / "needs_update"
     assert flag.read_text() == "1"
+
+
+def test_rebuild_code_writes_project_relative_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "a.py").write_text("def hello():\n    return 1\n", encoding="utf-8")
+
+    assert _rebuild_code(Path("."))
+
+    graph_json = (tmp_path / "graphify-out" / "graph.json").read_text(encoding="utf-8")
+    report = (tmp_path / "graphify-out" / "GRAPH_REPORT.md").read_text(encoding="utf-8")
+    html = (tmp_path / "graphify-out" / "graph.html").read_text(encoding="utf-8")
+    cache_entries = list((tmp_path / "graphify-out" / "cache").glob("*.json"))
+
+    assert '"source_file": "pkg/a.py"' in graph_json
+    assert str(tmp_path) not in graph_json
+    assert str(tmp_path) not in report
+    assert tmp_path.name in report.splitlines()[0]
+    assert str(tmp_path) not in html
+    assert cache_entries
+    for entry in cache_entries:
+        assert str(tmp_path) not in entry.read_text(encoding="utf-8")
+
+
+def test_rebuild_code_keeps_subdir_prefix_relative_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "a.py").write_text("def hello():\n    return 1\n", encoding="utf-8")
+
+    assert _rebuild_code(Path("pkg"))
+
+    graph_json = (tmp_path / "pkg" / "graphify-out" / "graph.json").read_text(encoding="utf-8")
+    assert '"source_file": "pkg/a.py"' in graph_json
 
 
 # --- _WATCHED_EXTENSIONS ---


### PR DESCRIPTION
## Summary

Fixes #433.

`graphify update` should keep generated paths project-relative for code-only rebuilds, matching the rest of the pipeline.

## Root cause

`graphify.watch._rebuild_code()` resolved the requested path before detection and report generation. That changed a relative invocation such as `graphify update .` into an absolute rebuild root, which then leaked absolute paths into:

- `graphify-out/graph.json` `source_file` fields
- `graphify-out/GRAPH_REPORT.md` title and path-bearing sections
- `graphify-out/graph.html` title and node metadata
- `graphify-out/cache/*.json` AST cache entries

## What changed

- keep the cache root absolute, but run detection against the user-provided path so extractor inputs stay project-relative for normal `graphify update .` usage
- normalize merged rebuild payloads back to project-relative `source_file` values before report/JSON/HTML export
- render a non-absolute report root label for the common `.` case
- add watch rebuild regression tests for repo-root and subdirectory invocations

## Validation

- `.venv/bin/python -m pytest -q tests/test_watch.py`
- `.venv/bin/python -m pytest -q tests/test_pipeline.py`
- manual smoke test: `.venv/bin/python -m graphify update .` in a temporary repo, verifying no absolute project paths in `graph.json`, `GRAPH_REPORT.md`, `graph.html`, or `graphify-out/cache/*.json`
