### PR TITLE
Fix invalid escape sequence SyntaxWarning in __main__.py

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -48,7 +48,7 @@ _SETTINGS_HOOK = {
                 "import json,sys; d=json.load(sys.stdin); "
                 "print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); "
                 "case \"$CMD\" in "
-                "*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *) "
+                "*grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *) "
                 "  [ -f graphify-out/graph.json ] && "
                 r"""  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}}' """
                 "  || true ;; "


### PR DESCRIPTION
Python 3.12+ emits a `SyntaxWarning` for unrecognized backslash escapes in non-raw string literals. The shell case-pattern in `_SETTINGS_HOOK` (`graphify/__main__.py` line 51) used `\ ` (backslash + space) inside a regular Python string, which produced:

```
SyntaxWarning: invalid escape sequence '\ '
  "*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *) "
```

This change escapes the backslash (`\\ `) so Python emits a literal `\ ` to the shell, preserving the original case-pattern semantics. No behavioral change — just silences the warning on Python 3.12+.

Verified with `python -W error::SyntaxWarning -m py_compile graphify/__main__.py`.

Co-Authored-By: Oz <oz-agent@warp.dev>