### PR TITLE
Allow Homebrew python@ hook paths in generated git hooks

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -21,7 +21,7 @@ if [ -n "$GRAPHIFY_BIN" ]; then
     # Allowlist: only keep characters valid in a filesystem path to prevent
     # injection if the shebang contains shell metacharacters
     case "$GRAPHIFY_PYTHON" in
-        *[!a-zA-Z0-9/_.-]*) GRAPHIFY_PYTHON="" ;;
+        *[!a-zA-Z0-9/_.@-]*) GRAPHIFY_PYTHON="" ;;
     esac
     if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "import graphify" 2>/dev/null; then
         GRAPHIFY_PYTHON=""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -92,6 +92,17 @@ def test_install_creates_post_checkout_hook(tmp_path):
     assert _CHECKOUT_MARKER in hook.read_text()
 
 
+def test_install_allows_homebrew_python_paths(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+    expected_allowlist = '*[!a-zA-Z0-9/_.@-]*) GRAPHIFY_PYTHON="" ;;'
+    post_commit_hook = repo / ".git" / "hooks" / "post-commit"
+    post_checkout_hook = repo / ".git" / "hooks" / "post-checkout"
+
+    assert expected_allowlist in post_commit_hook.read_text()
+    assert expected_allowlist in post_checkout_hook.read_text()
+
+
 def test_install_post_checkout_is_executable(tmp_path):
     repo = _make_git_repo(tmp_path)
     install(repo)


### PR DESCRIPTION
## Summary
- allow `@` in the hook interpreter-path allowlist so Homebrew paths like `python@3.11` are not discarded
- add a regression test that verifies both generated hooks include the updated allowlist
- fix #473

## Root cause
The shared `_PYTHON_DETECT` snippet rejected valid shebang-derived interpreter paths containing `@`, which caused Homebrew Python paths to be cleared and forced the hook into the fallback interpreter path.

## Existing installs
Existing users can recover by rerunning `graphify hook uninstall && graphify hook install` to regenerate the installed hook scripts. It may also be possible to refresh existing hooks automatically, but that is not included in this PR.

## Validation
- `/tmp/graphify-pr-473/.venv/bin/python -m pytest tests/test_hooks.py -q`