### PR TITLE
fix(hooks): expand ~ in core.hooksPath before resolving install target

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -145,7 +145,7 @@ def _hooks_dir(root: Path) -> Path:
         if result.returncode == 0:
             custom = result.stdout.strip()
             if custom:
-                p = Path(custom)
+                p = Path(custom).expanduser()
                 if not p.is_absolute():
                     p = root / p
                 p.mkdir(parents=True, exist_ok=True)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -123,3 +123,30 @@ def test_hook_skips_head_on_exe():
     """Hook script must skip shebang extraction for .exe binaries (Windows)."""
     from graphify.hooks import _PYTHON_DETECT
     assert "*.exe) _SHEBANG=" in _PYTHON_DETECT or '*.exe)' in _PYTHON_DETECT
+
+
+def test_hooks_dir_expands_tilde(tmp_path, monkeypatch):
+    """_hooks_dir must call expanduser() so ~/... paths in core.hooksPath resolve correctly."""
+    from graphify.hooks import _hooks_dir
+    import types
+
+    repo = _make_git_repo(tmp_path)
+    custom_hooks = tmp_path / "custom_hooks"
+    custom_hooks.mkdir()
+
+    # expanduser() reads $HOME, so override it to make ~/custom_hooks predictable
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if isinstance(cmd, list) and "config" in cmd and "core.hooksPath" in cmd:
+            return types.SimpleNamespace(returncode=0, stdout="~/custom_hooks")
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    resolved = _hooks_dir(repo)
+    assert resolved == custom_hooks, (
+        f"expected {custom_hooks}, got {resolved} — tilde was not expanded"
+    )


### PR DESCRIPTION
## Problem

When `.gitconfig` sets:

```ini
[core]
    hooksPath = ~/gitconfig/hooks
```

`graphify hook install` installs into `<repo>/~/gitconfig/hooks` instead of the user's home-relative path. The tilde is treated as a literal directory name.

Root cause: `_hooks_dir()` built `Path(custom)` from the raw git config string without calling `.expanduser()`.

## Fix

Add `.expanduser()` immediately after constructing the path from the config value, before the `is_absolute()` / root-relative fallback:

```python
p = Path(custom).expanduser()
```

## Testing

Added `test_hooks_dir_expands_tilde` in `tests/test_hooks.py`:
- patches `$HOME` so `~/custom_hooks` resolves to a known temp directory
- stubs `subprocess.run` to return a tilde-form `core.hooksPath`
- asserts `_hooks_dir()` returns the fully expanded absolute path

All 15 hook tests pass.

Fixes #547