### PR TITLE
fix(extract): Java extends/implements + resolve cross-file imports

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -803,6 +803,52 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                                         seen_ids.add(base_nid)
                                 add_edge(class_nid, base_nid, "inherits", line)
 
+            # Java-specific: extends (superclass) / implements (super_interfaces) / interface-extends
+            if config.ts_module == "tree_sitter_java":
+                def _emit_java_parent(base_name: str, rel: str, at_line: int) -> None:
+                    if not base_name:
+                        return
+                    base_nid = _make_id(stem, base_name)
+                    if base_nid not in seen_ids:
+                        base_nid = _make_id(base_name)
+                        if base_nid not in seen_ids:
+                            nodes.append({
+                                "id": base_nid,
+                                "label": base_name,
+                                "file_type": "code",
+                                "source_file": "",
+                                "source_location": "",
+                            })
+                            seen_ids.add(base_nid)
+                    add_edge(class_nid, base_nid, rel, at_line)
+
+                # class X extends Y  -> superclass field on class_declaration
+                sup = node.child_by_field_name("superclass")
+                if sup is not None:
+                    for sub in sup.children:
+                        if sub.type == "type_identifier":
+                            _emit_java_parent(_read_text(sub, source), "extends", line)
+                            break  # Java has single inheritance for classes
+
+                # class X implements A, B  -> interfaces field -> super_interfaces -> type_list
+                ifs = node.child_by_field_name("interfaces")
+                if ifs is not None:
+                    for sub in ifs.children:
+                        if sub.type == "type_list":
+                            for tid in sub.children:
+                                if tid.type == "type_identifier":
+                                    _emit_java_parent(_read_text(tid, source), "implements", line)
+
+                # interface X extends A, B  -> extends_interfaces child -> type_list
+                if t == "interface_declaration":
+                    for child in node.children:
+                        if child.type == "extends_interfaces":
+                            for sub in child.children:
+                                if sub.type == "type_list":
+                                    for tid in sub.children:
+                                        if tid.type == "type_identifier":
+                                            _emit_java_parent(_read_text(tid, source), "extends", line)
+
             # Find body and recurse
             body = _find_body(node, config)
             if body:
@@ -2664,6 +2710,117 @@ def _resolve_cross_file_imports(
     return new_edges
 
 
+def _resolve_cross_file_java_imports(
+    per_file: list[dict],
+    paths: list[Path],
+) -> list[dict]:
+    """
+    Two-pass Java import resolution.
+
+    Pass 1 - build a global index {ClassName: [node_id, ...]} across all Java
+             nodes in the corpus.
+    Pass 2 - re-parse each Java file and, for every `import a.b.C;`, resolve C
+             against the index. When C resolves to one or more internal nodes,
+             emit a proper `imports` edge with a target that exists in the
+             graph. Wildcard imports (`a.b.*`) and stdlib/third-party names
+             are left unresolved and produce no edge (they'd be dropped at
+             build time anyway).
+
+    Without this pass, the per-file `_import_java` handler creates edges whose
+    target is just the class name (e.g. `list` for `java.util.List`). Those
+    targets never match any real node id (node ids use `{stem}_{class}`), so
+    every Java import edge is silently discarded in `build_from_json`. This
+    function restores them.
+    """
+    try:
+        import tree_sitter_java as tsjava
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return []
+
+    language = Language(tsjava.language())
+    parser = Parser(language)
+
+    # Pass 1: class-name index
+    name_to_ids: dict[str, list[str]] = {}
+    for file_result in per_file:
+        for node in file_result.get("nodes", []):
+            label = node.get("label", "")
+            nid = node.get("id", "")
+            src = node.get("source_file", "")
+            if not label or not nid or not src:
+                continue
+            # Skip method stubs (".foo()"), file-level nodes ("Foo.java"),
+            # and synthetic external nodes (source_file == "").
+            if label.endswith(")") or label.endswith(".java"):
+                continue
+            # Java class names start with an uppercase letter.
+            if not label[0].isalpha() or not label[0].isupper():
+                continue
+            name_to_ids.setdefault(label, []).append(nid)
+
+    # Pass 2: re-parse imports and emit resolved edges
+    new_edges: list[dict] = []
+    seen_pairs: set[tuple[str, str]] = set()
+    for path in paths:
+        stem = path.stem
+        file_nid = _make_id(stem)
+        str_path = str(path)
+        try:
+            source = path.read_bytes()
+            tree = parser.parse(source)
+        except Exception:
+            continue
+
+        def walk(n) -> None:
+            if n.type == "import_declaration":
+                # Find the final scoped_identifier / identifier under the node.
+                # `import a.b.C;`  -> last part "C"
+                # `import a.b.*;`  -> wildcard -> skip (ambiguous)
+                # `import static a.b.C.foo;` -> last part "C" (strip trailing .foo? no — take C)
+                # For simplicity: walk tokens, pick the last identifier before `*` / `;`.
+                raw_text = _read_text(n, source).strip()
+                # Normalise: drop `import`, `static`, trailing `;`
+                body = raw_text[len("import"):].strip().rstrip(";").strip()
+                if body.startswith("static "):
+                    body = body[len("static "):].strip()
+                if body.endswith(".*"):
+                    return  # wildcard import — target ambiguous
+                # For static imports like `a.b.C.foo`, take the second-to-last
+                # segment if the last segment is lowercase (method), else last.
+                parts = body.split(".")
+                if not parts:
+                    return
+                last = parts[-1]
+                # static method import: last is lower-case; the class is second to last
+                if parts[-1] and parts[-1][0].islower() and len(parts) >= 2:
+                    last = parts[-2]
+                candidates = name_to_ids.get(last, [])
+                line = n.start_point[0] + 1
+                for tgt_nid in candidates:
+                    if tgt_nid == file_nid:
+                        continue
+                    key = (file_nid, tgt_nid)
+                    if key in seen_pairs:
+                        continue
+                    seen_pairs.add(key)
+                    new_edges.append({
+                        "source": file_nid,
+                        "target": tgt_nid,
+                        "relation": "imports",
+                        "confidence": "EXTRACTED",
+                        "source_file": str_path,
+                        "source_location": f"L{line}",
+                        "weight": 1.0,
+                    })
+            for child in n.children:
+                walk(child)
+
+        walk(tree.root_node)
+
+    return new_edges
+
+
 def extract_objc(path: Path) -> dict:
     """Extract interfaces, implementations, protocols, methods, and imports from .m/.mm/.h files."""
     try:
@@ -3178,6 +3335,19 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
         except Exception as exc:
             import logging
             logging.getLogger(__name__).warning("Cross-file import resolution failed, skipping: %s", exc)
+
+    # Cross-file Java import resolution. Rewrites `_import_java`-emitted edges
+    # (whose targets were bare class names and got dropped at build time) into
+    # resolved edges pointing at real class nodes elsewhere in the corpus.
+    java_paths = [p for p in paths if p.suffix == ".java"]
+    if java_paths:
+        java_results = [r for r, p in zip(per_file, paths) if p.suffix == ".java"]
+        try:
+            java_edges = _resolve_cross_file_java_imports(java_results, java_paths)
+            all_edges.extend(java_edges)
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("Java cross-file import resolution failed, skipping: %s", exc)
 
     # Cross-file call resolution for all languages
     # Each extractor saved unresolved calls in raw_calls. Now that we have all

--- a/tests/fixtures/sample_imported.java
+++ b/tests/fixtures/sample_imported.java
@@ -1,0 +1,13 @@
+package com.example.base;
+
+public class Animal {
+    public String species;
+
+    public Animal(String species) {
+        this.species = species;
+    }
+
+    public String describe() {
+        return species;
+    }
+}

--- a/tests/fixtures/sample_inherit.java
+++ b/tests/fixtures/sample_inherit.java
@@ -1,0 +1,14 @@
+package com.example.sample;
+
+import com.example.base.Animal;
+import com.example.contracts.Runnable;
+import com.example.contracts.Swimmable;
+
+public class Dog extends Animal implements Runnable, Swimmable {
+    public void run() {}
+    public void swim() {}
+}
+
+interface LoudRunnable extends Runnable {
+    default void bark() {}
+}

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -56,6 +56,54 @@ def test_java_no_dangling_edges():
         assert e["source"] in node_ids
 
 
+def test_java_finds_extends():
+    r = extract_java(FIXTURES / "sample_inherit.java")
+    relations = _relations(r)
+    assert "extends" in relations, (
+        f"expected `extends` edge for `class Dog extends Animal`; got relations={relations}"
+    )
+
+    # Node exists for the extended class, even if defined outside the file.
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    extends_targets = {
+        node_by_id.get(e["target"])
+        for e in r["edges"]
+        if e["relation"] == "extends"
+    }
+    assert "Animal" in extends_targets, f"extends edge should point to Animal; got {extends_targets}"
+
+
+def test_java_finds_implements():
+    r = extract_java(FIXTURES / "sample_inherit.java")
+    relations = _relations(r)
+    assert "implements" in relations, (
+        f"expected `implements` edge for `class Dog implements Runnable, Swimmable`; got {relations}"
+    )
+
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    implements_targets = {
+        node_by_id.get(e["target"])
+        for e in r["edges"]
+        if e["relation"] == "implements"
+    }
+    assert "Runnable" in implements_targets
+    assert "Swimmable" in implements_targets
+
+
+def test_java_finds_interface_extends():
+    r = extract_java(FIXTURES / "sample_inherit.java")
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    # interface LoudRunnable extends Runnable
+    extends_pairs = {
+        (node_by_id.get(e["source"]), node_by_id.get(e["target"]))
+        for e in r["edges"]
+        if e["relation"] == "extends"
+    }
+    assert ("LoudRunnable", "Runnable") in extends_pairs, (
+        f"expected interface LoudRunnable extends Runnable; got {extends_pairs}"
+    )
+
+
 # ── C ────────────────────────────────────────────────────────────────────────
 
 def test_c_no_error():

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -149,6 +149,33 @@ def test_extract_dispatches_all_languages():
     assert any("sample.rs" in f for f in source_files)
 
 
+def test_extract_resolves_java_cross_file_imports():
+    """When `sample_inherit.java` imports a class defined in
+    `sample_imported.java`, the import edge must point at the actual class
+    node (not a dangling target that the builder drops)."""
+    files = [
+        FIXTURES / "sample_imported.java",  # defines class Animal
+        FIXTURES / "sample_inherit.java",   # imports com.example.base.Animal
+    ]
+    r = extract(files)
+    node_ids = {n["id"] for n in r["nodes"]}
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+
+    import_edges = [e for e in r["edges"] if e["relation"] == "imports"]
+    # There must be at least one `imports` edge whose target is a real node
+    # AND whose target resolves to `Animal` (the class defined in sample_imported.java).
+    resolved = [
+        e for e in import_edges
+        if e["target"] in node_ids
+        and node_by_id.get(e["target"]) == "Animal"
+        and "sample_inherit.java" in e.get("source_file", "")
+    ]
+    assert resolved, (
+        f"expected a resolved import edge pointing at Animal from sample_inherit.java; "
+        f"got {[(e['source'], e['target'], e.get('source_file','')) for e in import_edges]}"
+    )
+
+
 # ── Cache ─────────────────────────────────────────────────────────────────────
 
 def test_cache_hit_returns_same_result(tmp_path):


### PR DESCRIPTION
Closes #435 (Java inheritance support). Also fixes a related Java-imports bug that would have blocked #435 from actually working end-to-end.

## Summary

Two issues in Java AST extraction that silently drop all Java-type edges from the graph. On any real Java corpus, the `structural_type` layer (imports / extends / implements) comes out **empty**.

### Issue 1 — Java inheritance was never extracted

The class handler inside `_extract_generic` has language-specific blocks for Python (`inherits`), Swift (`inherits`), and C# (`inherits`) — but **nothing for Java**, even though `tree-sitter-java` exposes the `superclass` / `interfaces` / `extends_interfaces` fields.

Result: for a Java corpus of 5,727 files, `extends` = 0 and `implements` = 0.

### Issue 2 — Java import edges had dangling targets

`_import_java` emits edges whose `target` is just the bare class name (`_make_id(module_name)` → e.g. `list` for `java.util.List`), while real node ids use `{stem}_{classname}`. Those edges never match a node id, so `build_from_json` silently drops every single one at line 75-76 of `build.py`.

Result: `imports` = 0 in the built graph, even though `_import_java` ran.

## What this PR changes

### `graphify/extract.py`

- **New `tree_sitter_java` block in the class handler** (alongside the existing Python / Swift / C# blocks). Emits:
  - `extends` edge for `class X extends Y` (via `node.child_by_field_name(\"superclass\")`)
  - `implements` edges for `class X implements A, B` (via `node.child_by_field_name(\"interfaces\") → super_interfaces → type_list`)
  - `extends` edges for `interface X extends A, B` (via the `extends_interfaces` child)
  - When the parent/interface is defined outside the current file, a synthetic external node is added (same pattern as the existing Python / Swift / C# inheritance blocks).

- **New `_resolve_cross_file_java_imports` helper** mirroring the existing `_resolve_cross_file_imports` (Python). Runs a second pass on Java corpora, builds a `{ClassName: [node_id, …]}` index across all nodes, re-parses each file's imports, and emits resolved `imports` edges pointing at real class nodes elsewhere in the corpus.
  - Wildcard imports (`a.b.*`) are skipped — the target is ambiguous.
  - `static` imports strip the `static` keyword and resolve the class name (not the method).
  - Stdlib / third-party names left unresolved produce no edge (they would be dropped anyway).

- **`extract()` now calls the Java resolver** after the existing Python one, in the same try/except style so an import failure in `tree_sitter_java` only logs a warning.

### Tests

All four new tests pass locally; the full upstream suite (**437 tests**) passes with no regressions.

- `tests/test_languages.py::test_java_finds_extends`
- `tests/test_languages.py::test_java_finds_implements`
- `tests/test_languages.py::test_java_finds_interface_extends`
- `tests/test_multilang.py::test_extract_resolves_java_cross_file_imports`

Two new fixtures: `sample_inherit.java` (single inheritance + multi-interface + interface-extends-interface) and `sample_imported.java` (defines a class imported cross-file).

## Validated on a real Java corpus

Spring / JPA / Lombok monorepo of **5,727 `.java` files** parsed with no errors:

| relation | before this PR | after this PR |
| --- | ---: | ---: |
| `extends` | **0** | **2,072** |
| `implements` | **0** | **1,285** |
| `imports` (internal) | **0** | **58,019** |

Before the fix, the entire `structural_type` layer of this corpus had **11 edges** (all from README.md via the LLM pass, none from AST). After the fix it has **61,376** real AST edges.

## Test plan

- [x] All 4 new tests pass against the patched `graphify/extract.py`
- [x] Full upstream `pytest tests/` — 437 passed, 0 failed
- [x] Validated on 5,727-file Java codebase: counts above
- [x] Cross-language regression check: no changes to non-Java code paths

## Notes

- `_import_java` is left in place. The edges it produces still reach `build_from_json` and still get dropped for stdlib / third-party imports — that is the expected behaviour for dangling externals. The new cross-file pass now re-resolves the internal ones correctly.
- `extends` / `implements` are used as distinct relation names (rather than the `inherits` used by Python / Swift / C#) because Java separates the two cleanly and the distinction is useful downstream. If you'd prefer to unify under `inherits`, happy to adjust.
