### PR TITLE
fix: cache.save_cached race + _clone_repo argument-injection hardening

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -943,6 +943,13 @@ def _clone_repo(url: str, branch: str | None = None, out_dir: Path | None = None
         sys.exit(1)
     owner, repo = m.group(1), m.group(2)
 
+    # Reject branch names that look like CLI flags. git treats refspecs starting
+    # with `-` as options in some positions, which would let a caller smuggle
+    # arguments through this surface (e.g. `--upload-pack=evilcmd`).
+    if branch is not None and branch.startswith("-"):
+        print(f"error: refusing branch name starting with '-': {branch!r}", file=sys.stderr)
+        sys.exit(1)
+
     if out_dir:
         dest = out_dir
     else:
@@ -952,7 +959,7 @@ def _clone_repo(url: str, branch: str | None = None, out_dir: Path | None = None
         print(f"Repo already cloned at {dest} — pulling latest...", flush=True)
         cmd = ["git", "-C", str(dest), "pull"]
         if branch:
-            cmd += ["origin", branch]
+            cmd += ["--", "origin", branch]
         result = _sp.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             print(f"warning: git pull failed:\n{result.stderr}", file=sys.stderr)
@@ -962,7 +969,7 @@ def _clone_repo(url: str, branch: str | None = None, out_dir: Path | None = None
         cmd = ["git", "clone", "--depth", "1"]
         if branch:
             cmd += ["--branch", branch]
-        cmd += [git_url, str(dest)]
+        cmd += ["--", git_url, str(dest)]
         result = _sp.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             print(f"error: git clone failed:\n{result.stderr}", file=sys.stderr)

--- a/graphify/cache.py
+++ b/graphify/cache.py
@@ -99,10 +99,17 @@ def save_cached(path: Path, result: dict, root: Path = Path("."), kind: str = "a
     if not p.is_file():
         return
     h = file_hash(p, root)
-    entry = cache_dir(root, kind) / f"{h}.json"
-    tmp = entry.with_suffix(".tmp")
+    target_dir = cache_dir(root, kind)
+    entry = target_dir / f"{h}.json"
+    # Per-writer unique temp filename: concurrent save_cached calls for the same
+    # hash (parallel extractors, retries) used to share `entry.with_suffix(".tmp")`
+    # and trample each other; tempfile.mkstemp gives each writer its own path.
+    import tempfile
+    fd, tmp_str = tempfile.mkstemp(dir=str(target_dir), prefix=f"{h}.", suffix=".tmp")
+    tmp = Path(tmp_str)
     try:
-        tmp.write_text(json.dumps(result), encoding="utf-8")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(result))
         try:
             os.replace(tmp, entry)
         except PermissionError:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -124,3 +124,47 @@ def test_body_content_no_frontmatter():
     """_body_content returns content unchanged when no frontmatter present."""
     content = b"No frontmatter here."
     assert _body_content(content) == content
+
+
+def test_save_cached_concurrent_writers_no_collision(tmp_path):
+    """Concurrent save_cached calls for the same file/hash must not collide
+    on a shared `.tmp` filename (regression: previously they all used
+    `entry.with_suffix('.tmp')` and trampled each other).
+
+    The fix uses tempfile.mkstemp so each writer gets a unique temp path.
+    """
+    import threading
+
+    f = tmp_path / "shared.txt"
+    f.write_text("same content for all writers")
+
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(8)
+
+    def writer(i: int) -> None:
+        try:
+            barrier.wait(timeout=5)
+            save_cached(f, {"nodes": [{"id": f"n{i}"}], "edges": []}, root=tmp_path)
+        except BaseException as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"concurrent writers raised: {errors}"
+
+    # Final cache entry must be a complete, valid JSON document — not a partial
+    # write left behind by a colliding writer.
+    loaded = load_cached(f, root=tmp_path)
+    assert loaded is not None
+    assert "nodes" in loaded
+    assert "edges" in loaded
+    assert loaded["nodes"] and loaded["nodes"][0]["id"].startswith("n")
+
+    # No leftover .tmp files in the cache dir.
+    cdir = cache_dir(tmp_path, "ast")
+    leftover = list(cdir.glob("*.tmp"))
+    assert leftover == [], f"orphaned tmp files: {leftover}"

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,0 +1,69 @@
+"""Tests for graphify/__main__._clone_repo argument hardening.
+
+The clone path historically passed user-supplied `--branch <branch>` and
+`<git_url>` straight to `git` without a `--` separator, and without rejecting
+branch names that look like CLI flags. That made the surface a candidate for
+argument injection (e.g. `--upload-pack=evilcmd`).
+
+These tests assert the hardened behaviour:
+  * `branch` starting with `-` is rejected before any git invocation.
+  * The constructed argv contains a `--` separator before positional refs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from graphify.__main__ import _clone_repo
+
+
+def test_clone_rejects_branch_starting_with_dash(tmp_path, monkeypatch, capsys):
+    """A branch name like `--upload-pack=evilcmd` must be rejected before
+    any subprocess.run is called."""
+    called: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        called.append(list(args[0]) if args else [])
+        raise AssertionError("subprocess.run must not run when branch is rejected")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    out = tmp_path / "dest"
+    with pytest.raises(SystemExit):
+        _clone_repo(
+            "https://github.com/example/repo",
+            branch="--upload-pack=evilcmd",
+            out_dir=out,
+        )
+    err = capsys.readouterr().err
+    assert "refusing branch name" in err
+    assert called == []
+
+
+def test_clone_argv_uses_double_dash_separator(tmp_path, monkeypatch):
+    """Verify the constructed argv places `--` before positional URL/dest so
+    a future url-like flag cannot be reinterpreted as a git option."""
+    captured: list[list[str]] = []
+
+    class _Result:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, *_args, **_kwargs):
+        captured.append(list(cmd))
+        return _Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    out = tmp_path / "dest"
+    _clone_repo("https://github.com/example/repo", branch="main", out_dir=out)
+
+    assert captured, "expected a git invocation"
+    cmd = captured[0]
+    assert cmd[:4] == ["git", "clone", "--depth", "1"]
+    assert "--branch" in cmd and "main" in cmd
+    # Must contain a literal `--` before the URL/dest pair.
+    assert "--" in cmd
+    sep = cmd.index("--")
+    assert cmd[sep + 1].endswith("repo.git")
+    assert Path(cmd[sep + 2]) == out


### PR DESCRIPTION
Two small, independent hardening fixes — each in its own commit with a regression test.

## 1. cache.save_cached: per-writer unique tempfile

`save_cached` used `entry.with_suffix(\".tmp\")` for the staging path, which is a single shared filename per hash. Concurrent writers for the same hash (parallel extractors, retries) raced on that file — one writer's partial bytes could land in another's atomic \`os.replace\`, leaving a truncated/mixed cache entry on disk.

Switched to \`tempfile.mkstemp(dir=target_dir, prefix=f\"{h}.\", suffix=\".tmp\")\` so every writer gets its own staging file. The final \`os.replace\` is still atomic; only the final rename contends, and last-writer-wins is fine because two writers with the same hash are writing the same content.

Test: \`test_save_cached_concurrent_writers_no_collision\` fans out 8 threads writing the same hash, asserts the final entry is parseable, no orphan \`.tmp\` files remain, and no writer raised.

## 2. _clone_repo: argument-injection hardening

Two changes to the git invocation:

- Reject \`branch\` names starting with \`-\`. git can treat refspecs starting with \`-\` as options in some positions, so a value like \`--upload-pack=evilcmd\` passed via \`--branch\` could be reinterpreted by git for the next argument. Now fails fast with a clear error.
- Add a \`--\` separator before positional URL/dest arguments. The \`git_url\` is currently regex-locked to github.com URLs so immediate exposure is small, but the separator makes it impossible for future changes to the URL-building code to leak an option through this surface. Same guard added to the \`git pull origin <branch>\` path.

Test: \`tests/test_clone.py\`
- \`test_clone_rejects_branch_starting_with_dash\` — \`SystemExit\` raised before any \`subprocess.run\`
- \`test_clone_argv_uses_double_dash_separator\` — constructed argv contains a literal \`--\` before positional URL/dest

## Out of scope (filing separately)

These came up in the same review pass but need design discussion, not a 5-fix PR:

- DNS rebinding TOCTOU in \`security.validate_url\` / \`safe_fetch\` (resolves twice, attacker DNS can return public IP first and metadata IP second).
- \`yt-dlp\` SSRF bypass in \`transcribe.download_audio\` — the URL never goes through \`validate_url\`.

I'll open these as separate issues so they can be discussed independently.

## Test run

\`\`\`
$ pytest tests/test_cache.py tests/test_clone.py
12 passed (1 pre-existing failure in test_clear_cache that exists on v5 HEAD without my changes, due to cache_dir now returning .../cache/{kind}/)
\`\`\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>