### PR TITLE
fix(detect): strip inline comments from .graphifyignore patterns

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -272,17 +272,41 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
     parent directory still work when graphify is run on a subfolder.
 
     Walks upward from *root* towards the filesystem root, stopping at a
-    ``.git`` boundary. Lines starting with # are comments; blank lines ignored.
+    ``.git`` boundary.
+
+    Comment handling (gitignore extension):
+      * Lines starting with # are full-line comments — skipped.
+      * Inline comments (whitespace + hash to end of line) are stripped
+        from each pattern. This matches user intuition for documenting
+        patterns inline, e.g. `chitta/varta/  # daily briefings`.
+      * Use ``\\#`` to keep a literal hash in a pattern (rare).
+      * Blank lines after stripping are ignored.
     """
     patterns: list[tuple[Path, str]] = []
     current = root.resolve()
     while True:
         ignore_file = current / ".graphifyignore"
         if ignore_file.exists():
-            for line in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
-                line = line.strip()
-                if line and not line.startswith("#"):
-                    patterns.append((current, line))
+            for raw_line in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                # Strip inline comment (whitespace + '#' to end of line),
+                # preserve escaped backslash-# as literal hash in pattern.
+                pieces = []
+                i = 0
+                while i < len(line):
+                    if line[i] == "\\" and i + 1 < len(line) and line[i + 1] == "#":
+                        pieces.append("#")
+                        i += 2
+                        continue
+                    if line[i].isspace() and i + 1 < len(line) and line[i + 1] == "#":
+                        break
+                    pieces.append(line[i])
+                    i += 1
+                pattern = "".join(pieces).rstrip()
+                if pattern:
+                    patterns.append((current, pattern))
         # Stop climbing once we've processed the git repo root
         if (current / ".git").exists():
             break

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -114,6 +114,57 @@ def test_graphifyignore_comments_ignored(tmp_path):
     assert any("other.py" in f for f in result["files"]["code"])
 
 
+def test_graphifyignore_inline_comments_stripped(tmp_path):
+    """Inline comments (whitespace + '#' to end of line) are stripped from
+    pattern lines, so `vendor/  # legacy code` ignores the `vendor/` directory
+    rather than treating the entire line including the comment as the pattern.
+    """
+    (tmp_path / ".graphifyignore").write_text(
+        "vendor/  # legacy code\n"
+        "*.generated.py    # auto-generated, skip\n"
+        "main.py\n"
+    )
+    (tmp_path / "vendor").mkdir()
+    (tmp_path / "vendor" / "lib.py").write_text("x = 1")
+    (tmp_path / "auto.generated.py").write_text("x = 2")
+    (tmp_path / "main.py").write_text("x = 3")
+    (tmp_path / "other.py").write_text("x = 4")
+    result = detect(tmp_path)
+    assert not any("lib.py" in f for f in result["files"]["code"]), (
+        "vendor/ should be ignored after stripping inline comment"
+    )
+    assert not any("auto.generated.py" in f for f in result["files"]["code"]), (
+        "*.generated.py should match after stripping inline comment"
+    )
+    assert not any("main.py" in f for f in result["files"]["code"])
+    assert any("other.py" in f for f in result["files"]["code"])
+
+
+def test_graphifyignore_inline_comment_requires_whitespace_before_hash(tmp_path):
+    """A '#' without preceding whitespace is part of the pattern, not a comment.
+    Standard gitignore semantics — `path#name` matches a file literally named
+    `path#name`, not a comment.
+    """
+    (tmp_path / ".graphifyignore").write_text("file#with#hash.py\n")
+    (tmp_path / "file#with#hash.py").write_text("x = 1")
+    (tmp_path / "other.py").write_text("x = 2")
+    result = detect(tmp_path)
+    assert not any("file#with#hash.py" in f for f in result["files"]["code"])
+    assert any("other.py" in f for f in result["files"]["code"])
+
+
+def test_graphifyignore_escaped_hash_is_literal(tmp_path):
+    r"""Backslash-hash (``\#``) keeps a literal '#' in the pattern even after
+    whitespace, escaping the inline-comment marker.
+    """
+    (tmp_path / ".graphifyignore").write_text("file \\# name.py\n")
+    (tmp_path / "file # name.py").write_text("x = 1")
+    (tmp_path / "other.py").write_text("x = 2")
+    result = detect(tmp_path)
+    assert not any("file # name.py" in f for f in result["files"]["code"])
+    assert any("other.py" in f for f in result["files"]["code"])
+
+
 def test_detect_follows_symlinked_directory(tmp_path):
     real_dir = tmp_path / "real_lib"
     real_dir.mkdir()


### PR DESCRIPTION
## Summary

`_load_graphifyignore` only handled full-line comments. Inline comments like `vendor/  # legacy code` were loaded as a single pattern including the trailing whitespace and comment text, which `fnmatch` could not match against any real path → the entry silently did not ignore anything.

## Real-world impact

In our knowledge corpus (~640 files, gitignore-style `.graphifyignore` with inline-documented patterns), 52 + 12 files in two categories were marked as changed on every `--update` run because their patterns had inline comments. This caused unnecessary LLM re-extraction (~\$1-3 per run) and noisy diff output.

The fix lets users document patterns inline (a common gitignore convention even though git itself does not support it natively):

```
chitta/varta/    # daily CEO briefings, regenerated nightly
chitta/spanda/   # webhook event cache
```

## Behavior

| Input line | Before | After |
|---|---|---|
| `vendor/  # legacy code` | pattern = `vendor/  # legacy code` (matches nothing) | pattern = `vendor/` (matches `vendor/...`) |
| `*.log` (no inline comment) | pattern = `*.log` | pattern = `*.log` (unchanged) |
| `# full-line comment` | skipped | skipped (unchanged) |
| `path#with#hash.py` (no whitespace before `#`) | pattern = `path#with#hash.py` | pattern = `path#with#hash.py` (unchanged — gitignore semantics) |
| `file \# name.py` (escaped hash) | pattern = `file \# name.py` | pattern = `file # name.py` (literal `#` preserved) |

## Tests

Three new tests added to `tests/test_detect.py`:
- `test_graphifyignore_inline_comments_stripped` — main case
- `test_graphifyignore_inline_comment_requires_whitespace_before_hash` — `#` without whitespace stays literal
- `test_graphifyignore_escaped_hash_is_literal` — `\#` escape

All 9 `.graphifyignore` tests pass.

## Notes

- Backward compatible: patterns without inline comments behave identically.
- Docstring updated to describe the inline-comment + escape semantics as a documented gitignore extension.
- The whitespace-before-`#` requirement matches user intuition while preserving the rare case of `#` as a literal filename character.