### PR TITLE
fix: skip structural-only communities in reports

### DIFF
--- a/graphify/report.py
+++ b/graphify/report.py
@@ -111,6 +111,8 @@ def generate(
         score = cohesion_scores.get(cid, 0.0)
         # Filter method/function stubs from display - they're structural noise
         real_nodes = [n for n in nodes if not _ifn(G, n)]
+        if not real_nodes:
+            continue
         display = [G.nodes[n].get("label", n) for n in real_nodes[:8]]
         suffix = f" (+{len(real_nodes)-8} more)" if len(real_nodes) > 8 else ""
         lines += [

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,11 +1,13 @@
 import json
 from pathlib import Path
+import networkx as nx
 from graphify.build import build_from_json
 from graphify.cluster import cluster, score_all
 from graphify.analyze import god_nodes, surprising_connections
 from graphify.report import generate
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
 
 def make_inputs():
     extraction = json.loads((FIXTURES / "extraction.json").read_text())
@@ -19,41 +21,69 @@ def make_inputs():
     tokens = {"input": extraction["input_tokens"], "output": extraction["output_tokens"]}
     return G, communities, cohesion, labels, gods, surprises, detection, tokens
 
+
 def test_report_contains_header():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "# Graph Report" in report
+
 
 def test_report_contains_corpus_check():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## Corpus Check" in report
 
+
 def test_report_contains_god_nodes():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## God Nodes" in report
+
 
 def test_report_contains_surprising_connections():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## Surprising Connections" in report
 
+
 def test_report_contains_communities():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## Communities" in report
+
+
+def test_report_omits_structural_only_communities():
+    G = nx.Graph()
+    G.add_node(
+        "contacts_vc_header",
+        label="CHContactsVC.h",
+        source_file="CH999OA/Module/通讯录/CHContactsVC.h",
+        source_location=None,
+    )
+    communities = {0: ["contacts_vc_header"]}
+    cohesion = {0: 1.0}
+    labels = {0: "Community 0"}
+    detection = {"total_files": 1, "total_words": 10, "needs_graph": True, "warning": None}
+    tokens = {"input": 0, "output": 0}
+
+    report = generate(G, communities, cohesion, labels, [], [], detection, tokens, "./project")
+
+    assert "### Community 0" not in report
+    assert "Nodes (0):" not in report
+
 
 def test_report_contains_ambiguous_section():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "## Ambiguous Edges" in report
 
+
 def test_report_shows_token_cost():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()
     report = generate(G, communities, cohesion, labels, gods, surprises, detection, tokens, "./project")
     assert "Token cost" in report
     assert "1,200" in report
+
 
 def test_report_shows_raw_cohesion_scores():
     G, communities, cohesion, labels, gods, surprises, detection, tokens = make_inputs()


### PR DESCRIPTION
## Summary
- skip community sections that become empty after filtering structural/file-only nodes
- avoid rendering `Nodes (0):` entries in `GRAPH_REPORT.md`
- add a regression test for structural-only communities

## Test plan
- [x] Run `python3 -m pytest tests/test_report.py -q --tb=short`
- [x] Rebuild a real contact-module report and confirm `Nodes (0):` no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)