### PR TITLE
fix hook context output - Fixes #533 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ graphify-out/
 .claude/
 skills/
 docs/superpowers/
+.codex/
+.codex-*
+.agents/
+codex-*.log
 .vscode/
 openspec/
 uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -15,19 +15,3 @@ build/
 .graphify/
 graphify-out/
 .graphify_*.json
-.graphify_python
-.claude/
-skills/
-docs/superpowers/
-.codex/
-.codex-*
-.agents/
-codex-*.log
-.vscode/
-openspec/
-uv.lock
-# Local benchmark scripts — never commit
-scripts/run_k2_*.py
-scripts/llm.py
-scripts/benchmark_kimi*.json
-scripts/benchmark_kimi*.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,15 @@ build/
 .graphify/
 graphify-out/
 .graphify_*.json
+.graphify_python
+.claude/
+skills/
+docs/superpowers/
+.vscode/
+openspec/
+uv.lock
+# Local benchmark scripts — never commit
+scripts/run_k2_*.py
+scripts/llm.py
+scripts/benchmark_kimi*.json
+scripts/benchmark_kimi*.py

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -711,7 +711,7 @@ _CODEX_HOOK = {
                         "type": "command",
                         "command": (
                             "[ -f graphify-out/graph.json ] && "
-                            r"""echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}}' """
+                            r"""echo '{"systemMessage":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}' """
                             "|| true"
                         ),
                     }

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -132,16 +132,38 @@ def test_codex_agents_install_writes_agents_md(tmp_path):
 def test_codex_agents_install_writes_supported_hook_output(tmp_path):
     """Codex rejects Claude-style additionalContext hook output."""
     import json as _json
+    import re
+    import subprocess
 
     _agents_install(tmp_path, "codex")
     hooks_path = tmp_path / ".codex" / "hooks.json"
     hooks = _json.loads(hooks_path.read_text())["hooks"]["PreToolUse"]
-    hook_text = str(hooks)
+    command = hooks[0]["hooks"][0]["command"]
+    match = re.search(r"echo '([^']+)'", command)
+    assert match, command
 
-    assert "systemMessage" in hook_text
-    assert "additionalContext" not in hook_text
-    assert "hookSpecificOutput" not in hook_text
-    assert "permissionDecision" not in hook_text
+    allowed_keys = {"systemMessage"}
+    unsupported_keys = {"additionalContext", "hookSpecificOutput", "permissionDecision"}
+    literal_output = _json.loads(match.group(1))
+
+    assert set(literal_output) == allowed_keys
+    assert unsupported_keys.isdisjoint(literal_output)
+
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir()
+    graph_path.write_text("{}")
+    result = subprocess.run(
+        command,
+        shell=True,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    runtime_output = _json.loads(result.stdout)
+    assert set(runtime_output) == allowed_keys
+    assert unsupported_keys.isdisjoint(runtime_output)
 
 
 def test_opencode_agents_install_writes_agents_md(tmp_path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -129,6 +129,21 @@ def test_codex_agents_install_writes_agents_md(tmp_path):
     assert "GRAPH_REPORT.md" in agents_md.read_text()
 
 
+def test_codex_agents_install_writes_supported_hook_output(tmp_path):
+    """Codex rejects Claude-style additionalContext hook output."""
+    import json as _json
+
+    _agents_install(tmp_path, "codex")
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    hooks = _json.loads(hooks_path.read_text())["hooks"]["PreToolUse"]
+    hook_text = str(hooks)
+
+    assert "systemMessage" in hook_text
+    assert "additionalContext" not in hook_text
+    assert "hookSpecificOutput" not in hook_text
+    assert "permissionDecision" not in hook_text
+
+
 def test_opencode_agents_install_writes_agents_md(tmp_path):
     _agents_install(tmp_path, "opencode")
     assert (tmp_path / "AGENTS.md").exists()


### PR DESCRIPTION
## Summary

- Fix PreToolUse hook output to emit top-level `systemMessage` instead of unsupported `hookSpecificOutput.additionalContext`.
- Add a regression test covering unsupported hook fields.
- Ignore local assistant artifacts in `.gitignore`.

## Why

Newer CLI versions reject hook output containing `additionalContext` with:

`PreToolUse hook returned unsupported additionalContext`

The generated hook had regressed to a Claude-specific output shape.

## Validation

- `.venv/bin/pip install -e '.[all]'`
- `.venv/bin/pip check`
- `env HOME=/tmp/graphify-pytest-home .venv/bin/python -m pytest -q`
- `.venv/bin/graphify update .`
- Smoke-tested the platform install and verified the generated hook output contains `systemMessage` and no `additionalContext`.

Fixes #533 
Resolves #533 