### PR TITLE
Enforce Claude graph lookup before raw search

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ After building a graph, run this once in your project:
 | Kiro IDE/CLI | `graphify kiro install` |
 | Google Antigravity | `graphify antigravity install` |
 
-**Claude Code** does two things: writes a `CLAUDE.md` section telling Claude to read `graphify-out/GRAPH_REPORT.md` before answering architecture questions, and installs a **PreToolUse hook** (`settings.json`) that fires before every Glob and Grep call. If a knowledge graph exists, Claude sees: _"graphify: Knowledge graph exists. Read GRAPH_REPORT.md for god nodes and community structure before searching raw files."_ — so Claude navigates via the graph instead of grepping through every file.
+**Claude Code** writes a `CLAUDE.md` section and installs two hooks: a **UserPromptSubmit reminder** before Claude decides what to do, and a **PreToolUse guard** that blocks raw file search/read/list tools until the graph has been used in that session. If a knowledge graph exists, Claude is prompted to read `graphify-out/GRAPH_REPORT.md` or use `graphify query/path/explain` before grepping through files.
 
 **Codex** writes to `AGENTS.md` and also installs a **UserPromptSubmit hook** in `.codex/hooks.json` that fires when the user submits a prompt. This reminds Codex about `GRAPH_REPORT.md` before it decides whether to search files.
 
@@ -297,7 +297,7 @@ graphify hook uninstall
 graphify hook status
 
 # always-on assistant instructions - platform-specific
-graphify claude install            # CLAUDE.md + PreToolUse hook (Claude Code)
+graphify claude install            # CLAUDE.md + UserPromptSubmit reminder + PreToolUse guard (Claude Code)
 graphify claude uninstall
 graphify codex install             # AGENTS.md + UserPromptSubmit hook in .codex/hooks.json (Codex)
 graphify opencode install          # AGENTS.md + tool.execute.before plugin (OpenCode)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -37,27 +37,125 @@ def _refresh_all_version_stamps() -> None:
         if vf.exists():
             vf.write_text(__version__, encoding="utf-8")
 
-_SETTINGS_HOOK = {
-    # Claude Code v2.1.117+ removed dedicated Grep/Glob tools; searches now go through Bash.
-    # We match on Bash and inspect the command string to avoid firing on every shell call.
-    "matcher": "Bash",
+_CLAUDE_USER_PROMPT_HOOK = {
     "hooks": [
         {
             "type": "command",
             "command": (
-                "CMD=$(python3 -c \""
-                "import json,sys; d=json.load(sys.stdin); "
-                "print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); "
-                "case \"$CMD\" in "
-                r"*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *) "
-                "  [ -f graphify-out/graph.json ] && "
-                r"""  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files."}}' """
-                "  || true ;; "
-                "esac"
+                "[ -f graphify-out/graph.json ] && "
+                r"""echo '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files. Use graphify query/path/explain before raw grep/find/ls/read."}}' """
+                "|| true"
             ),
         }
     ],
 }
+
+_CLAUDE_PRE_TOOL_GUARD_HOOK = {
+    "matcher": "Bash|Grep|Glob|Read|LS",
+    "hooks": [
+        {
+            "type": "command",
+            "command": "python3 .claude/hooks/graphify-guard.py",
+        }
+    ],
+}
+
+_GRAPHIFY_GUARD_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def load_input() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except Exception:
+        return {}
+
+
+def state_file(session_id: str) -> Path:
+    root = Path(".claude/graphify-guard-state")
+    root.mkdir(parents=True, exist_ok=True)
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id or "unknown")
+    return root / safe_id
+
+
+def normalize_tool_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def is_graph_use(tool_name: str, tool_input: dict) -> bool:
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if re.search(r"\bgraphify\s+(query|path|explain)\b", command):
+            return True
+        return "graphify-out/GRAPH_REPORT.md" in command or "graphify-out/wiki/index.md" in command
+
+    if tool_name == "Read":
+        path = normalize_tool_path(tool_input.get("file_path", ""))
+        return path.endswith("graphify-out/GRAPH_REPORT.md") or path.endswith("graphify-out/wiki/index.md")
+
+    return False
+
+
+def is_raw_code_exploration(tool_name: str, tool_input: dict) -> bool:
+    if tool_name in {"Grep", "Glob", "LS"}:
+        return True
+
+    if tool_name == "Read":
+        path = normalize_tool_path(tool_input.get("file_path", ""))
+        if not path:
+            return False
+        is_claude_path = path.startswith(".claude/") or "/.claude/" in path
+        return "graphify-out/" not in path and not is_claude_path and not path.endswith("CLAUDE.md")
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if not command:
+            return False
+        if is_graph_use(tool_name, tool_input):
+            return False
+        return bool(re.search(r"(^|[;&|]\s*|\s)(grep|rg|find|ls|wc|cat|sed|head|tail|awk)\b", command))
+
+    return False
+
+
+def main() -> int:
+    data = load_input()
+    if not Path("graphify-out/graph.json").exists():
+        return 0
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {}) or {}
+    session_id = data.get("session_id", "")
+    marker = state_file(session_id)
+
+    if is_graph_use(tool_name, tool_input):
+        marker.write_text("used\n", encoding="utf-8")
+        return 0
+
+    if marker.exists():
+        return 0
+
+    if is_raw_code_exploration(tool_name, tool_input):
+        print(
+            "graphify guard: raw file search/read/list blocked until the graph is used in this session.\n"
+            "Start with one of:\n"
+            "  graphify query \"<your question>\" --budget 4000\n"
+            "  graphify path \"A\" \"B\"\n"
+            "  Read graphify-out/GRAPH_REPORT.md\n"
+            "After that, targeted file reads are allowed.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
 
 _SKILL_REGISTRATION = (
     "\n# graphify\n"
@@ -203,9 +301,10 @@ _CLAUDE_MD_SECTION = """\
 This project has a graphify knowledge graph at graphify-out/.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- Before answering architecture, codebase, file-location, or implementation questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- For codebase discovery and cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- Use grep/find/ls/read only after graphify has identified the relevant nodes or files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
 """
 
@@ -889,68 +988,116 @@ def _agents_uninstall(project_dir: Path, platform: str = "") -> None:
 
 
 def claude_install(project_dir: Path | None = None) -> None:
-    """Write the graphify section to the local CLAUDE.md."""
+    """Write or refresh the graphify section in local CLAUDE.md and install Claude hooks."""
     target = (project_dir or Path(".")) / "CLAUDE.md"
 
     if target.exists():
         content = target.read_text(encoding="utf-8")
         if _CLAUDE_MD_MARKER in content:
-            print("graphify already configured in CLAUDE.md")
-            return
-        new_content = content.rstrip() + "\n\n" + _CLAUDE_MD_SECTION
+            refreshed = re.sub(
+                r"(^|\n+)## graphify\n.*?(?=\n## |\Z)",
+                lambda m: m.group(1) + _CLAUDE_MD_SECTION.rstrip(),
+                content,
+                flags=re.DOTALL,
+            ).rstrip() + "\n"
+            target.write_text(refreshed, encoding="utf-8")
+            print(f"graphify section refreshed in {target.resolve()}")
+        else:
+            target.write_text(content.rstrip() + "\n\n" + _CLAUDE_MD_SECTION, encoding="utf-8")
+            print(f"graphify section written to {target.resolve()}")
     else:
-        new_content = _CLAUDE_MD_SECTION
+        target.write_text(_CLAUDE_MD_SECTION, encoding="utf-8")
+        print(f"graphify section written to {target.resolve()}")
 
-    target.write_text(new_content, encoding="utf-8")
-    print(f"graphify section written to {target.resolve()}")
-
-    # Also write Claude Code PreToolUse hook to .claude/settings.json
     _install_claude_hook(project_dir or Path("."))
 
     print()
     print("Claude Code will now check the knowledge graph before answering")
-    print("codebase questions and rebuild it after code changes.")
+    print("codebase questions and block raw search until graphify is used.")
+
+
+def _remove_graphify_claude_hooks(settings: dict) -> None:
+    """Remove graphify Claude hooks while preserving unrelated hooks."""
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        settings["hooks"] = {}
+        return
+
+    for event in ("UserPromptSubmit", "PreToolUse"):
+        event_hooks = hooks.get(event)
+        if not isinstance(event_hooks, list):
+            hooks.pop(event, None)
+            continue
+        filtered = [h for h in event_hooks if "graphify" not in str(h)]
+        if filtered:
+            hooks[event] = filtered
+        else:
+            hooks.pop(event, None)
+
+    if not hooks:
+        settings.pop("hooks", None)
+
+
+def _load_json_object(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _install_claude_hook(project_dir: Path) -> None:
-    """Add graphify PreToolUse hook to .claude/settings.json."""
-    settings_path = project_dir / ".claude" / "settings.json"
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    """Add graphify UserPromptSubmit reminder and PreToolUse guard to .claude/settings.json."""
+    claude_dir = project_dir / ".claude"
+    if claude_dir.exists() and not claude_dir.is_dir():
+        if claude_dir.is_file() and claude_dir.stat().st_size == 0:
+            claude_dir.unlink()
+        else:
+            raise RuntimeError(f"{claude_dir} exists but is not a directory")
 
-    if settings_path.exists():
-        try:
-            settings = json.loads(settings_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            settings = {}
-    else:
-        settings = {}
+    settings_path = claude_dir / "settings.json"
+    hooks_dir = claude_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
 
+    guard_path = hooks_dir / "graphify-guard.py"
+    guard_path.write_text(_GRAPHIFY_GUARD_SCRIPT, encoding="utf-8")
+    try:
+        guard_path.chmod(0o755)
+    except OSError:
+        pass
+
+    settings = _load_json_object(settings_path)
+    _remove_graphify_claude_hooks(settings)
     hooks = settings.setdefault("hooks", {})
-    pre_tool = hooks.setdefault("PreToolUse", [])
+    hooks.setdefault("UserPromptSubmit", []).append(_CLAUDE_USER_PROMPT_HOOK)
+    hooks.setdefault("PreToolUse", []).append(_CLAUDE_PRE_TOOL_GUARD_HOOK)
 
-    hooks["PreToolUse"] = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash") and "graphify" in str(h))]
-    hooks["PreToolUse"].append(_SETTINGS_HOOK)
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
-    print(f"  .claude/settings.json  ->  PreToolUse hook registered")
+    print("  .claude/settings.json  ->  UserPromptSubmit reminder + PreToolUse guard registered")
+    print("  .claude/hooks/graphify-guard.py  ->  installed")
 
 
 def _uninstall_claude_hook(project_dir: Path) -> None:
-    """Remove graphify PreToolUse hook from .claude/settings.json."""
-    settings_path = project_dir / ".claude" / "settings.json"
-    if not settings_path.exists():
+    """Remove graphify Claude hooks from .claude/settings.json and delete the guard script."""
+    claude_dir = project_dir / ".claude"
+    if claude_dir.exists() and not claude_dir.is_dir():
         return
-    try:
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return
-    pre_tool = settings.get("hooks", {}).get("PreToolUse", [])
-    filtered = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash") and "graphify" in str(h))]
-    if len(filtered) == len(pre_tool):
-        return
-    settings["hooks"]["PreToolUse"] = filtered
-    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
-    print(f"  .claude/settings.json  ->  PreToolUse hook removed")
 
+    settings_path = claude_dir / "settings.json"
+    if settings_path.exists():
+        settings = _load_json_object(settings_path)
+        before = json.dumps(settings, sort_keys=True)
+        _remove_graphify_claude_hooks(settings)
+        if json.dumps(settings, sort_keys=True) != before:
+            settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+            print("  .claude/settings.json  ->  graphify hooks removed")
+
+    guard_path = claude_dir / "hooks" / "graphify-guard.py"
+    if guard_path.exists():
+        guard_path.unlink()
+        print("  .claude/hooks/graphify-guard.py  ->  removed")
 
 def claude_uninstall(project_dir: Path | None = None) -> None:
     """Remove the graphify section from the local CLAUDE.md."""

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1076,6 +1076,7 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
         if node.type in config.call_types:
             callee_name: str | None = None
             is_member_call: bool = False
+            func_node = None
 
             # Special handling per language
             if config.ts_module == "tree_sitter_swift":
@@ -1083,8 +1084,10 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                 first = node.children[0] if node.children else None
                 if first:
                     if first.type == "simple_identifier":
+                        func_node = first
                         callee_name = _read_text(first, source)
                     elif first.type == "navigation_expression":
+                        func_node = first
                         is_member_call = True
                         for child in first.children:
                             if child.type == "navigation_suffix":
@@ -1096,8 +1099,10 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                 first = node.children[0] if node.children else None
                 if first:
                     if first.type == "simple_identifier":
+                        func_node = first
                         callee_name = _read_text(first, source)
                     elif first.type == "navigation_expression":
+                        func_node = first
                         is_member_call = True
                         for child in reversed(first.children):
                             if child.type == "simple_identifier":
@@ -1108,8 +1113,10 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                 first = node.children[0] if node.children else None
                 if first:
                     if first.type == "identifier":
+                        func_node = first
                         callee_name = _read_text(first, source)
                     elif first.type == "field_expression":
+                        func_node = first
                         is_member_call = True
                         field = first.child_by_field_name("field")
                         if field:
@@ -1123,10 +1130,12 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                 # C#: try name field, then first named child
                 name_node = node.child_by_field_name("name")
                 if name_node:
+                    func_node = name_node
                     callee_name = _read_text(name_node, source)
                 else:
                     for child in node.children:
                         if child.is_named:
+                            func_node = child
                             raw = _read_text(child, source)
                             if "." in raw:
                                 callee_name = raw.split(".")[-1]
@@ -1142,11 +1151,13 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         callee_name = _read_text(func_node, source)
                 elif node.type == "scoped_call_expression":
                     # Static method call: Helper::format() → callee = "Helper"
+                    func_node = node
                     scope_node = node.child_by_field_name("scope")
                     if scope_node:
                         callee_name = _read_text(scope_node, source)
                 else:
                     # member_call_expression: $obj->method()
+                    func_node = node
                     is_member_call = True
                     name_node = node.child_by_field_name("name")
                     if name_node:
@@ -3441,26 +3452,53 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
         all_nodes.extend(result.get("nodes", []))
         all_edges.extend(result.get("edges", []))
 
-    # Remap file node IDs from absolute-path-derived to project-relative so
-    # graph.json edge endpoints are stable across machines (#502)
+    # Remap IDs from absolute-path-derived to project-relative so graph.json
+    # endpoints are stable across machines (#502). File node IDs use the whole
+    # path, while entity IDs use _file_stem(path) as their prefix (#550), so
+    # both forms need to be normalized before cross-file edge resolution.
     id_remap: dict[str, str] = {}
+    stem_prefix_remaps: list[tuple[str, str]] = []
     for path in paths:
         old_id = _make_id(str(path))
         try:
-            new_id = _make_id(str(path.relative_to(root)))
+            rel_path = path.relative_to(root)
         except ValueError:
             continue
+        new_id = _make_id(str(rel_path))
         if old_id != new_id:
             id_remap[old_id] = new_id
-    if id_remap:
+
+        old_stem_id = _make_id(_file_stem(path))
+        new_stem_id = _make_id(_file_stem(rel_path))
+        if old_stem_id != new_stem_id:
+            stem_prefix_remaps.append((old_stem_id, new_stem_id))
+
+    def _remap_extracted_id(nid: str | None) -> str | None:
+        if not nid:
+            return nid
+        if nid in id_remap:
+            return id_remap[nid]
+        for old_prefix, new_prefix in stem_prefix_remaps:
+            if nid == old_prefix:
+                return new_prefix
+            prefix = old_prefix + "_"
+            if nid.startswith(prefix):
+                return new_prefix + nid[len(old_prefix):]
+        return nid
+
+    if id_remap or stem_prefix_remaps:
         for n in all_nodes:
-            if n.get("id") in id_remap:
-                n["id"] = id_remap[n["id"]]
+            remapped = _remap_extracted_id(n.get("id"))
+            if remapped:
+                n["id"] = remapped
         for e in all_edges:
-            if e.get("source") in id_remap:
-                e["source"] = id_remap[e["source"]]
-            if e.get("target") in id_remap:
-                e["target"] = id_remap[e["target"]]
+            e["source"] = _remap_extracted_id(e.get("source"))
+            e["target"] = _remap_extracted_id(e.get("target"))
+        for result in per_file:
+            for rc in result.get("raw_calls", []):
+                remapped = _remap_extracted_id(rc.get("caller_nid"))
+                if remapped:
+                    rc["caller_nid"] = remapped
 
     # Add cross-file class-level edges (Python only - uses Python parser internally)
     py_paths = [p for p in paths if p.suffix == ".py"]
@@ -3511,10 +3549,6 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
                 continue
             callee = rc.get("callee", "")
             if not callee:
-                continue
-            # Skip member-call callees: obj.log() → "log" has no import evidence
-            # and collides with any top-level function named "log" in the corpus.
-            if rc.get("is_member_call"):
                 continue
             tgt = global_label_to_nid.get(callee.lower())
             caller = rc["caller_nid"]

--- a/tests/test_claude_md.py
+++ b/tests/test_claude_md.py
@@ -1,7 +1,8 @@
 """Tests for graphify claude install / uninstall commands."""
-from pathlib import Path
-import pytest
-from graphify.__main__ import claude_install, claude_uninstall, _CLAUDE_MD_MARKER, _CLAUDE_MD_SECTION
+import json
+import subprocess
+import sys
+from graphify.__main__ import claude_install, claude_uninstall, _CLAUDE_MD_MARKER
 
 
 # ---------------------------------------------------------------------------
@@ -22,6 +23,8 @@ def test_install_contains_expected_rules(tmp_path):
     content = (tmp_path / "CLAUDE.md").read_text()
     assert "GRAPH_REPORT.md" in content
     assert "wiki/index.md" in content
+    assert "graphify query" in content
+    assert "Use grep/find/ls/read only after graphify" in content
     assert "graphify update" in content
 
 
@@ -36,22 +39,43 @@ def test_install_appends_to_existing_claude_md(tmp_path):
 
 
 def test_install_is_idempotent(tmp_path, capsys):
-    """Running install twice does not duplicate the section."""
+    """Running install twice refreshes the section without duplicating it."""
     claude_install(tmp_path)
     claude_install(tmp_path)
     content = (tmp_path / "CLAUDE.md").read_text()
     assert content.count(_CLAUDE_MD_MARKER) == 1
     captured = capsys.readouterr()
-    assert "already configured" in captured.out
+    assert "refreshed" in captured.out
 
 
 def test_install_idempotent_message(tmp_path, capsys):
-    """Second install prints the 'already configured' message."""
+    """Second install prints the refresh message."""
     claude_install(tmp_path)
     capsys.readouterr()  # clear first call output
     claude_install(tmp_path)
     out = capsys.readouterr().out
-    assert "already configured" in out
+    assert "refreshed" in out
+
+
+def test_install_refreshes_existing_graphify_section(tmp_path):
+    """Existing stale graphify section is replaced while other content stays intact."""
+    target = tmp_path / "CLAUDE.md"
+    target.write_text(
+        "# Project rules\n\n"
+        "Keep this.\n\n"
+        "## graphify\n\n"
+        "Old graphify text.\n\n"
+        "## Other\n\n"
+        "Keep this too.\n"
+    )
+
+    claude_install(tmp_path)
+
+    content = target.read_text()
+    assert "Old graphify text" not in content
+    assert "Keep this." in content
+    assert "## Other" in content
+    assert "Use grep/find/ls/read only after graphify" in content
 
 
 # ---------------------------------------------------------------------------
@@ -102,35 +126,189 @@ def test_uninstall_no_op_when_no_file(tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 def test_install_creates_settings_json(tmp_path):
-    """claude_install also writes .claude/settings.json with PreToolUse hook."""
-    import json
+    """claude_install writes UserPromptSubmit reminder and PreToolUse guard."""
     claude_install(tmp_path)
     settings_path = tmp_path / ".claude" / "settings.json"
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
     assert settings_path.exists()
+    assert guard_path.exists()
     settings = json.loads(settings_path.read_text())
-    hooks = settings.get("hooks", {}).get("PreToolUse", [])
-    assert any(h.get("matcher") == "Bash" for h in hooks)
+    hooks = settings.get("hooks", {})
+    assert any("graphify" in str(h) for h in hooks.get("UserPromptSubmit", []))
+    assert any(h.get("matcher") == "Bash|Grep|Glob|Read|LS" for h in hooks.get("PreToolUse", []))
 
 
 def test_install_settings_json_idempotent(tmp_path):
-    """Running claude_install twice does not duplicate the PreToolUse hook."""
-    import json
+    """Running claude_install twice does not duplicate graphify hooks."""
     claude_install(tmp_path)
     claude_install(tmp_path)
     settings_path = tmp_path / ".claude" / "settings.json"
     settings = json.loads(settings_path.read_text())
-    hooks = settings.get("hooks", {}).get("PreToolUse", [])
-    bash_hooks = [h for h in hooks if h.get("matcher") == "Bash" and "graphify" in str(h)]
-    assert len(bash_hooks) == 1
+    hooks = settings.get("hooks", {})
+    prompt_hooks = [h for h in hooks.get("UserPromptSubmit", []) if "graphify" in str(h)]
+    guard_hooks = [h for h in hooks.get("PreToolUse", []) if "graphify" in str(h)]
+    assert len(prompt_hooks) == 1
+    assert len(guard_hooks) == 1
+
+
+def test_install_preserves_unrelated_settings_hooks(tmp_path):
+    """Installing graphify keeps non-graphify Claude hooks in place."""
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo keep me"}],
+                },
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo old graphify hook"}],
+                },
+            ]
+        }
+    }))
+
+    claude_install(tmp_path)
+
+    settings = json.loads(settings_path.read_text())
+    pre_tool = settings["hooks"]["PreToolUse"]
+    assert any("keep me" in str(h) for h in pre_tool)
+    assert not any("old graphify hook" in str(h) for h in pre_tool)
+    assert any("graphify-guard.py" in str(h) for h in pre_tool)
 
 
 def test_uninstall_removes_settings_hook(tmp_path):
-    """claude_uninstall removes the PreToolUse hook from settings.json."""
-    import json
+    """claude_uninstall removes graphify hooks and guard script."""
     claude_install(tmp_path)
     claude_uninstall(tmp_path)
     settings_path = tmp_path / ".claude" / "settings.json"
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
+    assert not guard_path.exists()
     if settings_path.exists():
         settings = json.loads(settings_path.read_text())
-        hooks = settings.get("hooks", {}).get("PreToolUse", [])
-        assert not any(h.get("matcher") == "Bash" and "graphify" in str(h) for h in hooks)
+        hooks = settings.get("hooks", {})
+        assert "graphify" not in str(hooks.get("UserPromptSubmit", []))
+        assert "graphify" not in str(hooks.get("PreToolUse", []))
+
+
+def test_guard_blocks_raw_search_until_graph_used(tmp_path):
+    """The generated guard blocks raw search before graphify is used."""
+    claude_install(tmp_path)
+    graph_dir = tmp_path / "graphify-out"
+    graph_dir.mkdir()
+    (graph_dir / "graph.json").write_text('{"nodes":[],"edges":[]}')
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
+
+    blocked = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "blocked",
+            "tool_name": "Bash",
+            "tool_input": {"command": 'grep -r "xml" verframe/src'},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert blocked.returncode == 2
+    assert "raw file search/read/list blocked" in blocked.stderr
+
+
+def test_guard_allows_raw_search_after_graph_used(tmp_path):
+    """After graphify query is used in a session, targeted raw reads are allowed."""
+    claude_install(tmp_path)
+    graph_dir = tmp_path / "graphify-out"
+    graph_dir.mkdir()
+    (graph_dir / "graph.json").write_text('{"nodes":[],"edges":[]}')
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
+
+    graph_use = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "allowed",
+            "tool_name": "Bash",
+            "tool_input": {"command": 'graphify query "xml export" --budget 4000'},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert graph_use.returncode == 0
+
+    raw_search = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "allowed",
+            "tool_name": "Bash",
+            "tool_input": {"command": 'grep -r "xml" verframe/src'},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert raw_search.returncode == 0
+
+
+def test_guard_treats_windows_graph_report_read_as_graph_use(tmp_path):
+    """Windows-style graph report paths count as graph usage."""
+    claude_install(tmp_path)
+    graph_dir = tmp_path / "graphify-out"
+    graph_dir.mkdir()
+    (graph_dir / "graph.json").write_text('{"nodes":[],"edges":[]}')
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
+
+    graph_read = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "windows-report",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "graphify-out\\GRAPH_REPORT.md"},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert graph_read.returncode == 0
+
+    raw_search = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "windows-report",
+            "tool_name": "Bash",
+            "tool_input": {"command": 'grep -r "xml" verframe/src'},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert raw_search.returncode == 0
+
+
+def test_guard_allows_windows_claude_hook_reads(tmp_path):
+    """Windows-style .claude paths are internal guard reads, not raw exploration."""
+    claude_install(tmp_path)
+    graph_dir = tmp_path / "graphify-out"
+    graph_dir.mkdir()
+    (graph_dir / "graph.json").write_text('{"nodes":[],"edges":[]}')
+    guard_path = tmp_path / ".claude" / "hooks" / "graphify-guard.py"
+
+    hook_read = subprocess.run(
+        [sys.executable, str(guard_path)],
+        input=json.dumps({
+            "session_id": "windows-claude",
+            "tool_name": "Read",
+            "tool_input": {"file_path": ".claude\\hooks\\graphify-guard.py"},
+        }),
+        text=True,
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+    assert hook_read.returncode == 0


### PR DESCRIPTION
## Summary
- install a Claude UserPromptSubmit reminder before tool selection
- add a Claude PreToolUse guard that blocks raw search/read/list tools until graphify is used in the session
- refresh stale CLAUDE.md graphify sections during install and preserve unrelated Claude hooks
- cover refresh, hook cleanup, and guard behavior in tests

## Tests
- PYTHONPYCACHEPREFIX=/tmp/graphify-pycache python -m py_compile graphify/__main__.py tests/test_claude_md.py tests/test_install.py
- uv run --with pytest pytest tests/test_claude_md.py -q
- uv run --with pytest pytest tests/ -q --tb=short