### PR TITLE
feat(prompts): bundled prompt registry + extract subagent prompt (refs #580)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1013,6 +1013,8 @@ def main() -> None:
         print("    --memory-dir DIR        memory directory (default: graphify-out/memory)")
         print("  check-update <path>     check needs_update flag and notify if semantic re-extraction is pending (cron-safe)")
         print("  benchmark [graph.json]  measure token reduction vs naive full-corpus approach")
+        print("  prompts <name>          print a bundled prompt template (e.g. extraction-subagent)")
+        print("  prompts list            list bundled prompt names")
         print("  hook install            install post-commit/post-checkout git hooks (all platforms)")
         print("  hook uninstall          remove git hooks")
         print("  hook status             check if git hooks are installed")
@@ -1504,6 +1506,28 @@ def main() -> None:
                 pass
         result = run_benchmark(graph_path, corpus_words=corpus_words)
         print_benchmark(result)
+    elif cmd == "prompts":
+        # Print a bundled prompt template by name. Skills consume long prompts
+        # this way (instead of inlining 50+ lines into skill.md), which keeps
+        # SKILL.md slim and lets prompt content evolve in version-controlled files.
+        # Filename uses underscores; CLI accepts either underscores or hyphens
+        # (extraction_subagent / extraction-subagent are equivalent).
+        from graphify import prompts as _prompts
+        if len(sys.argv) < 3 or sys.argv[2] in ("--help", "-h"):
+            print("Usage: graphify prompts <name>", file=sys.stderr)
+            print("       graphify prompts list", file=sys.stderr)
+            print("Available:", ", ".join(_prompts.available()) or "(none)", file=sys.stderr)
+            sys.exit(1)
+        name = sys.argv[2]
+        if name == "list":
+            for n in _prompts.available():
+                print(n)
+            sys.exit(0)
+        try:
+            sys.stdout.write(_prompts.load(name.replace("-", "_")))
+        except FileNotFoundError as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         print(f"error: unknown command '{cmd}'", file=sys.stderr)
         print("Run 'graphify --help' for usage.", file=sys.stderr)

--- a/graphify/prompts/__init__.py
+++ b/graphify/prompts/__init__.py
@@ -1,0 +1,26 @@
+"""Bundled prompt templates that ship with the graphify package.
+
+Skills consume long prompts (e.g. the semantic-extraction subagent prompt)
+via `graphify prompts <name>` instead of inlining them in skill.md. That
+keeps SKILL.md slim — it's loaded into the assistant's context every time
+the skill fires — while letting prompts evolve in version-controlled files.
+"""
+from __future__ import annotations
+from pathlib import Path
+
+PROMPTS_DIR = Path(__file__).parent
+
+
+def available() -> list[str]:
+    """Return the canonical name of every prompt template that ships with graphify."""
+    return sorted(p.stem for p in PROMPTS_DIR.glob("*.md"))
+
+
+def load(name: str) -> str:
+    """Read a bundled prompt by canonical name. Raises FileNotFoundError if missing."""
+    path = PROMPTS_DIR / f"{name}.md"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"prompt '{name}' not found. Available: {', '.join(available()) or '(none)'}"
+        )
+    return path.read_text(encoding="utf-8")

--- a/graphify/prompts/extraction_subagent.md
+++ b/graphify/prompts/extraction_subagent.md
@@ -1,0 +1,53 @@
+You are a graphify extraction subagent. Read the files listed and extract a knowledge graph fragment.
+Output ONLY valid JSON matching the schema below - no explanation, no markdown fences, no preamble.
+
+Files (chunk CHUNK_NUM of TOTAL_CHUNKS):
+FILE_LIST
+
+Rules:
+- EXTRACTED: relationship explicit in source (import, call, citation, "see §3.2")
+- INFERRED: reasonable inference (shared data structure, implied dependency)
+- AMBIGUOUS: uncertain - flag for review, do not omit
+
+Code files: focus on semantic edges AST cannot find (call relationships, shared data, arch patterns).
+  Do not re-extract imports - AST already has those.
+Doc/paper files: extract named concepts, entities, citations. For rationale (WHY decisions were made, trade-offs, design intent): store as a `rationale` attribute on the relevant concept node — do NOT create a separate rationale node or fragment node. Only create a node for something that is itself a named entity or concept.
+Code files: when adding `calls` edges, source MUST be the caller (the function/class doing the calling), target MUST be the callee. Never reverse this direction.
+Image files: use vision to understand what the image IS - do not just OCR.
+  UI screenshot: layout patterns, design decisions, key elements, purpose.
+  Chart: metric, trend/insight, data source.
+  Tweet/post: claim as node, author, concepts mentioned.
+  Diagram: components and connections.
+  Research figure: what it demonstrates, method, result.
+  Handwritten/whiteboard: ideas and arrows, mark uncertain readings AMBIGUOUS.
+
+DEEP_MODE (if --mode deep was given): be aggressive with INFERRED edges - indirect deps,
+  shared assumptions, latent couplings. Mark uncertain ones AMBIGUOUS instead of omitting.
+
+Semantic similarity: if two concepts in this chunk solve the same problem or represent the same idea without any structural link (no import, no call, no citation), add a `semantically_similar_to` edge marked INFERRED with a confidence_score reflecting how similar they are (0.6-0.95). Examples:
+- Two functions that both validate user input but never call each other
+- A class in code and a concept in a paper that describe the same algorithm
+- Two error types that handle the same failure mode differently
+Only add these when the similarity is genuinely non-obvious and cross-cutting. Do not add them for trivially similar things.
+
+Hyperedges: if 3 or more nodes clearly participate together in a shared concept, flow, or pattern that is not captured by pairwise edges alone, add a hyperedge to a top-level `hyperedges` array. Examples:
+- All classes that implement a common protocol or interface
+- All functions in an authentication flow (even if they don't all call each other)
+- All concepts from a paper section that form one coherent idea
+Use sparingly — only when the group relationship adds information beyond the pairwise edges. Maximum 3 hyperedges per chunk.
+
+If a file has YAML frontmatter (--- ... ---), copy source_url, captured_at, author,
+  contributor onto every node from that file.
+
+confidence_score is REQUIRED on every edge - never omit it, never use 0.5 as a default:
+- EXTRACTED edges: confidence_score = 1.0 always
+- INFERRED edges: reason about each edge individually.
+  Direct structural evidence (shared data structure, clear dependency): 0.8-0.9.
+  Reasonable inference with some uncertainty: 0.6-0.7.
+  Weak or speculative: 0.4-0.5. Most edges should be 0.6-0.9, not 0.5.
+- AMBIGUOUS edges: 0.1-0.3
+
+Node ID format: lowercase, only `[a-z0-9_]`, no dots or slashes. Format: `{stem}_{entity}` where stem is the filename without extension and entity is the symbol name, both normalized (lowercase, non-alphanumeric chars replaced with `_`). Example: `src/auth/session.py` + `ValidateToken` → `session_validatetoken`. This must match the ID the AST extractor generates so cross-references between code and semantic nodes connect correctly. CRITICAL: never append chunk numbers, sequence numbers, or any suffix to an ID (no `_c1`, `_c2`, `_chunk2`, etc.). IDs must be deterministic from the label alone — the same entity must always produce the same ID regardless of which chunk processes it.
+
+Output exactly this JSON (no other text):
+{"nodes":[{"id":"session_validatetoken","label":"Human Readable Name","file_type":"code|document|paper|image","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to|rationale_for","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -284,63 +284,13 @@ Concrete example for 3 chunks:
 ```
 All three in one message. Not three separate messages.
 
-Each subagent receives this exact prompt (substitute FILE_LIST, CHUNK_NUM, TOTAL_CHUNKS, and DEEP_MODE):
+Each subagent receives the bundled `extraction-subagent` prompt. Fetch it once and reuse for every chunk — substitute `FILE_LIST`, `CHUNK_NUM`, `TOTAL_CHUNKS`, and (if applicable) `DEEP_MODE`:
 
+```bash
+SUBAGENT_PROMPT=$(graphify prompts extraction-subagent)
 ```
-You are a graphify extraction subagent. Read the files listed and extract a knowledge graph fragment.
-Output ONLY valid JSON matching the schema below - no explanation, no markdown fences, no preamble.
 
-Files (chunk CHUNK_NUM of TOTAL_CHUNKS):
-FILE_LIST
-
-Rules:
-- EXTRACTED: relationship explicit in source (import, call, citation, "see §3.2")
-- INFERRED: reasonable inference (shared data structure, implied dependency)
-- AMBIGUOUS: uncertain - flag for review, do not omit
-
-Code files: focus on semantic edges AST cannot find (call relationships, shared data, arch patterns).
-  Do not re-extract imports - AST already has those.
-Doc/paper files: extract named concepts, entities, citations. For rationale (WHY decisions were made, trade-offs, design intent): store as a `rationale` attribute on the relevant concept node — do NOT create a separate rationale node or fragment node. Only create a node for something that is itself a named entity or concept.
-Code files: when adding `calls` edges, source MUST be the caller (the function/class doing the calling), target MUST be the callee. Never reverse this direction.
-Image files: use vision to understand what the image IS - do not just OCR.
-  UI screenshot: layout patterns, design decisions, key elements, purpose.
-  Chart: metric, trend/insight, data source.
-  Tweet/post: claim as node, author, concepts mentioned.
-  Diagram: components and connections.
-  Research figure: what it demonstrates, method, result.
-  Handwritten/whiteboard: ideas and arrows, mark uncertain readings AMBIGUOUS.
-
-DEEP_MODE (if --mode deep was given): be aggressive with INFERRED edges - indirect deps,
-  shared assumptions, latent couplings. Mark uncertain ones AMBIGUOUS instead of omitting.
-
-Semantic similarity: if two concepts in this chunk solve the same problem or represent the same idea without any structural link (no import, no call, no citation), add a `semantically_similar_to` edge marked INFERRED with a confidence_score reflecting how similar they are (0.6-0.95). Examples:
-- Two functions that both validate user input but never call each other
-- A class in code and a concept in a paper that describe the same algorithm
-- Two error types that handle the same failure mode differently
-Only add these when the similarity is genuinely non-obvious and cross-cutting. Do not add them for trivially similar things.
-
-Hyperedges: if 3 or more nodes clearly participate together in a shared concept, flow, or pattern that is not captured by pairwise edges alone, add a hyperedge to a top-level `hyperedges` array. Examples:
-- All classes that implement a common protocol or interface
-- All functions in an authentication flow (even if they don't all call each other)
-- All concepts from a paper section that form one coherent idea
-Use sparingly — only when the group relationship adds information beyond the pairwise edges. Maximum 3 hyperedges per chunk.
-
-If a file has YAML frontmatter (--- ... ---), copy source_url, captured_at, author,
-  contributor onto every node from that file.
-
-confidence_score is REQUIRED on every edge - never omit it, never use 0.5 as a default:
-- EXTRACTED edges: confidence_score = 1.0 always
-- INFERRED edges: reason about each edge individually.
-  Direct structural evidence (shared data structure, clear dependency): 0.8-0.9.
-  Reasonable inference with some uncertainty: 0.6-0.7.
-  Weak or speculative: 0.4-0.5. Most edges should be 0.6-0.9, not 0.5.
-- AMBIGUOUS edges: 0.1-0.3
-
-Node ID format: lowercase, only `[a-z0-9_]`, no dots or slashes. Format: `{stem}_{entity}` where stem is the filename without extension and entity is the symbol name, both normalized (lowercase, non-alphanumeric chars replaced with `_`). Example: `src/auth/session.py` + `ValidateToken` → `session_validatetoken`. This must match the ID the AST extractor generates so cross-references between code and semantic nodes connect correctly. CRITICAL: never append chunk numbers, sequence numbers, or any suffix to an ID (no `_c1`, `_c2`, `_chunk2`, etc.). IDs must be deterministic from the label alone — the same entity must always produce the same ID regardless of which chunk processes it.
-
-Output exactly this JSON (no other text):
-{"nodes":[{"id":"session_validatetoken","label":"Human Readable Name","file_type":"code|document|paper|image","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to|rationale_for","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
-```
+Then for each chunk, send the substituted prompt to a `general-purpose` Agent. The prompt itself is version-controlled in the package (see `graphify/prompts/extraction_subagent.md`); inlining it here would balloon SKILL.md and re-cost tokens on every skill load.
 
 **Step B3 - Collect, cache, and merge**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,4 @@ include = ["graphify*"]
 
 [tool.setuptools.package-data]
 graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-aider.md", "skill-copilot.md", "skill-claw.md", "skill-windows.md", "skill-droid.md", "skill-trae.md", "skill-kiro.md", "skill-vscode.md"]
+"graphify.prompts" = ["*.md"]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,60 @@
+"""Tests for the bundled prompt registry (graphify.prompts)."""
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from graphify import prompts
+
+
+def test_extraction_subagent_is_bundled():
+    """The extraction-subagent prompt must ship with the package."""
+    assert "extraction_subagent" in prompts.available()
+
+
+def test_load_returns_full_template():
+    body = prompts.load("extraction_subagent")
+    # Must contain the placeholder tokens skill.md substitutes at dispatch time.
+    assert "CHUNK_NUM" in body
+    assert "TOTAL_CHUNKS" in body
+    assert "FILE_LIST" in body
+    # Must contain the exact JSON shape contract — drift here will silently
+    # break extraction subagents in the field.
+    assert '"nodes":[' in body
+    assert '"edges":[' in body
+    assert '"hyperedges":[' in body
+
+
+def test_load_unknown_raises():
+    with pytest.raises(FileNotFoundError):
+        prompts.load("does_not_exist")
+
+
+def test_cli_prompts_list():
+    """`graphify prompts list` must include extraction_subagent."""
+    out = subprocess.run(
+        [sys.executable, "-m", "graphify", "prompts", "list"],
+        capture_output=True, text=True, check=True,
+    )
+    names = out.stdout.strip().splitlines()
+    assert "extraction_subagent" in names
+
+
+def test_cli_prompts_print_accepts_hyphen_alias():
+    """`graphify prompts extraction-subagent` should equal load('extraction_subagent')."""
+    out = subprocess.run(
+        [sys.executable, "-m", "graphify", "prompts", "extraction-subagent"],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout == prompts.load("extraction_subagent")
+
+
+def test_cli_prompts_unknown_exits_nonzero():
+    out = subprocess.run(
+        [sys.executable, "-m", "graphify", "prompts", "no_such_prompt"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode != 0
+    assert "not found" in out.stderr


### PR DESCRIPTION
## Context

Issue #580 reports that graphify is *increasing* token usage in Claude Code sessions rather than reducing it. A second user confirmed the same on the same day. After digging in, the root cause isn't the graph — it's `skill.md` itself. Skill files are pulled into the assistant's context **every time the skill fires**, and `skill.md` is currently 1378 lines / ~14k tokens, with significant content that's deterministic and could live in version-controlled files instead of being inlined.

This is a **focused first step** toward addressing #580. I'm opening it as a draft to validate the *direction* with you before going wide — happy to revise or scope it differently.

## What this PR does

Adds a `graphify.prompts` registry — a package-data home for long deterministic prompts that skills consume on demand:

- `graphify/prompts/__init__.py` — `available()` and `load(name)` helpers
- `graphify/prompts/extraction_subagent.md` — the Step B2 subagent prompt, content preserved verbatim (placeholders `FILE_LIST` / `CHUNK_NUM` / `TOTAL_CHUNKS` / `DEEP_MODE` intact, JSON output schema unchanged)
- New CLI subcommand `graphify prompts <name>` (and `graphify prompts list`) — accepts both `extraction-subagent` and `extraction_subagent` for ergonomics
- `pyproject.toml` ships `graphify.prompts/*.md` as package data
- `skill.md` Step B2 now fetches the prompt once via `SUBAGENT_PROMPT=\$(graphify prompts extraction-subagent)` and substitutes per-chunk
- 6 new tests in `tests/test_prompts.py`

**skill.md size: 60,766 → 56,159 bytes (-4.6KB / ≈ -1,150 tokens, ~8%).** Small in isolation, but it's the cheapest 8% — the 53 lines of subagent-prompt body are 100% boilerplate that doesn't need to be re-loaded into every invocation's context.

## Why this shape

The prompts registry is reusable infrastructure. Same pattern works for the other long inline blocks I'd like to migrate next (one PR at a time, behind your design feedback):

- the JSON output schema example (~1 line, but very dense)
- the ID-format rules block
- the whisper-hint guidance for transcribe
- per-step usage examples

…and pairs naturally with the larger refactor I'd suggest in a follow-up PR: replacing the inline `python3 -c \"...\"` heredocs (detect, extract-AST, cache check/save/merge, build/cluster/report, label-communities, vault, wiki) with thin CLI subcommands wrapping the existing module functions. That would take `skill.md` to ~3.5k tokens (~75% reduction) without changing any pipeline behavior.

If that direction sounds good, I'll send the next PR. If you'd rather I batch them differently — or if there's already work in flight here — happy to adapt.

## Verification

- Full test suite green: **447 passing** (existing 441 + 6 new).
- `graphify prompts list` → `extraction_subagent`
- `graphify prompts extraction-subagent` → 54 lines, byte-identical to the original Step B2 block.
- Unknown prompt name exits 1 with helpful message.

## Compatibility

- No behavior change for any existing subcommand.
- Skill installs that pull `skill.md` from the package will get the slim version automatically; the prompt content reaches subagents the same way as before, just via a cheap shell substitution.
- Older skill installs still in the wild (pre-this-version) will keep working — the inline prompt isn't removed from any external surface, just from the in-package skill.md template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)