### PR TITLE
fix: persist manifest after _rebuild_code (fixes #538)

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -43,7 +43,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
     report_root = _report_root_label(watch_path)
     try:
         from graphify.extract import extract
-        from graphify.detect import detect
+        from graphify.detect import detect, save_manifest
         from graphify.build import build_from_json
         from graphify.cluster import cluster, score_all
         from graphify.analyze import god_nodes, surprising_connections, suggest_questions
@@ -124,6 +124,15 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
         flag = out / "needs_update"
         if flag.exists():
             flag.unlink()
+
+        # Persist manifest so detect_incremental has a fresh baseline.
+        # Without this, detect_incremental returns every file as "new" on
+        # the next call, so `graphify update` and `graphify watch` re-fire
+        # every time. Closes #538.
+        try:
+            save_manifest(detected['files'])
+        except Exception as exc:
+            print(f"[graphify watch] Warning: manifest save failed: {exc}")
 
         print(f"[graphify watch] Rebuilt: {G.number_of_nodes()} nodes, "
               f"{G.number_of_edges()} edges, {len(communities)} communities")


### PR DESCRIPTION
## Summary

- `graphify update`, `graphify watch`, and the installed `.git/hooks/post-checkout` all call `_rebuild_code()` but never call `save_manifest()`.
- Without a fresh manifest, `detect_incremental()` reads a stale baseline on the next call, so every file looks new and the rebuild re-fires every time.
- One-line fix: persist the manifest at the end of `_rebuild_code` using the `detected` dict already built at the top of the function. Gated by `try/except` so a manifest write failure cannot fail the rebuild.

Closes #538.

Single edit covers three call sites: the CLI `update` command, the `watch` loop, and the post-checkout hook. The skill markdown pipeline mentioned in the issue's suggested fix is a separate surface and may still need its own Step 9 patch.

## Test plan

- [x] Reproduce on `v5`: `rm graphify-out/manifest.json && graphify update .` → no manifest written, next `detect_incremental` reports every file as new.
- [x] Apply patch, repeat: `rm graphify-out/manifest.json && graphify update .` → `manifest.json` written (~35KB, 360 entries on a real repo).
- [x] Re-run `detect_incremental` immediately after rebuild → returns `new_total: 0, deleted: 0`.
- [x] Manifest write failure path: confirm the warning prints and the rebuild still returns `True`.
