### PR TITLE
Closes #538: save_manifest at end of --update merge step

### DIFF
--- a/graphify/skill-copilot.md
+++ b/graphify/skill-copilot.md
@@ -823,6 +823,14 @@ if deleted:
 # Merge: new nodes/edges into existing graph
 G_existing.update(G_new)
 print(f'Merged: {G_existing.number_of_nodes()} nodes, {G_existing.number_of_edges()} edges')
+
+# Save manifest with the CURRENT full file list so the next --update
+# diffs against today's filesystem state, not the prior --update's
+# baseline. Without this, deleted files get reported as ghosts again
+# on every subsequent --update until a full rebuild runs.
+from graphify.detect import save_manifest
+save_manifest(incremental['files'])
+print('[graphify update] Manifest saved.')
 " 
 ```
 

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -931,6 +931,14 @@ merged_out = {
 }
 Path('graphify-out/.graphify_extract.json').write_text(json.dumps(merged_out))
 print(f'[graphify update] Merged extraction written ({len(merged_out[\"nodes\"])} nodes, {len(merged_out[\"edges\"])} edges)')
+
+# Save manifest with the CURRENT full file list so the next --update
+# diffs against today's filesystem state, not the prior --update's
+# baseline. Without this, deleted files get reported as ghosts again
+# on every subsequent --update until a full rebuild runs.
+from graphify.detect import save_manifest
+save_manifest(incremental['files'])
+print('[graphify update] Manifest saved.')
 " 
 ```
 


### PR DESCRIPTION
Closes #538.

## Summary

Adds `save_manifest(incremental['files'])` at the end of the `--update` merge step in `skill.md` and `skill-copilot.md`.

## Why

The full-pipeline path's Step 9 already calls `save_manifest`, so the **next** `--update` can diff against the full-rebuild's baseline. But the `--update` flow itself does NOT save the manifest after merging the incremental result.

**Consequence:** a file deleted between `--update #1` and `--update #2` keeps reappearing in `#2`'s `deleted_files` list (since the manifest still records its old mtime), generating a spurious ghost-node prune attempt every run. The drift never settles until a full rebuild runs.

This was originally reported as "manifest should be saved on every full rebuild," but on inspection of v0.5.0 the full-rebuild path is already correct — the actual gap is in `--update`. Fixing in the right place.

## Files changed

- `graphify/skill.md` (line ~933) — primary skill template
- `graphify/skill-copilot.md` (line ~825) — Copilot variant carries the merge step verbatim

The other 9 skill-*.md files don't include the `--update` merge step inline.

## Test plan

- [ ] Manual: run `--update` after a deletion → verify manifest is rewritten and a follow-up `--update` reports no `deleted_files`
- [ ] No code changes; pure skill-prompt edit — no test suite impact