### PR TITLE
Ci/v5 trigger and matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,25 @@ name: CI
 
 on:
   push:
-    branches: ["v1", "v2", "v3", "v4", "main"]
+    branches: ["v1", "v2", "v3", "v4", "v5", "main"]
   pull_request:
-    branches: ["v1", "v2", "v3", "v4", "main"]
+    branches: ["v1", "v2", "v3", "v4", "v5", "main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -20,11 +29,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install dependencies
         run: |
-          pip install -e ".[mcp,pdf,watch]"
-          pip install pytest
+          pip install -e ".[all,test]"
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ leiden = ["graspologic; python_version < '3.13'"]
 office = ["python-docx", "openpyxl"]
 video = ["faster-whisper", "yt-dlp"]
 kimi = ["openai"]
+test = ["pytest>=7", "pytest-cov"]
 all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper", "yt-dlp", "matplotlib", "openai"]
 
 [project.scripts]


### PR DESCRIPTION
## Context

CI on `v5` (the default branch) currently does not run — `.github/workflows/ci.yml` lists `["v1", "v2", "v3", "v4", "main"]` in its `push`/`pull_request` triggers but omits `v5`. Every commit and PR to the active development branch ships without test coverage.

## Changes

### `.github/workflows/ci.yml`
- **Adds `v5` to both `push` and `pull_request` triggers** — main fix.
- Expands matrix to `3.10/3.11/3.12/3.13` to match `requires-python = ">=3.10"`. Python 3.13 silently skips graspologic via its existing `python_version < '3.13'` marker.
- Installs `[all,test]` instead of `[mcp,pdf,watch]` + sidecar `pip install pytest`. Tests covering `transcribe` (video), `cluster` (leiden), `serve` (mcp), `export` (svg) now have their dependencies available.
- Adds pip caching (`cache: 'pip'` + `cache-dependency-path: pyproject.toml`).
- Adds `concurrency:` block (`cancel-in-progress: true` on same ref).
- Adds explicit `permissions: { contents: read }` for least-privilege.
- Adds `fail-fast: false` so a single Python-version regression doesn't mask the others.
- Adds `workflow_dispatch:` for manual reruns.

### `pyproject.toml`
Adds `test = ["pytest>=7", "pytest-cov"]` optional-dependencies group. Kept out of `[all]` deliberately — `[all]` is runtime extras only.

## Verification
- After merge, push a trivial commit to `v5` and confirm the run shows up in `gh run list -R safishamsi/graphify -b v5`.
- The 3.13 job should pass while skipping graspologic.
- Test count should be ≥ baseline.

## Out of scope
Multi-OS matrix, coverage upload, SHA-pinning actions, pruning v1–v4 from triggers.