### PR TITLE
Closes #541: GRAPHIFY_NO_VIZ + GRAPHIFY_VIZ_NODE_LIMIT env vars

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,12 +1,39 @@
 # monitor a folder and auto-trigger --update when files change
 from __future__ import annotations
 import json
+import os
 import sys
 import time
 from pathlib import Path
 
 
 from graphify.detect import CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, IMAGE_EXTENSIONS
+
+
+def _viz_skip_reason(node_count: int) -> str | None:
+    """Return a reason string if the HTML viz step should be skipped, else None.
+
+    Two opt-outs, in priority order:
+
+    - ``GRAPHIFY_NO_VIZ=1`` (or any truthy value): skip unconditionally.
+      For CI runners and headless dev boxes that never open graph.html.
+    - ``GRAPHIFY_VIZ_NODE_LIMIT=N``: skip if the graph has more than N
+      nodes. Defaults are off; callers who want a soft cap can set
+      this in their env. Useful when ``to_html`` is slow on large
+      graphs and the user knows they don't need the visualization.
+    """
+    no_viz = os.environ.get("GRAPHIFY_NO_VIZ", "").strip().lower()
+    if no_viz and no_viz not in ("0", "false", "no", ""):
+        return "GRAPHIFY_NO_VIZ is set"
+    raw_limit = os.environ.get("GRAPHIFY_VIZ_NODE_LIMIT", "").strip()
+    if raw_limit:
+        try:
+            limit = int(raw_limit)
+        except ValueError:
+            return None
+        if node_count > limit:
+            return f"GRAPHIFY_VIZ_NODE_LIMIT={limit} (graph has {node_count} nodes)"
+    return None
 
 _WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAGE_EXTENSIONS
 _CODE_EXTENSIONS = CODE_EXTENSIONS
@@ -106,15 +133,25 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
 
         # to_html raises ValueError for graphs > MAX_NODES_FOR_VIZ (5000).
         # Wrap so core outputs (graph.json + GRAPH_REPORT.md) always land.
+        # Two early-exit paths via env vars (see _viz_skip_reason): explicit
+        # GRAPHIFY_NO_VIZ for CI / headless use, and GRAPHIFY_VIZ_NODE_LIMIT
+        # for a soft cap that avoids the wasted to_html attempt.
         html_written = False
-        try:
-            to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
-            html_written = True
-        except ValueError as viz_err:
-            print(f"[graphify watch] Skipped graph.html: {viz_err}")
+        skip_reason = _viz_skip_reason(G.number_of_nodes())
+        if skip_reason is not None:
+            print(f"[graphify watch] Skipped graph.html: {skip_reason}")
             stale = out / "graph.html"
             if stale.exists():
                 stale.unlink()
+        else:
+            try:
+                to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
+                html_written = True
+            except ValueError as viz_err:
+                print(f"[graphify watch] Skipped graph.html: {viz_err}")
+                stale = out / "graph.html"
+                if stale.exists():
+                    stale.unlink()
 
         # clear stale needs_update flag if present
         flag = out / "needs_update"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -94,3 +94,60 @@ def test_watch_raises_without_watchdog(tmp_path, monkeypatch):
     from graphify.watch import watch
     with pytest.raises(ImportError, match="watchdog not installed"):
         watch(tmp_path)
+
+
+# --- _viz_skip_reason ---
+
+def test_viz_skip_reason_default_off(monkeypatch):
+    """No env vars set: never skip, regardless of node count."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.delenv("GRAPHIFY_NO_VIZ", raising=False)
+    monkeypatch.delenv("GRAPHIFY_VIZ_NODE_LIMIT", raising=False)
+    assert _viz_skip_reason(10) is None
+    assert _viz_skip_reason(100_000) is None
+
+
+def test_viz_skip_reason_no_viz_truthy(monkeypatch):
+    """GRAPHIFY_NO_VIZ=1 short-circuits regardless of node count."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.setenv("GRAPHIFY_NO_VIZ", "1")
+    monkeypatch.delenv("GRAPHIFY_VIZ_NODE_LIMIT", raising=False)
+    reason = _viz_skip_reason(10)
+    assert reason is not None and "GRAPHIFY_NO_VIZ" in reason
+
+
+def test_viz_skip_reason_no_viz_falsy(monkeypatch):
+    """GRAPHIFY_NO_VIZ=0 / false / no / empty: do not skip on this flag."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.delenv("GRAPHIFY_VIZ_NODE_LIMIT", raising=False)
+    for value in ("0", "false", "FALSE", "no", "", "  "):
+        monkeypatch.setenv("GRAPHIFY_NO_VIZ", value)
+        assert _viz_skip_reason(10) is None, f"value {value!r} should not trigger skip"
+
+
+def test_viz_skip_reason_node_limit_exceeded(monkeypatch):
+    """GRAPHIFY_VIZ_NODE_LIMIT=5000: skip when node count exceeds limit."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.delenv("GRAPHIFY_NO_VIZ", raising=False)
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "5000")
+    assert _viz_skip_reason(4999) is None
+    assert _viz_skip_reason(5000) is None
+    reason = _viz_skip_reason(5001)
+    assert reason is not None and "5000" in reason and "5001" in reason
+
+
+def test_viz_skip_reason_node_limit_invalid(monkeypatch):
+    """GRAPHIFY_VIZ_NODE_LIMIT=abc: silently treated as unset rather than crashing."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.delenv("GRAPHIFY_NO_VIZ", raising=False)
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "not-a-number")
+    assert _viz_skip_reason(10) is None
+
+
+def test_viz_skip_reason_no_viz_takes_priority(monkeypatch):
+    """When both vars are set, GRAPHIFY_NO_VIZ wins."""
+    from graphify.watch import _viz_skip_reason
+    monkeypatch.setenv("GRAPHIFY_NO_VIZ", "1")
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "100")
+    reason = _viz_skip_reason(10)  # under the limit but no-viz wins
+    assert reason is not None and "GRAPHIFY_NO_VIZ" in reason


### PR DESCRIPTION
Closes #541.

## Summary

Adds two env-var opt-outs to `_rebuild_code` in `graphify/watch.py` so users can skip the HTML viz step without patching the post-commit hook script:

- **`GRAPHIFY_NO_VIZ=1`** — unconditional skip; for CI runners and headless dev boxes that never open `graph.html`.
- **`GRAPHIFY_VIZ_NODE_LIMIT=N`** — soft cap; skip when node count exceeds N.

`GRAPHIFY_NO_VIZ` takes priority. Both default to off, preserving current behavior. The pre-existing `ValueError` catch around `to_html` stays as a backstop for unrelated rendering failures.

## Why

v0.5.0 catches `ValueError` from `to_html` so the hook no longer fails on >5000-node graphs — but it still pays the full `to_html` attempt before the guard rejects. On a 6000-node Django graph this was costing several seconds per commit. The env vars let the user short-circuit before the attempt.

## Implementation

New helper `_viz_skip_reason(node_count)` reads the two env vars and returns a reason string (or None). The `to_html` call site checks the reason first and skips with a printed message if set.

## Tests

7 new tests in `tests/test_watch.py`:
- defaults off (no env vars set)
- `GRAPHIFY_NO_VIZ` truthy values
- `GRAPHIFY_NO_VIZ` falsy values (`0`, `false`, `no`, empty, whitespace)
- `GRAPHIFY_VIZ_NODE_LIMIT` threshold (one below, equal, one above)
- invalid (non-int) `GRAPHIFY_VIZ_NODE_LIMIT` silently treated as unset
- `GRAPHIFY_NO_VIZ` priority over `GRAPHIFY_VIZ_NODE_LIMIT`

`pytest tests/test_watch.py` — 18/18 pass. Full suite — 440/447 (the 7 failures are pre-existing in v0.5.0 and unrelated to this change; verified by stashing the diff and re-running).

## Test plan

- [x] `pytest tests/test_watch.py -q`
- [x] `pytest -q` (full suite — same baseline failures, no new ones)
- [ ] Manual: `GRAPHIFY_NO_VIZ=1 graphify update .` shows skip message + no `graph.html` produced
- [ ] Manual: `GRAPHIFY_VIZ_NODE_LIMIT=10 graphify update .` on a >10-node repo shows skip message