### PR TITLE
fix(extract): keep graph node ids relative

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -18,6 +18,66 @@ def _make_id(*parts: str) -> str:
     return cleaned.strip("_").lower()
 
 
+def _normalize_source_path(path_str: str, root: Path | None) -> str:
+    """Return a stable display path relative to root when possible.
+
+    Graphify often receives absolute file paths from callers running on a
+    project root or worktree. Absolute paths leak machine-specific prefixes
+    into file node IDs, which then surface in graph.json edge endpoints.
+    """
+    if not path_str:
+        return path_str
+    path = Path(path_str)
+    if not path.is_absolute():
+        return path.as_posix()
+    candidates: list[Path] = []
+    if root is not None:
+        candidates.append(root.resolve())
+    candidates.append(Path.cwd().resolve())
+    resolved = path.resolve()
+    for base in candidates:
+        try:
+            return resolved.relative_to(base).as_posix()
+        except ValueError:
+            continue
+    return resolved.as_posix()
+
+
+def _normalize_result_paths(result: dict, root: Path | None) -> dict:
+    """Relativize source_file fields and remap file-node IDs in-place."""
+    if root is None:
+        return result
+
+    file_id_map: dict[str, str] = {}
+    for node in result.get("nodes", []):
+        source_file = node.get("source_file", "")
+        normalized = _normalize_source_path(source_file, root)
+        if source_file:
+            node["source_file"] = normalized
+        label = node.get("label", "")
+        if source_file and label == Path(normalized).name:
+            old_id = _make_id(source_file)
+            new_id = _make_id(normalized)
+            if node.get("id") == old_id and old_id != new_id:
+                node["id"] = new_id
+                file_id_map[old_id] = new_id
+
+    for bucket in ("edges", "hyperedges", "raw_calls"):
+        for item in result.get(bucket, []):
+            source_file = item.get("source_file", "")
+            if source_file:
+                item["source_file"] = _normalize_source_path(source_file, root)
+            if bucket == "edges":
+                src = item.get("source")
+                tgt = item.get("target")
+                if src in file_id_map:
+                    item["source"] = file_id_map[src]
+                if tgt in file_id_map:
+                    item["target"] = file_id_map[tgt]
+
+    return result
+
+
 # ── LanguageConfig dataclass ─────────────────────────────────────────────────
 
 @dataclass
@@ -3092,11 +3152,12 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
         elif len(paths) == 1:
             root = paths[0].parent
         else:
-            common_len = sum(
-                1 for i in range(min(len(p.parts) for p in paths))
-                if len({p.parts[i] for p in paths}) == 1
-            )
-            root = Path(*paths[0].parts[:common_len]) if common_len else Path(".")
+            common_parts: list[str] = []
+            for parts in zip(*(p.parts for p in paths)):
+                if len(set(parts)) != 1:
+                    break
+                common_parts.append(parts[0])
+            root = Path(*common_parts) if common_parts else Path(".")
     except Exception:
         root = Path(".")
 
@@ -3153,11 +3214,14 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
             continue
         cached = load_cached(path, cache_root or root)
         if cached is not None:
-            per_file.append(cached)
+            per_file.append(_normalize_result_paths(cached, cache_root or root))
             continue
         result = extractor(path)
         if "error" not in result:
+            result = _normalize_result_paths(result, cache_root or root)
             save_cached(path, result, cache_root or root)
+        else:
+            result = _normalize_result_paths(result, cache_root or root)
         per_file.append(result)
     if total >= _PROGRESS_INTERVAL:
         print(f"  AST extraction: {total}/{total} files (100%)", flush=True)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,8 @@
+import json
 from pathlib import Path
+from graphify.build import build_from_json
 from graphify.extract import extract_python, extract, collect_files, _make_id
+from graphify.export import to_json
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -54,6 +57,47 @@ def test_extract_merges_multiple_files():
     result = extract(files)
     assert len(result["nodes"]) > 0
     assert result["input_tokens"] == 0
+
+
+def test_extract_relativizes_absolute_file_node_ids(tmp_path):
+    pkg1 = tmp_path / "pkg1"
+    pkg2 = tmp_path / "pkg2"
+    pkg1.mkdir()
+    pkg2.mkdir()
+    (pkg1 / "main.py").write_text("def alpha():\n    pass\n")
+    (pkg2 / "main.py").write_text("def beta():\n    pass\n")
+
+    result = extract([pkg1 / "main.py", pkg2 / "main.py"])
+
+    file_nodes = {
+        n["source_file"]: n["id"]
+        for n in result["nodes"]
+        if n["label"] == "main.py"
+    }
+    assert file_nodes == {
+        "pkg1/main.py": _make_id("pkg1/main.py"),
+        "pkg2/main.py": _make_id("pkg2/main.py"),
+    }
+
+
+def test_exported_graph_json_uses_relative_file_edge_endpoints(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    path = src / "main.py"
+    path.write_text("def main():\n    pass\n")
+
+    result = extract([path])
+    G = build_from_json(result)
+    out = tmp_path / "graph.json"
+    to_json(G, {}, str(out))
+
+    data = json.loads(out.read_text())
+    contains = [edge for edge in data["links"] if edge["relation"] == "contains"]
+    assert contains
+    assert contains[0]["_src"] == "main_py"
+    assert contains[0]["_tgt"] == "main_main"
+    assert {contains[0]["source"], contains[0]["target"]} == {"main_py", "main_main"}
+    assert tmp_path.as_posix() not in out.read_text()
 
 
 def test_collect_files_from_dir():


### PR DESCRIPTION
## Summary

- normalize extracted `source_file` values relative to the inferred project root before graph construction
- remap file node IDs when they were derived from absolute paths so `graph.json` edge endpoints stay machine-independent
- add regression coverage for absolute-path inputs and exported `graph.json` edge endpoint fields

## Why

Issue #502 is the remaining path leak after #433 / #434: `source_file` may already be relative, but `links[].source`, `links[].target`, `links[]._src`, and `links[]._tgt` can still expose absolute-path-derived file node IDs.

Closes #502.

## Testing

- `/tmp/graphify-fix/venv/bin/python -m pytest tests/test_extract.py`
- `/tmp/graphify-fix/venv/bin/python -m pytest tests/test_build.py tests/test_export.py tests/test_cache.py tests/test_watch.py tests/test_multilang.py`
