### PR TITLE
fix(build): prevent partial-chunk overwrite with build_merge() and node-count guard (#479)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -1,17 +1,42 @@
 # assemble node+edge dicts into a NetworkX graph, preserving edge direction
 from __future__ import annotations
 import sys
+from pathlib import Path
 import networkx as nx
 from .validate import validate_extraction
 
 
-def build_from_json(extraction: dict) -> nx.Graph:
+def build_from_json(extraction: dict, *, directed: bool = False) -> "nx.Graph":
+    # Detect and warn about legacy "source" field on nodes; rename to "source_file" without mutating caller data.
+    nodes = extraction.get("nodes", [])
+    edges = extraction.get("edges", [])
+    legacy_nodes = [n for n in nodes if isinstance(n, dict) and "source_file" not in n and "source" in n]
+    if legacy_nodes:
+        legacy_ids = {n["id"] for n in legacy_nodes if "id" in n}
+        affected_edge_count = sum(
+            1 for e in edges
+            if isinstance(e, dict) and (e.get("source") in legacy_ids or e.get("target") in legacy_ids)
+        )
+        print(
+            f"[graphify] WARNING: {len(legacy_nodes)} node(s) use legacy field 'source' instead of 'source_file' "
+            f"({affected_edge_count} affected edge(s)). Rename 'source' -> 'source_file' in your extraction.",
+            file=sys.stderr,
+        )
+        # Build a patched copy - do not mutate caller's dicts
+        extraction = dict(extraction)
+        extraction["nodes"] = [
+            {**{k: v for k, v in n.items() if k != "source"}, "source_file": n["source"]}
+            if isinstance(n, dict) and "source_file" not in n and "source" in n
+            else n
+            for n in nodes
+        ]
+
     errors = validate_extraction(extraction)
     # Dangling edges (stdlib/external imports) are expected - only warn about real schema errors.
     real_errors = [e for e in errors if "does not match any node id" not in e]
     if real_errors:
         print(f"[graphify] Extraction warning ({len(real_errors)} issues): {real_errors[0]}", file=sys.stderr)
-    G = nx.Graph()
+    G: nx.Graph = nx.DiGraph() if directed else nx.Graph()
     for node in extraction.get("nodes", []):
         G.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
     node_set = set(G.nodes())
@@ -31,7 +56,7 @@ def build_from_json(extraction: dict) -> nx.Graph:
     return G
 
 
-def build(extractions: list[dict]) -> nx.Graph:
+def build(extractions: list[dict], *, directed: bool = False) -> "nx.Graph":
     """Merge multiple extraction results into one graph."""
     combined: dict = {"nodes": [], "edges": [], "input_tokens": 0, "output_tokens": 0}
     for ext in extractions:
@@ -39,4 +64,37 @@ def build(extractions: list[dict]) -> nx.Graph:
         combined["edges"].extend(ext.get("edges", []))
         combined["input_tokens"] += ext.get("input_tokens", 0)
         combined["output_tokens"] += ext.get("output_tokens", 0)
-    return build_from_json(combined)
+    return build_from_json(combined, directed=directed)
+
+
+def build_merge(
+    new_extractions: list[dict],
+    existing_graph_path,
+    *,
+    directed: bool = False,
+    force: bool = False,
+) -> "nx.Graph":
+    """Load existing graph, merge new_extractions in, never replace only grow."""
+    from networkx.readwrite import json_graph
+    import json as _json
+
+    new_G = build(new_extractions, directed=directed)
+    existing_path = Path(existing_graph_path)
+
+    if existing_path.exists():
+        existing_data = _json.loads(existing_path.read_text())
+        old_G = json_graph.node_link_graph(existing_data, edges="edges")
+        merged_G = old_G.copy()
+        merged_G.update(new_G)
+        if not force:
+            nodes_list = existing_data.get("nodes")
+            old_count = len(nodes_list) if nodes_list is not None else old_G.number_of_nodes()
+            if merged_G.number_of_nodes() < old_count:
+                raise ValueError(
+                    f"[graphify] build_merge: merged graph has {merged_G.number_of_nodes()} nodes "
+                    f"but existing had {old_count}. Pass force=True to override."
+                )
+    else:
+        merged_G = new_G
+
+    return merged_G

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,6 +1,7 @@
 # monitor a folder and auto-trigger --update when files change
 from __future__ import annotations
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -54,15 +55,30 @@ def _rebuild_code(watch_path: Path) -> bool:
         }
 
         G = build_from_json(result)
+
+        out = watch_path / "graphify-out"
+        out.mkdir(exist_ok=True)
+
+        # Node-count safety check: merged graph must not lose nodes vs the existing graph.json.
+        graph_json_path = out / "graph.json"
+        if graph_json_path.exists():
+            import json as _json
+            existing_data = _json.loads(graph_json_path.read_text())
+            nodes_list = existing_data.get("nodes")
+            existing_node_count = len(nodes_list) if nodes_list is not None else 0
+            if G.number_of_nodes() < existing_node_count:
+                raise ValueError(
+                    f"[graphify watch] node-count guard: new build has {G.number_of_nodes()} nodes "
+                    f"but existing graph.json has {existing_node_count}. "
+                    "Aborting rebuild to prevent data loss."
+                )
+
         communities = cluster(G)
         cohesion = score_all(G, communities)
         gods = god_nodes(G)
         surprises = surprising_connections(G, communities)
         labels = {cid: "Community " + str(cid) for cid in communities}
         questions = suggest_questions(G, communities, labels)
-
-        out = watch_path / "graphify-out"
-        out.mkdir(exist_ok=True)
 
         report = generate(G, communities, cohesion, labels, gods, surprises, detection,
                           {"input": 0, "output": 0}, str(watch_path), suggested_questions=questions)
@@ -79,6 +95,8 @@ def _rebuild_code(watch_path: Path) -> bool:
         print(f"[graphify watch] graph.json and GRAPH_REPORT.md updated in {out}")
         return True
 
+    except ValueError:
+        raise
     except Exception as exc:
         print(f"[graphify watch] Rebuild failed: {exc}")
         return False
@@ -158,7 +176,10 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
                 if _has_non_code(batch):
                     _notify_only(watch_path)
                 else:
-                    _rebuild_code(watch_path)
+                    try:
+                        _rebuild_code(watch_path)
+                    except ValueError as exc:
+                        print(f"[graphify watch] Rebuild aborted: {exc}", file=sys.stderr)
     except KeyboardInterrupt:
         print("\n[graphify watch] Stopped.")
     finally:


### PR DESCRIPTION
Closing in favour of a clean re-open — branch was based on stale fork main (189 commits behind upstream), producing a 37k-line diff. Replaced with a single-commit branch rebased directly onto current upstream main.