### PR TITLE
Wire --no-viz flag in cluster-only + GRAPHIFY_VIZ_NODE_LIMIT env var (closes #541)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -993,6 +993,7 @@ def main() -> None:
         print("  watch <path>            watch a folder and rebuild the graph on code changes")
         print("  update <path>           re-extract code files and update the graph (no LLM needed)")
         print("  cluster-only <path>     rerun clustering on an existing graph.json and regenerate report")
+        print("    --no-viz                skip graph.html generation (useful for >5000 node graphs / CI)")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
         print("    --budget N              cap output at N tokens (default 2000)")
@@ -1370,6 +1371,7 @@ def main() -> None:
 
     elif cmd == "cluster-only":
         watch_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".")
+        no_viz = "--no-viz" in sys.argv
         graph_json = watch_path / "graphify-out" / "graph.json"
         if not graph_json.exists():
             print(f"error: no graph found at {graph_json} — run /graphify first", file=sys.stderr)
@@ -1398,8 +1400,25 @@ def main() -> None:
         out = watch_path / "graphify-out"
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         to_json(G, communities, str(out / "graph.json"))
-        to_html(G, communities, str(out / "graph.html"), community_labels=labels or None)
-        print(f"Done — {len(communities)} communities. GRAPH_REPORT.md, graph.json and graph.html updated.")
+
+        # Mirror watch.py pattern: gate to_html so core outputs (graph.json +
+        # GRAPH_REPORT.md) always land. Honor --no-viz explicitly; otherwise
+        # fall back to ValueError handling so an oversized graph doesn't crash
+        # the CLI mid-write and leave a stale graph.html on disk.
+        html_target = out / "graph.html"
+        if no_viz:
+            if html_target.exists():
+                html_target.unlink()
+            print(f"Done — {len(communities)} communities. GRAPH_REPORT.md and graph.json updated (--no-viz; graph.html removed).")
+        else:
+            try:
+                to_html(G, communities, str(html_target), community_labels=labels or None)
+                print(f"Done — {len(communities)} communities. GRAPH_REPORT.md, graph.json and graph.html updated.")
+            except ValueError as viz_err:
+                if html_target.exists():
+                    html_target.unlink()
+                print(f"Skipped graph.html: {viz_err}")
+                print(f"Done — {len(communities)} communities. GRAPH_REPORT.md and graph.json updated.")
 
     elif cmd == "update":
         watch_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".")

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -25,6 +25,22 @@ COMMUNITY_COLORS = [
 MAX_NODES_FOR_VIZ = 5_000
 
 
+def _viz_node_limit() -> int:
+    """Return the effective viz node limit, honoring GRAPHIFY_VIZ_NODE_LIMIT env var.
+
+    Falls back to MAX_NODES_FOR_VIZ when the env var is unset, empty, or non-integer.
+    Set to 0 to disable HTML viz unconditionally (useful for CI runners).
+    """
+    import os
+    raw = os.environ.get("GRAPHIFY_VIZ_NODE_LIMIT")
+    if raw is None or not raw.strip():
+        return MAX_NODES_FOR_VIZ
+    try:
+        return int(raw)
+    except ValueError:
+        return MAX_NODES_FOR_VIZ
+
+
 def _html_styles() -> str:
     return """<style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -370,15 +386,18 @@ def to_html(
 
     Features: node size by degree, click-to-inspect panel, search box,
     community filter, physics clustering by community, confidence-styled edges.
-    Raises ValueError if graph exceeds MAX_NODES_FOR_VIZ.
+    Raises ValueError if graph exceeds the effective viz node limit
+    (MAX_NODES_FOR_VIZ by default; overridable via GRAPHIFY_VIZ_NODE_LIMIT env var).
 
     If member_counts is provided (aggregated community view), node sizes are
     based on community member counts rather than graph degree.
     """
-    if G.number_of_nodes() > MAX_NODES_FOR_VIZ:
+    limit = _viz_node_limit()
+    if G.number_of_nodes() > limit:
         raise ValueError(
-            f"Graph has {G.number_of_nodes()} nodes - too large for HTML viz. "
-            f"Use --no-viz or reduce input size."
+            f"Graph has {G.number_of_nodes()} nodes - too large for HTML viz "
+            f"(limit: {limit}). Use --no-viz, raise GRAPHIFY_VIZ_NODE_LIMIT, "
+            f"or reduce input size."
         )
 
     node_community = _node_community_map(communities)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,9 +1,19 @@
 import json
+import os
 import tempfile
+import pytest
 from pathlib import Path
 from graphify.build import build_from_json
 from graphify.cluster import cluster
-from graphify.export import to_json, to_cypher, to_graphml, to_html, to_canvas
+from graphify.export import (
+    to_json,
+    to_cypher,
+    to_graphml,
+    to_html,
+    to_canvas,
+    _viz_node_limit,
+    MAX_NODES_FOR_VIZ,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -125,6 +135,62 @@ def test_to_html_contains_nodes_and_edges():
         content = out.read_text()
         assert "RAW_NODES" in content
         assert "RAW_EDGES" in content
+
+
+# --- GRAPHIFY_VIZ_NODE_LIMIT env var --------------------------------------------
+
+@pytest.fixture
+def restore_viz_env(monkeypatch):
+    """Ensure each test runs without GRAPHIFY_VIZ_NODE_LIMIT bleeding across cases."""
+    monkeypatch.delenv("GRAPHIFY_VIZ_NODE_LIMIT", raising=False)
+    yield
+
+
+def test_viz_node_limit_default(restore_viz_env):
+    assert _viz_node_limit() == MAX_NODES_FOR_VIZ
+
+
+def test_viz_node_limit_env_override_higher(restore_viz_env, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "20000")
+    assert _viz_node_limit() == 20000
+
+
+def test_viz_node_limit_env_override_zero_disables(restore_viz_env, monkeypatch):
+    """Setting to 0 lets users disable HTML viz unconditionally (CI runners)."""
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "0")
+    assert _viz_node_limit() == 0
+
+
+def test_viz_node_limit_invalid_falls_back_to_default(restore_viz_env, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "not-an-int")
+    assert _viz_node_limit() == MAX_NODES_FOR_VIZ
+
+
+def test_viz_node_limit_empty_falls_back_to_default(restore_viz_env, monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "  ")
+    assert _viz_node_limit() == MAX_NODES_FOR_VIZ
+
+
+def test_to_html_raises_with_lowered_limit(restore_viz_env, monkeypatch):
+    """Lowering the limit below the test graph's size triggers ValueError."""
+    G = make_graph()
+    communities = cluster(G)
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "1")
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.html"
+        with pytest.raises(ValueError, match="too large for HTML viz"):
+            to_html(G, communities, str(out))
+
+
+def test_to_html_writes_with_raised_limit(restore_viz_env, monkeypatch):
+    """Raising the limit above the graph's size lets to_html proceed normally."""
+    G = make_graph()
+    communities = cluster(G)
+    monkeypatch.setenv("GRAPHIFY_VIZ_NODE_LIMIT", "100000")
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "graph.html"
+        to_html(G, communities, str(out))
+        assert out.exists()
 
 
 def test_to_html_member_counts_accepted():


### PR DESCRIPTION
## Summary

Closes #541 by exposing both APIs the reporter proposed:

- **`GRAPHIFY_VIZ_NODE_LIMIT` env var** (option 2 in #541): override `MAX_NODES_FOR_VIZ` without patching the package. Set to `0` to disable HTML viz unconditionally (CI runners). Falls back to default on unset / empty / non-integer values.
- **`--no-viz` flag** (option 1 in #541): now wired into `cluster-only`. The flag was already documented in `skill.md` but never actually parsed by the Python CLI.

Also fixes a related crash: `cluster-only` previously called `to_html()` unconditionally, so on graphs >5000 nodes the `ValueError` fired *after* `graph.json` was written but *before* the final "Done — …" line, leaving a stale `graph.html` on disk and no clear signal in CLI output. This mirrors the existing `watch.py` rebuild pattern (try/except + delete stale html).

## Repro of the cluster-only crash

```bash
# On any repo whose graph.json contains >5000 nodes:
graphify cluster-only .
```

**Before:**

```
Loading existing graph...
Graph: 8881 nodes, 10829 edges
Re-clustering...
Traceback (most recent call last):
  ...
ValueError: Graph has 8881 nodes - too large for HTML viz. Use --no-viz or reduce input size.
# graph.json fresh, GRAPH_REPORT.md fresh, graph.html stale, no "Done" line
```

**After (default):**

```
Loading existing graph...
Graph: 8881 nodes, 10829 edges
Re-clustering...
Skipped graph.html: Graph has 8881 nodes - too large for HTML viz (limit: 5000). Use --no-viz, raise GRAPHIFY_VIZ_NODE_LIMIT, or reduce input size.
Done — 741 communities. GRAPH_REPORT.md and graph.json updated.
```

**With `--no-viz`:**

```
Done — 741 communities. GRAPH_REPORT.md and graph.json updated (--no-viz; graph.html removed).
```

**With `GRAPHIFY_VIZ_NODE_LIMIT=10000`:**

```
Done — 741 communities. GRAPH_REPORT.md, graph.json and graph.html updated.
```

## Out of scope (intentionally)

- **`graphify hook install --no-viz`** (the original #541 reporter's option 1): the hook script invokes `_rebuild_code()` from `watch.py`, which already has the try/except guard. So hook users on `v5` are *implicitly* safe from the crash, and the env var lets them tune the limit globally. A dedicated `hook install --no-viz` flag could be added in a follow-up if you'd like a more explicit knob — happy to do it.
- **`argparse` refactor of `__main__.py`:** would be cleaner than the ad-hoc `sys.argv` slicing, but is a larger change that deserves its own PR.

## Tests

`tests/test_export.py` gains 7 tests (all green together with the existing 13):

- `test_viz_node_limit_default` — unset env var falls back to `MAX_NODES_FOR_VIZ`
- `test_viz_node_limit_env_override_higher` — `=20000` raises the cap
- `test_viz_node_limit_env_override_zero_disables` — `=0` disables viz
- `test_viz_node_limit_invalid_falls_back_to_default` — non-integer is ignored
- `test_viz_node_limit_empty_falls_back_to_default` — whitespace/empty is ignored
- `test_to_html_raises_with_lowered_limit` — end-to-end ValueError with `=1`
- `test_to_html_writes_with_raised_limit` — end-to-end success with `=100000`

Run with: `pytest tests/test_export.py -v`

## Compatibility

- **Backward compatible.** Default behavior unchanged (`MAX_NODES_FOR_VIZ = 5_000`, `to_html` still raises `ValueError`).
- **No new dependencies.**
- One private symbol added to `graphify.export`: `_viz_node_limit` (underscore-prefixed; tests import it for direct unit coverage).

## Verified against

- `graphify cluster-only .` on a real 8881-node graph (a polyglot Flutter + Postgres + n8n repo): all three exit paths (default, `--no-viz`, env var override) produce the expected output and artifact mtimes.
