### PR TITLE
fix: disable thinking on Moonshot calls so kimi-k2.6 populates content

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -102,6 +102,14 @@ def _call_openai_compat(
     }
     if temperature is not None:
         kwargs["temperature"] = temperature
+    # kimi-k2.6 is a reasoning model: it writes its chain-of-thought to
+    # `reasoning_content` and the answer to `content`. When reasoning consumes
+    # the entire max_completion_tokens budget on large chunks, `content` stays
+    # empty and we parse zero nodes while still paying for the input + reasoning
+    # tokens. For structured extraction we don't need chain-of-thought, so
+    # disable thinking on Moonshot-hosted models.
+    if "moonshot" in base_url:
+        kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
     resp = client.chat.completions.create(**kwargs)
     result = _parse_llm_json(resp.choices[0].message.content or "{}")
     result["input_tokens"] = resp.usage.prompt_tokens if resp.usage else 0

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,57 @@
+"""Tests for the direct LLM backend (Claude / Kimi)."""
+from unittest.mock import MagicMock, patch
+
+
+def _mock_response(content: str = '{"nodes":[],"edges":[]}', completion_tokens: int = 10):
+    """Build a fake OpenAI ChatCompletion response."""
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=content))]
+    resp.usage = MagicMock(prompt_tokens=100, completion_tokens=completion_tokens)
+    return resp
+
+
+def test_kimi_call_disables_thinking():
+    """kimi-k2.6 is a reasoning model: when thinking is enabled and the chunk
+    is large, all of max_completion_tokens is consumed by reasoning_content,
+    leaving content empty and graphify parsing zero nodes. Disable thinking on
+    Moonshot endpoints so content is always populated for structured extraction.
+    """
+    from graphify.llm import _call_openai_compat
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = _mock_response()
+
+    with patch("openai.OpenAI", return_value=fake_client):
+        _call_openai_compat(
+            base_url="https://api.moonshot.ai/v1",
+            api_key="sk-test",
+            model="kimi-k2.6",
+            user_message="=== example.py ===\ndef hello(): pass\n",
+            temperature=None,
+        )
+
+    kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert "extra_body" in kwargs, "moonshot calls must pass extra_body to disable thinking"
+    assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+def test_non_moonshot_call_does_not_disable_thinking():
+    """The thinking-disabled flag is Moonshot-specific extra_body. Other
+    OpenAI-compatible providers (real OpenAI, Together, Groq, etc.) don't
+    accept it and would 400. Only set it for Moonshot URLs."""
+    from graphify.llm import _call_openai_compat
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = _mock_response()
+
+    with patch("openai.OpenAI", return_value=fake_client):
+        _call_openai_compat(
+            base_url="https://api.openai.com/v1",
+            api_key="sk-test",
+            model="gpt-4o",
+            user_message="hi",
+            temperature=0,
+        )
+
+    kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert "extra_body" not in kwargs, "non-Moonshot calls must not pass thinking flag"


### PR DESCRIPTION
## Summary

- Disable Moonshot's `thinking` mode for kimi-k2.6 by passing `extra_body={"thinking": {"type": "disabled"}}` on the OpenAI-compatible call
- Gated on `"moonshot" in base_url` so other OpenAI-compatible providers (real OpenAI, Together, Groq) aren't affected — they'd 400 on the flag
- Add 2 mock-based tests covering the moonshot path and the non-moonshot path

## Why

`kimi-k2.6` is a reasoning model. Its OpenAI-compatible response splits across two fields:

```python
resp.choices[0].message.content            # the structured answer
resp.choices[0].message.reasoning_content  # chain-of-thought
```

With `max_completion_tokens=8192`, large chunks (the default `chunk_size=20` regularly produces 50k+ token user messages) cause reasoning to consume the entire output budget. `content` comes back empty, `_parse_llm_json("{}")` returns `{"nodes":[],...}`, and the chunk silently contributes nothing.

## Reproduction

162-file repo (~125k words, mixed code/docs/images), default settings:

| | input tokens | output tokens | nodes | edges |
|---|---|---|---|---|
| Before | 453,282 | 71,361 | 2 | 1 |
| After  | 446,890 | 40,523 | 138 | 160 |

The 71k output tokens before were almost entirely `reasoning_content` that graphify ignores. Empty `content`, empty graph, full bill.

## Test plan

- [x] `test_kimi_call_disables_thinking` — verifies the flag is sent on a moonshot URL
- [x] `test_non_moonshot_call_does_not_disable_thinking` — verifies the flag is not sent on `api.openai.com`
- [x] Full existing test suite (443 tests) passes with zero regressions