### PR TITLE
fix: remove stray colon in --cluster-only dict literal (SyntaxError)

### DIFF
--- a/graphify/skill-trae.md
+++ b/graphify/skill-trae.md
@@ -823,7 +823,7 @@ G = json_graph.node_link_graph(data, edges='links')
 
 detection = {'total_files': 0, 'total_words': 99999, 'needs_graph': True, 'warning': None,
              'files': {'code': [], 'document': [], 'paper': []}}
-tokens = {'input': 0, 'output':': 0}
+tokens = {'input': 0, 'output': 0}
 
 communities = cluster(G)
 cohesion = score_all(G, communities)


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm-for-claude), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `tokens = {'input': 0, 'output':': 0}` at line 826 of `graphify/skill-trae.md` — stray colon between `':` and `: 0` produces a Python SyntaxError, crashing the `--cluster-only` block of the Trae skill variant.

**Evidence**: `python3 -c "import ast; ast.parse(\"tokens = {'input': 0, 'output':': 0}\")"` → `SyntaxError: unterminated string literal (detected at line 1)`.

**Fix**: Changed `'output':': 0}` to `'output': 0}` (removed the stray colon before the value).

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-syntax-error","fingerprint":"sha256:c5ff2beccc8af5662eed24d04172989e05b28f479a497c821383ec4fa0eb9fbd"}]}
nlpm-metadata-end -->