### PR TITLE
fix(build): canonicalize legacy from/to and source fields before validation

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -46,6 +46,18 @@ def build_from_json(extraction: dict, *, directed: bool = False) -> nx.Graph:
     # NetworkX <= 3.1 serialised edges as "links"; remap to "edges" for compatibility.
     if "edges" not in extraction and "links" in extraction:
         extraction = dict(extraction, edges=extraction["links"])
+
+    # Normalize legacy formats to canonical schema
+    for node in extraction.get("nodes", []):
+        if isinstance(node, dict) and "source" in node and "source_file" not in node:
+            node["source_file"] = node.pop("source")
+    for edge in extraction.get("edges", []):
+        if isinstance(edge, dict):
+            if "from" in edge and "source" not in edge:
+                edge["source"] = edge.pop("from")
+            if "to" in edge and "target" not in edge:
+                edge["target"] = edge.pop("to")
+
     errors = validate_extraction(extraction)
     # Dangling edges (stdlib/external imports) are expected - only warn about real schema errors.
     real_errors = [e for e in errors if "does not match any node id" not in e]

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -79,6 +79,12 @@ _CHECKOUT_SCRIPT = """\
 # Auto-rebuilds the knowledge graph (code only) when switching branches.
 # Installed by: graphify hook install
 
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
 PREV_HEAD=$1
 NEW_HEAD=$2
 BRANCH_SWITCH=$3

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -79,12 +79,6 @@ _CHECKOUT_SCRIPT = """\
 # Auto-rebuilds the knowledge graph (code only) when switching branches.
 # Installed by: graphify hook install
 
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-[ -d "$GIT_DIR/rebase-merge" ] && exit 0
-[ -d "$GIT_DIR/rebase-apply" ] && exit 0
-[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
-[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
-
 PREV_HEAD=$1
 NEW_HEAD=$2
 BRANCH_SWITCH=$3


### PR DESCRIPTION
## What

Added a backwards-compatible normalization pass in `build_from_json()` to accept legacy edge schema (`from`/`to`) and legacy node schema (`source`).

## How

Before calling `validate_extraction()`, the function maps any `from`/`to` keys in the edge dicts to `source`/`target` and pops the old keys. It similarly maps `source` in the node dicts to `source_file`. This satisfies Option A described in the issue, allowing older manual chunk files or pre-schema-change extractions to be parsed without silently dropping edges or cache-missing on nodes during incremental runs.

## Testing

- [x] Existing tests pass
- [x] `uv run pytest tests/` — 433 passed, 0 failed

## Related

Closes #484