### PR TITLE
Closes #539: clarify --update prune message (split drift vs no-drift)

### DIFF
--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -818,7 +818,10 @@ deleted = set(incremental.get('deleted_files', []))
 if deleted:
     to_remove = [n for n, d in G_existing.nodes(data=True) if d.get('source_file') in deleted]
     G_existing.remove_nodes_from(to_remove)
-    print(f'Pruned {len(to_remove)} ghost nodes from {len(deleted)} deleted file(s)')
+    if to_remove:
+        print(f'Pruned {len(to_remove)} ghost node(s) from {len(deleted)} deleted file(s) — drift detected and corrected.')
+    else:
+        print(f'{len(deleted)} file(s) deleted since last run, but no ghost nodes were present in the graph — no drift.')
 
 # Merge: new nodes/edges into existing graph
 G_existing.update(G_new)

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -915,7 +915,10 @@ deleted = set(incremental.get('deleted_files', []))
 if deleted:
     to_remove = [n for n, d in G_existing.nodes(data=True) if d.get('source_file') in deleted]
     G_existing.remove_nodes_from(to_remove)
-    print(f'Pruned {len(to_remove)} ghost nodes from {len(deleted)} deleted file(s)')
+    if to_remove:
+        print(f'Pruned {len(to_remove)} ghost node(s) from {len(deleted)} deleted file(s) — drift detected and corrected.')
+    else:
+        print(f'{len(deleted)} file(s) deleted since last run, but no ghost nodes were present in the graph — no drift.')
 
 # Merge: new nodes/edges into existing graph
 G_existing.update(G_new)


### PR DESCRIPTION
Closes #539.

## Summary

Splits the ambiguous `Pruned 0 ghost nodes from 13 deleted file(s)` message into two unambiguous variants:

- **Drift case** (something to prune): `Pruned N ghost node(s) from M deleted file(s) — drift detected and corrected.`
- **No-drift case** (deleted files were already absent): `M file(s) deleted since last run, but no ghost nodes were present in the graph — no drift.`

## Why

The current message reads `Pruned 0 ghost nodes from 13 deleted file(s)`. A reader can't tell whether:
- (a) 13 files were detected as deleted and 0 of them had nodes worth pruning (benign — graph already clean), or
- (b) 13 ghost nodes still exist and only 0 got pruned (bug).

The two interpretations have very different operational implications. Splitting the cases removes the ambiguity.

## Files changed

- `graphify/skill.md` (line 918) — primary skill template
- `graphify/skill-copilot.md` (line 821) — Copilot variant carries the same merge step verbatim

The other 9 skill-*.md files don't include the `--update` merge step inline (they reference it via the canonical `skill.md`).

## Test plan

- [ ] Manual: trigger `--update` after a deletion (drift) — verify drift message
- [ ] Manual: trigger `--update` after deleting a file with no graph nodes — verify no-drift message
- [ ] No code changes; pure skill-prompt edit — no test suite impact