### PR TITLE
fix: restore empty-community filter lost in v2 report rewrite

### DIFF
--- a/graphify/report.py
+++ b/graphify/report.py
@@ -28,6 +28,16 @@ def generate(
     inf_scores = [d.get("confidence_score", 0.5) for _, _, d in inf_edges]
     inf_avg = round(sum(inf_scores) / len(inf_scores), 2) if inf_scores else None
 
+    # Communities whose members are all file-level stubs (filtered out by
+    # _is_file_node in the Communities section below) add pure noise — on
+    # mid-size codebases they accounted for 70-80% of communities and
+    # distorted the Summary count / Knowledge Gaps flags. The filter was
+    # shipped in v0.4.25 (PR #476) and regressed during the v2 report
+    # rewrite; this restores it.
+    from .analyze import _is_file_node as _ifn
+    non_empty = {cid: nodes for cid, nodes in communities.items()
+                 if any(not _ifn(G, n) for n in nodes)}
+
     lines = [
         f"# Graph Report - {root}  ({today})",
         "",
@@ -44,7 +54,7 @@ def generate(
     lines += [
         "",
         "## Summary",
-        f"- {G.number_of_nodes()} nodes · {G.number_of_edges()} edges · {len(communities)} communities detected",
+        f"- {G.number_of_nodes()} nodes · {G.number_of_edges()} edges · {len(non_empty)} communities detected",
         f"- Extraction: {ext_pct}% EXTRACTED · {inf_pct}% INFERRED · {amb_pct}% AMBIGUOUS"
         + (f" · INFERRED: {len(inf_edges)} edges (avg confidence: {inf_avg})" if inf_avg is not None else ""),
         f"- Token cost: {token_cost.get('input', 0):,} input · {token_cost.get('output', 0):,} output",
@@ -85,12 +95,15 @@ def generate(
             lines.append(f"- **{h.get('label', h.get('id', ''))}** — {node_labels} [{conf_tag}]")
 
     lines += ["", "## Communities"]
-    from .analyze import _is_file_node as _ifn
     for cid, nodes in communities.items():
         label = community_labels.get(cid, f"Community {cid}")
         score = cohesion_scores.get(cid, 0.0)
         # Filter method/function stubs from display - they're structural noise
         real_nodes = [n for n in nodes if not _ifn(G, n)]
+        # Skip clustering artifacts: all members were file-level stubs.
+        # Printing "Nodes (0):" adds noise and inflates the report.
+        if not real_nodes:
+            continue
         display = [G.nodes[n].get("label", n) for n in real_nodes[:8]]
         suffix = f" (+{len(real_nodes)-8} more)" if len(real_nodes) > 8 else ""
         lines += [
@@ -118,8 +131,15 @@ def generate(
         n for n in G.nodes()
         if G.degree(n) <= 1 and not _is_file_node(G, n) and not _is_concept_node(G, n)
     ]
+    # Knowledge Gaps should flag communities that are genuinely too small
+    # (real-node count between 1 and 2), not clustering artifacts where every
+    # member is a file-level stub.  Zero-real-node communities are already
+    # skipped in the Communities section above.
     thin_communities = {
-        cid: nodes for cid, nodes in communities.items() if len(nodes) < 3
+        cid: real_ns
+        for cid, nodes in communities.items()
+        for real_ns in [[n for n in nodes if not _ifn(G, n)]]
+        if 0 < len(real_ns) < 3
     }
     gap_count = len(isolated) + len(thin_communities)
 

--- a/tests/test_report_empty_communities.py
+++ b/tests/test_report_empty_communities.py
@@ -1,0 +1,73 @@
+"""Regression test for PR #476 (v0.4.25) — empty-community filter.
+
+The v2 report rewrite dropped the filter that skipped clustering artifacts
+whose entire membership is file-level stubs (`_is_file_node`).  These
+"empty" communities inflated the Summary count, added blank "Nodes (0):"
+blocks to the Communities section, and polluted the Knowledge Gaps list
+with noise.
+
+This test drives `generate` directly with a minimal 2-node graph + two
+communities (one real, one stub-only) and asserts the stub community is
+suppressed everywhere downstream.  No clustering pipeline (graspologic)
+is required.
+"""
+
+import networkx as nx
+
+from graphify.report import generate
+
+
+def _make_graph():
+    """Graph with a non-stub class node + two file-level stubs.
+
+    `analyze._is_file_node` treats labels ending in `.py` (or other code
+    extensions) as file-level hubs, and labels ending in `()` with degree
+    ≤ 1 as isolated function stubs.  Our "class Authenticator" label
+    dodges both filters so it reads as a real, non-stub node.
+    """
+    G = nx.Graph()
+    G.add_node("real_class", label="class Authenticator", kind="class")
+    G.add_node("file_stub_a", label="auth.py",   kind="file")
+    G.add_node("file_stub_b", label="models.py", kind="file")
+    G.add_edge("real_class", "file_stub_a", confidence="EXTRACTED")
+    G.add_edge("real_class", "file_stub_b", confidence="EXTRACTED")
+    return G
+
+
+def _inputs():
+    G = _make_graph()
+    communities = {
+        0: ["real_class"],                     # non-empty — keep
+        1: ["file_stub_a", "file_stub_b"],     # stub-only — drop
+    }
+    cohesion = {0: 1.0, 1: 0.5}
+    labels   = {0: "Community 0", 1: "Community 1"}
+    gods     = [{"label": "class Authenticator", "edges": 2}]
+    surprises = []
+    detection = {"total_files": 2, "total_words": 42, "needs_graph": True, "warning": None}
+    tokens = {"input": 0, "output": 0}
+    return G, communities, cohesion, labels, gods, surprises, detection, tokens
+
+
+def test_summary_counts_only_non_empty_communities():
+    report = generate(*_inputs(), root="./fixture")
+    # 2 raw communities → 1 non-empty.
+    assert "1 communities detected" in report
+    assert "2 communities detected" not in report
+
+
+def test_empty_community_not_rendered_in_communities_section():
+    report = generate(*_inputs(), root="./fixture")
+    # Stub-only community should be fully suppressed — not even an
+    # empty "Nodes (0):" block should be emitted.
+    assert 'Community 1 - "Community 1"' not in report
+    # Sanity: the real one IS rendered.
+    assert 'Community 0 - "Community 0"' in report
+
+
+def test_stub_only_community_excluded_from_knowledge_gaps():
+    report = generate(*_inputs(), root="./fixture")
+    # thin_communities filter must not flag the stub-only community as
+    # "too small to be a meaningful cluster" — it was never a community
+    # of real nodes in the first place.
+    assert "Thin community `Community 1`" not in report


### PR DESCRIPTION
## Summary

The empty-community filter originally shipped in **v0.4.25 (PR #476)** regressed during the v2 report rewrite. On mid-size codebases 70-80% of communities are clustering artifacts whose entire membership is file-level stubs (filtered by `_is_file_node`), and these are once again polluting the Summary count, the Communities section, and the Knowledge Gaps list.

This PR restores the three behaviours from v0.4.25 that are gone on current `main`:

1. **Summary** now reports `len(non_empty)` — communities that contain at least one non-stub node. Before: 287 on my aria-core graph. After: a much smaller, meaningful number.
2. **Communities section** skips entries whose `real_nodes` list is empty, dropping blank `Nodes (0):` blocks.
3. **Knowledge Gaps** (`thin_communities`) now keeps only communities with 1 or 2 real nodes, excluding zero-real-node artifacts that aren't "too small to be a meaningful cluster" warnings — they are not clusters of real nodes at all.

## Verification against current `main`

On the 14996-node aria-core graph, `graphify update src/` currently reports:
```
## Summary
- 14996 nodes · 38860 edges · 287 communities detected
## Communities
### Community 47 - "Community 47"
Cohesion: 1.0
Nodes (0):
```
…and dozens of identical empty `Community N` blocks. After this patch, the Summary count drops to the non-empty subset and the empty blocks are suppressed entirely.

## Tests

`tests/test_report_empty_communities.py` — 3 new tests:

- `test_summary_counts_only_non_empty_communities`
- `test_empty_community_not_rendered_in_communities_section`
- `test_stub_only_community_excluded_from_knowledge_gaps`

Each drives `generate()` with a 3-node graph and two communities (one with a real `class Authenticator` node, one with only file stubs `auth.py` + `models.py`) and asserts the stub-only community is suppressed in every downstream section. No graspologic dependency — runs on any dev box.

## History

- [PR #476](https://github.com/safishamsi/graphify/pull/476) — the original, closed with the v0.4.25 fix applied.
- This is a clean re-submission against current `main` after the v2 rewrite lost the filter.