### PR TITLE
Fix Codex PreToolUse hook payload

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -37,6 +37,30 @@ def _refresh_all_version_stamps() -> None:
         if vf.exists():
             vf.write_text(__version__, encoding="utf-8")
 
+_GRAPH_REMINDER = "graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."
+
+
+def build_pre_tool_use_response(context: str, assistant: str) -> dict:
+    """Return the assistant-specific PreToolUse response payload."""
+    normalized = assistant.lower()
+    if normalized in {"claude", "claude-code"}:
+        return {"additionalContext": context}
+    return {"systemMessage": context}
+
+
+def _shell_echo_json(payload: dict) -> str:
+    return "echo " + json.dumps(json.dumps(payload))
+
+
+def _claude_pre_tool_use_payload(context: str = _GRAPH_REMINDER) -> dict:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            **build_pre_tool_use_response(context, "claude"),
+        }
+    }
+
+
 _SETTINGS_HOOK = {
     # Claude Code v2.1.117+ removed dedicated Grep/Glob tools; searches now go through Bash.
     # We match on Bash and inspect the command string to avoid firing on every shell call.
@@ -51,7 +75,7 @@ _SETTINGS_HOOK = {
                 "case \"$CMD\" in "
                 r"*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *) "
                 "  [ -f graphify-out/graph.json ] && "
-                r"""  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}}' """
+                "  " + _shell_echo_json(_claude_pre_tool_use_payload()) + " "
                 "  || true ;; "
                 "esac"
             ),
@@ -720,7 +744,7 @@ _CODEX_HOOK = {
                         "type": "command",
                         "command": (
                             "[ -f graphify-out/graph.json ] && "
-                            r"""echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}}' """
+                            + _shell_echo_json(build_pre_tool_use_response(_GRAPH_REMINDER, "codex")) + " "
                             "|| true"
                         ),
                     }

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 """Tests for graphify install --platform routing."""
+import json
 from pathlib import Path
 from unittest.mock import patch
 import pytest
@@ -127,6 +128,36 @@ def test_codex_agents_install_writes_agents_md(tmp_path):
     assert agents_md.exists()
     assert "graphify" in agents_md.read_text()
     assert "GRAPH_REPORT.md" in agents_md.read_text()
+
+
+def test_codex_pre_tool_use_uses_system_message():
+    from graphify.__main__ import build_pre_tool_use_response
+
+    payload = build_pre_tool_use_response("hello", assistant="codex")
+
+    assert payload == {"systemMessage": "hello"}
+    assert "additionalContext" not in payload
+
+
+def test_claude_pre_tool_use_uses_additional_context():
+    from graphify.__main__ import build_pre_tool_use_response
+
+    payload = build_pre_tool_use_response("hello", assistant="claude")
+
+    assert payload == {"additionalContext": "hello"}
+    assert "systemMessage" not in payload
+
+
+def test_codex_hook_does_not_emit_additional_context(tmp_path):
+    _agents_install(tmp_path, "codex")
+
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    hooks = json.loads(hooks_path.read_text())
+    command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    assert "systemMessage" in command
+    assert "additionalContext" not in command
+    assert "hookSpecificOutput" not in command
 
 
 def test_opencode_agents_install_writes_agents_md(tmp_path):


### PR DESCRIPTION
## Summary
- add assistant-aware PreToolUse payload generation
- make Codex hooks emit top-level `systemMessage` instead of Claude-style `additionalContext`
- keep Claude hook output using `hookSpecificOutput.additionalContext`
- add tests for Codex and Claude payload behavior

Fixes #533.

## Tests
- `python -m py_compile graphify/__main__.py tests/test_install.py tests/test_claude_md.py`
- `uv run --with pytest pytest tests/test_install.py tests/test_claude_md.py`