### PR TITLE
Fix ambiguous cross-file call inference for duplicate helper names

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3435,12 +3435,12 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
     # Cross-file call resolution for all languages
     # Each extractor saved unresolved calls in raw_calls. Now that we have all
     # nodes from all files, resolve any callee that exists in another file.
-    global_label_to_nid: dict[str, str] = {}
+    global_label_to_nids: dict[str, list[str]] = {}
     for n in all_nodes:
         raw = n.get("label", "")
         normalised = raw.strip("()").lstrip(".")
         if normalised:
-            global_label_to_nid[normalised.lower()] = n["id"]
+            global_label_to_nids.setdefault(normalised.lower(), []).append(n["id"])
 
     existing_pairs = {(e["source"], e["target"]) for e in all_edges}
     for result in per_file:
@@ -3452,7 +3452,14 @@ def extract(paths: list[Path], cache_root: Path | None = None) -> dict:
             # and collides with any top-level function named "log" in the corpus.
             if rc.get("is_member_call"):
                 continue
-            tgt = global_label_to_nid.get(callee.lower())
+            # Unqualified cross-file calls are only safe when the label resolves
+            # uniquely. Common helper names such as log(), execute(), or main()
+            # often appear in many files; choosing the last node seen creates
+            # false INFERRED calls and inflates god_nodes rankings (#543).
+            candidates = global_label_to_nids.get(callee.lower(), [])
+            if len(candidates) != 1:
+                continue
+            tgt = candidates[0]
             caller = rc["caller_nid"]
             if tgt and tgt != caller and (caller, tgt) not in existing_pairs:
                 existing_pairs.add((caller, tgt))

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -168,3 +168,25 @@ def test_calls_deduplication():
     result = extract_python(FIXTURES / "sample_calls.py")
     call_pairs = [(e["source"], e["target"]) for e in result["edges"] if e["relation"] == "calls"]
     assert len(call_pairs) == len(set(call_pairs)), "Duplicate calls edges found"
+
+
+def test_cross_file_calls_skip_ambiguous_duplicate_labels(tmp_path):
+    """Unqualified cross-file calls must not guess between duplicate helper names."""
+    caller = tmp_path / "caller.py"
+    helper_a = tmp_path / "a.py"
+    helper_b = tmp_path / "b.py"
+    caller.write_text("def run():\n    log()\n")
+    helper_a.write_text("def log():\n    return 'a'\n")
+    helper_b.write_text("def log():\n    return 'b'\n")
+
+    result = extract([caller, helper_a, helper_b], cache_root=tmp_path)
+    nodes = {n["id"]: n for n in result["nodes"]}
+    calls = [
+        e for e in result["edges"]
+        if e["relation"] == "calls" and e["confidence"] == "INFERRED"
+    ]
+
+    assert not any(
+        nodes[e["source"]]["label"] == "run()" and nodes[e["target"]]["label"] == "log()"
+        for e in calls
+    )


### PR DESCRIPTION
Fixes #543.

This keeps cross-file `calls` inference from guessing when an unqualified callee label resolves to multiple functions across the corpus. Today the global label map stores one node per normalized label, so common helper names like `log()`, `execute()`, or `main()` can resolve to whichever duplicate was seen last, creating false `INFERRED` calls and inflating graph metrics such as `god_nodes`.

Changes:
- track all global label candidates instead of overwriting duplicates
- resolve an unqualified cross-file raw call only when the label has exactly one candidate
- add a regression with two `log()` helpers proving `run() -> log()` is not guessed when ambiguous

Verification:
- `python3 -m py_compile graphify/extract.py tests/test_extract.py`
- fresh venv: `pip install -e . pytest`
- `pytest tests/test_extract.py -q` → 21 passed
- `graphify update .`
