### PR TITLE
feat: add graph-query CLI rule to AGENTS.md / CLAUDE.md / GEMINI.md sections

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -191,6 +191,7 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
 """
 
@@ -206,6 +207,7 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
 """
 
@@ -219,6 +221,7 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
 """
 
@@ -421,6 +424,7 @@ Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - If the graphify MCP server is active, utilize tools like `query_graph`, `get_node`, and `shortest_path` for precise architecture navigation instead of falling back to `grep`
+- If the MCP server is not active, the CLI equivalents are `graphify query "<question>"`, `graphify path "<A>" "<B>"`, and `graphify explain "<concept>"` — prefer these over grep for cross-module questions
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
 """
 


### PR DESCRIPTION
## Summary

Add a new rule to the three "`Rules:`" sections written to project-root instruction files (`_CLAUDE_MD_SECTION`, `_AGENTS_MD_SECTION`, `_GEMINI_MD_SECTION`) naming `graphify query`, `graphify path`, and `graphify explain` as preferred tools over `grep` for cross-module architecture questions. Mirrors the MCP-tool guidance that's already in `_ANTIGRAVITY_RULES`, extended with a parallel CLI-fallback line there too.

## Motivation

On platforms where graphify's proactive hook covers only `bash` (OpenCode, per #71) or where there's no hook at all (AGENTS.md-only platforms), agents default to `grep` when answering architecture questions — because the instructions don't name the graph-traversal commands.

Observed this on OpenCode with the question *"What is the exact relationship between JWT Token Authentication and One-CommonAPI Sequelize Models?"*:

1. Agent read `GRAPH_REPORT.md` (following rule 1 ✓)
2. Glob'd `graphify-out/wiki/index.md` (following rule 2, file existed ✓)
3. Went straight to `grep` across the repo

The agent never tried `graphify query "..."` / `graphify path "A" "B"` / `graphify explain "..."` because they weren't mentioned in `_AGENTS_MD_SECTION`. For that particular question (an inter-module path), `graphify path` would've been the ideal first step.

## The change

Four rule sections get one new line each:

**`_CLAUDE_MD_SECTION`, `_AGENTS_MD_SECTION`, `_GEMINI_MD_SECTION`** — add:
> `- For cross-module "how does X relate to Y" questions, prefer ` `graphify query "<question>"` `, ` `graphify path "<A>" "<B>"` `, or ` `graphify explain "<concept>"` ` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files`

**`_ANTIGRAVITY_RULES`** — already mentions MCP tools; add a parallel CLI fallback:
> `- If the MCP server is not active, the CLI equivalents are ` `graphify query "<question>"` `, ` `graphify path "<A>" "<B>"` `, and ` `graphify explain "<concept>"` ` — prefer these over grep for cross-module questions`

## Scope

- `_VSCODE_INSTRUCTIONS_SECTION` left alone — shorter, different structure; happy to also update if desired
- `_KIRO_STEERING` left alone — its single-paragraph form is already abstract ("navigate by graph structure")
- No test changes — `tests/test_install.py` doesn't assert section content

## Why now

After #71 added the OpenCode plugin, the remaining gap for OpenCode (and other AGENTS.md-only platforms like Codex / OpenClaw) is that agents don't know the graph-query CLI exists. The instructions file is the one surface that reaches every supported platform.