### PR TITLE
v5: fix CI gap, silent failures, and fake success states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["v1", "v2", "v3", "v4", "main"]
+    branches: ["v1", "v2", "v3", "v4", "v5", "main"]
   pull_request:
-    branches: ["v1", "v2", "v3", "v4", "main"]
+    branches: ["v1", "v2", "v3", "v4", "v5", "main"]
 
 jobs:
   test:
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[mcp,pdf,watch]"
+          pip install -e ".[mcp,pdf,watch,dashboard,embeddings]"
           pip install pytest
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ scripts/run_k2_*.py
 scripts/llm.py
 scripts/benchmark_kimi*.json
 scripts/benchmark_kimi*.py
+
+# Dev artifacts that have leaked into the repo before
+graph.db
+_debug_ts.py

--- a/graphify/cypher.py
+++ b/graphify/cypher.py
@@ -1,0 +1,442 @@
+# Cypher-subset query engine for graphify graphs.
+# Supports: MATCH, WHERE, RETURN, LIMIT, ORDER BY
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import networkx as nx
+
+
+def _tokenize(query: str) -> list[str]:
+    """Split a Cypher query into tokens, preserving quoted strings."""
+    tokens: list[str] = []
+    current = ""
+    in_string = False
+    string_char = ""
+    for ch in query:
+        if ch in ('"', "'") and not in_string:
+            in_string = True
+            string_char = ch
+            if current:
+                tokens.append(current)
+                current = ""
+            current += ch
+        elif ch == string_char and in_string:
+            current += ch
+            tokens.append(current)
+            current = ""
+            in_string = False
+            string_char = ""
+        elif ch.isspace() and not in_string:
+            if current:
+                tokens.append(current)
+                current = ""
+        elif ch in "[](),-><>=!.:" and not in_string:
+            if current:
+                tokens.append(current)
+                current = ""
+            tokens.append(ch)
+        else:
+            current += ch
+    if current:
+        tokens.append(current)
+    return tokens
+
+
+def _parse_cypher(query: str) -> dict:
+    """Parse a Cypher-like query into a structured dict.
+
+    Supported patterns:
+      MATCH (n) RETURN n
+      MATCH (n:code) RETURN n.label
+      MATCH (n)-[r:uses]->(m) RETURN n, m
+      MATCH (n) WHERE n.community = 0 RETURN n LIMIT 10
+    """
+    tokens = _tokenize(query)
+    result: dict[str, Any] = {
+        "match_nodes": [],
+        "match_edges": [],
+        "where": [],
+        "return_fields": [],
+        "limit": None,
+        "order_by": None,
+        "order_desc": False,
+    }
+
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i].upper()
+
+        if tok == "MATCH":
+            i += 1
+            # Parse node or edge pattern
+            while i < len(tokens) and tokens[i].upper() not in ("WHERE", "RETURN", "LIMIT", "ORDER"):
+                if tokens[i] == "(":
+                    i += 1
+                    node_var = tokens[i]
+                    i += 1
+                    node_label = None
+                    if i < len(tokens) and tokens[i] == ":":
+                        i += 1
+                        node_label = tokens[i].strip()
+                        i += 1
+                    result["match_nodes"].append({"var": node_var, "label": node_label})
+                    if i < len(tokens) and tokens[i] == ")":
+                        i += 1
+                elif tokens[i] == "-":
+                    # Edge pattern: -[r:rel]-> or <-[r:rel]-
+                    direction = "both"
+                    # Pre-bracket direction (uncommon): ->[r]-
+                    if i + 1 < len(tokens) and tokens[i + 1] == ">":
+                        direction = "out"
+                        i += 2
+                    elif i + 1 < len(tokens) and tokens[i + 1] == "-":
+                        i += 2
+                    else:
+                        i += 1
+                    if i < len(tokens) and tokens[i] == "[":
+                        i += 1
+                        edge_var = tokens[i]
+                        i += 1
+                        edge_type = None
+                        if i < len(tokens) and tokens[i] == ":":
+                            i += 1
+                            edge_type = tokens[i].strip()
+                            i += 1
+                        if i < len(tokens) and tokens[i] == "]":
+                            i += 1
+                        # Post-bracket direction: ]-> (the standard form)
+                        if i < len(tokens) and tokens[i] == "-":
+                            if i + 1 < len(tokens) and tokens[i + 1] == ">":
+                                direction = "out"
+                                i += 2
+                            elif i + 1 < len(tokens) and tokens[i + 1] == "-":
+                                i += 2
+                            else:
+                                i += 1
+                        result["match_edges"].append({"var": edge_var, "type": edge_type, "direction": direction})
+                elif tokens[i] == "<":
+                    if i + 1 < len(tokens) and tokens[i + 1] == "-":
+                        direction = "in"
+                        i += 2
+                        if i < len(tokens) and tokens[i] == "[":
+                            i += 1
+                            edge_var = tokens[i]
+                            i += 1
+                            edge_type = None
+                            if i < len(tokens) and tokens[i] == ":":
+                                i += 1
+                                edge_type = tokens[i].strip()
+                                i += 1
+                            result["match_edges"].append({"var": edge_var, "type": edge_type, "direction": direction})
+                            if i < len(tokens) and tokens[i] == "]":
+                                i += 1
+                    else:
+                        i += 1
+                else:
+                    i += 1
+
+        elif tok == "WHERE":
+            i += 1
+            clause_tokens = []
+            while i < len(tokens) and tokens[i].upper() not in ("RETURN", "LIMIT", "ORDER"):
+                clause_tokens.append(tokens[i])
+                i += 1
+            result["where"] = _parse_where(clause_tokens)
+
+        elif tok == "RETURN":
+            i += 1
+            fields = []
+            while i < len(tokens) and tokens[i].upper() not in ("LIMIT", "ORDER"):
+                if tokens[i] == ",":
+                    i += 1
+                    continue
+                # Reassemble var.prop patterns
+                if i + 2 < len(tokens) and tokens[i + 1] == ".":
+                    fields.append(f"{tokens[i]}.{tokens[i + 2]}")
+                    i += 3
+                else:
+                    fields.append(tokens[i])
+                    i += 1
+            result["return_fields"] = fields
+
+        elif tok == "LIMIT":
+            i += 1
+            if i < len(tokens):
+                try:
+                    result["limit"] = int(tokens[i])
+                except ValueError:
+                    pass
+                i += 1
+
+        elif tok == "ORDER" and i + 1 < len(tokens) and tokens[i + 1].upper() == "BY":
+            i += 2
+            if i < len(tokens):
+                result["order_by"] = tokens[i]
+                i += 1
+            if i < len(tokens) and tokens[i].upper() == "DESC":
+                result["order_desc"] = True
+                i += 1
+
+        else:
+            i += 1
+
+    return result
+
+
+def _parse_where(tokens: list[str]) -> list[dict]:
+    """Parse WHERE clause tokens into predicate dicts.
+
+    Supports: n.prop = value, n.prop != value, n.prop > value, n.prop CONTAINS 'str'
+    """
+    predicates: list[dict] = []
+    i = 0
+    while i < len(tokens):
+        if i + 2 < len(tokens) and tokens[i + 1] == ".":
+            var = tokens[i]
+            prop = tokens[i + 2]
+            i += 3
+            op = tokens[i].upper() if i < len(tokens) else "="
+            i += 1
+            val = None
+            if i < len(tokens):
+                val = tokens[i]
+                i += 1
+            # Strip quotes
+            if val and val[0] in ('"', "'"):
+                val = val[1:-1]
+            # Try numeric
+            if val is not None:
+                try:
+                    val = int(val)
+                except ValueError:
+                    try:
+                        val = float(val)
+                    except ValueError:
+                        pass
+            predicates.append({"var": var, "prop": prop, "op": op, "value": val})
+        elif i + 1 < len(tokens) and tokens[i].upper() == "CONTAINS":
+            # Handle: n.prop CONTAINS 'value'
+            pass  # already handled above as op
+            i += 1
+        else:
+            i += 1
+    return predicates
+
+
+def _eval_predicate(data: dict, pred: dict) -> bool:
+    """Evaluate a single predicate against node/edge data."""
+    prop_val = data.get(pred["prop"])
+    target = pred["value"]
+    op = pred["op"]
+
+    if op == "=":
+        return prop_val == target
+    elif op in ("!=", "<>"):
+        return prop_val != target
+    elif op == ">":
+        try:
+            return float(prop_val or 0) > float(target or 0)
+        except (TypeError, ValueError):
+            return False
+    elif op == "<":
+        try:
+            return float(prop_val or 0) < float(target or 0)
+        except (TypeError, ValueError):
+            return False
+    elif op == ">=":
+        try:
+            return float(prop_val or 0) >= float(target or 0)
+        except (TypeError, ValueError):
+            return False
+    elif op == "<=":
+        try:
+            return float(prop_val or 0) <= float(target or 0)
+        except (TypeError, ValueError):
+            return False
+    elif op.upper() == "CONTAINS":
+        return target in str(prop_val or "")
+    return False
+
+
+def _resolve_field(G: nx.Graph, obj, field: str) -> Any:
+    """Resolve a RETURN field like 'n.label' or 'n.community'."""
+    if field == "n" or field == "*":
+        return dict(obj[1]) if hasattr(obj, "__iter__") and len(obj) == 2 else obj
+    parts = field.split(".")
+    if len(parts) == 2:
+        var, prop = parts
+        if isinstance(obj, tuple):
+            data = obj[1]
+        elif isinstance(obj, dict):
+            data = obj
+        else:
+            data = G.nodes.get(obj, {})
+        return data.get(prop)
+    return obj
+
+
+def execute_cypher(G: nx.Graph, query: str) -> list[dict]:
+    """Execute a Cypher-subset query against a NetworkX graph.
+
+    Returns a list of result rows (dicts keyed by RETURN field names).
+    """
+    parsed = _parse_cypher(query)
+    results: list[dict] = []
+
+    # Build candidate items based on MATCH
+    match_nodes = parsed["match_nodes"]
+    match_edges = parsed["match_edges"]
+    where_preds = parsed["where"]
+    return_fields = parsed["return_fields"]
+    limit = parsed["limit"]
+
+    if match_edges:
+        # Edge-based query
+        direction = match_edges[0]["direction"]
+        edge_type = match_edges[0]["type"]
+
+        for u, v, edata in G.edges(data=True):
+            if edge_type and edata.get("relation") != edge_type:
+                continue
+
+            # Honor the directional intent encoded by build_from_json into
+            # _src/_tgt. NetworkX's undirected iteration yields edges in
+            # canonical (u, v) order which need not match the original
+            # direction; without this, MATCH (n)-[r]->(m) silently returns
+            # back-edges. If _src/_tgt are absent (e.g. compressed graphs),
+            # fall back to (u, v) for "both" but skip the row for explicit
+            # direction queries to avoid fake matches.
+            src_id = edata.get("_src")
+            tgt_id = edata.get("_tgt")
+            if direction in ("out", "in"):
+                if src_id is None or tgt_id is None or src_id not in G or tgt_id not in G:
+                    continue
+                if direction == "out":
+                    n_id, m_id = src_id, tgt_id
+                else:  # "in"
+                    n_id, m_id = tgt_id, src_id
+            else:
+                n_id, m_id = u, v
+
+            n_data = G.nodes[n_id]
+            m_data = G.nodes[m_id]
+            if match_nodes:
+                if len(match_nodes) >= 1:
+                    label_filter = match_nodes[0].get("label")
+                    if label_filter and n_data.get("file_type") != label_filter and n_data.get("label") != label_filter:
+                        continue
+                if len(match_nodes) >= 2:
+                    label_filter = match_nodes[1].get("label")
+                    if label_filter and m_data.get("file_type") != label_filter and m_data.get("label") != label_filter:
+                        continue
+
+            # WHERE filtering
+            row_bindings = {
+                match_nodes[0]["var"]: (n_id, n_data) if match_nodes else (n_id, n_data),
+            }
+            if len(match_nodes) > 1:
+                row_bindings[match_nodes[1]["var"]] = (m_id, m_data)
+            if match_edges:
+                row_bindings[match_edges[0]["var"]] = edata
+
+            skip = False
+            for pred in where_preds:
+                binding = row_bindings.get(pred["var"])
+                if binding is None:
+                    skip = True
+                    break
+                data = binding[1] if isinstance(binding, tuple) else binding
+                if not _eval_predicate(data, pred):
+                    skip = True
+                    break
+            if skip:
+                continue
+
+            # Build result row
+            row: dict[str, Any] = {}
+            for field in return_fields:
+                if "." in field:
+                    var, prop = field.split(".", 1)
+                    binding = row_bindings.get(var)
+                    data = binding[1] if isinstance(binding, tuple) else binding
+                    row[field] = data.get(prop)
+                else:
+                    binding = row_bindings.get(field)
+                    row[field] = binding[1] if isinstance(binding, tuple) else binding
+            results.append(row)
+    else:
+        # Node-only query
+        for nid, data in G.nodes(data=True):
+            if match_nodes:
+                label_filter = match_nodes[0].get("label")
+                if label_filter and data.get("file_type") != label_filter and data.get("label") != label_filter:
+                    continue
+
+            bindings = {match_nodes[0]["var"]: (nid, data)} if match_nodes else {"n": (nid, data)}
+
+            skip = False
+            for pred in where_preds:
+                binding = bindings.get(pred["var"])
+                if binding is None:
+                    skip = True
+                    break
+                check_data = binding[1] if isinstance(binding, tuple) else binding
+                if not _eval_predicate(check_data, pred):
+                    skip = True
+                    break
+            if skip:
+                continue
+
+            row = {}
+            for field in return_fields:
+                if "." in field:
+                    var, prop = field.split(".", 1)
+                    binding = bindings.get(var)
+                    check_data = binding[1] if isinstance(binding, tuple) else binding
+                    row[field] = check_data.get(prop) if check_data else None
+                elif field == "*":
+                    row[field] = dict(data)
+                else:
+                    binding = bindings.get(field)
+                    row[field] = binding[1] if isinstance(binding, tuple) else binding
+            results.append(row)
+
+    # ORDER BY
+    order_by = parsed["order_by"]
+    if order_by and results:
+        def _sort_key(r):
+            val = r.get(order_by)
+            if val is None:
+                return (1, "")
+            try:
+                return (0, float(val))
+            except (TypeError, ValueError):
+                return (0, str(val).lower())
+        results.sort(key=_sort_key, reverse=parsed["order_desc"])
+
+    # LIMIT
+    if limit is not None:
+        results = results[:limit]
+
+    return results
+
+
+def render_results(results: list[dict], format: str = "table") -> str:
+    """Render query results as a human-readable string."""
+    if not results:
+        return "(no results)"
+    if format == "json":
+        import json
+        return json.dumps(results, indent=2, default=str)
+
+    # Table format
+    keys = list(results[0].keys())
+    lines = []
+    header = " | ".join(str(k) for k in keys)
+    lines.append(header)
+    lines.append("-" * len(header))
+    for row in results:
+        lines.append(" | ".join(str(row.get(k, "")) for k in keys))
+    return "\n".join(lines)

--- a/graphify/dashboard.py
+++ b/graphify/dashboard.py
@@ -1,0 +1,293 @@
+# FastAPI web dashboard for graphify graphs.
+# Usage: python -m graphify.dashboard --graph graphify-out/graph.json --port 8000
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+
+try:
+    from fastapi import FastAPI, HTTPException, Query
+    from fastapi.responses import HTMLResponse, JSONResponse
+    from fastapi.staticfiles import StaticFiles
+    from pydantic import BaseModel
+    HAS_FASTAPI = True
+except ImportError:
+    HAS_FASTAPI = False
+    FastAPI = object  # type: ignore[misc, assignment]
+    BaseModel = object  # type: ignore[misc, assignment]
+    HTTPException = Exception  # type: ignore[misc, assignment]
+
+
+_GRAPH_PATH: Path | None = None
+_G: nx.Graph | None = None
+_COMMUNITIES: dict[int, list[str]] = {}
+_LABELS: dict[int, str] = {}
+
+
+def _load_graph(graph_path: str | Path) -> nx.Graph:
+    global _G, _COMMUNITIES, _LABELS
+    path = Path(graph_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Graph not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        G = json_graph.node_link_graph(data, edges="links", multigraph=False)
+    except TypeError:
+        G = json_graph.node_link_graph(data, multigraph=False)
+    _G = G
+
+    # Reconstruct communities from node attributes
+    comm_map: dict[int, list[str]] = {}
+    for nid, ndata in G.nodes(data=True):
+        cid = ndata.get("community")
+        if cid is not None:
+            comm_map.setdefault(int(cid), []).append(nid)
+    _COMMUNITIES = comm_map
+
+    # Auto-label if missing
+    from graphify.label import label_communities
+    _LABELS = label_communities(G, _COMMUNITIES)
+    return G
+
+
+def create_app(graph_path: str | Path = "graphify-out/graph.json") -> "FastAPI":
+    if not HAS_FASTAPI:
+        raise ImportError("fastapi not installed. Run: pip install fastapi")
+
+    app = FastAPI(title="graphify dashboard")
+    _load_graph(graph_path)
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        return _html_page()
+
+    @app.get("/api/graph")
+    def api_graph() -> dict:
+        if _G is None:
+            raise HTTPException(status_code=503, detail="Graph not loaded")
+        node_community = {n: cid for cid, nodes in _COMMUNITIES.items() for n in nodes}
+        nodes = []
+        degree = dict(_G.degree())
+        max_deg = max(degree.values(), default=1) or 1
+        for nid, data in _G.nodes(data=True):
+            cid = node_community.get(nid, 0)
+            nodes.append({
+                "id": nid,
+                "label": data.get("label", nid),
+                "community": cid,
+                "community_name": _LABELS.get(cid, f"Community {cid}"),
+                "file_type": data.get("file_type", ""),
+                "source_file": data.get("source_file", ""),
+                "degree": degree.get(nid, 0),
+                "size": 10 + 30 * (degree.get(nid, 1) / max_deg),
+            })
+        edges = [
+            {"source": u, "target": v, "relation": d.get("relation", ""),
+             "confidence": d.get("confidence", "EXTRACTED")}
+            for u, v, d in _G.edges(data=True)
+        ]
+        return {"nodes": nodes, "edges": edges}
+
+    @app.get("/api/search")
+    def api_search(q: str = Query(...), top_k: int = 10) -> list[dict]:
+        if _G is None:
+            raise HTTPException(status_code=503, detail="Graph not loaded")
+        from graphify.embeddings import EmbeddingIndex
+        idx = EmbeddingIndex().build(_G)
+        results = idx.search(q, top_k=top_k)
+        return [
+            {"id": nid, "score": round(score, 4),
+             "label": _G.nodes[nid].get("label", nid),
+             **{k: v for k, v in _G.nodes[nid].items() if k != "label"}}
+            for nid, score in results
+        ]
+
+    @app.get("/api/node/{node_id}")
+    def api_node(node_id: str) -> dict:
+        if _G is None:
+            raise HTTPException(status_code=503, detail="Graph not loaded")
+        if node_id not in _G:
+            raise HTTPException(status_code=404, detail="Node not found")
+        data = dict(_G.nodes[node_id])
+        neighbors = [
+            {"id": nb, "label": _G.nodes[nb].get("label", nb),
+             "relation": _G.edges[node_id, nb].get("relation", "")}
+            for nb in _G.neighbors(node_id)
+        ]
+        return {"id": node_id, **data, "neighbors": neighbors}
+
+    @app.get("/api/communities")
+    def api_communities() -> list[dict]:
+        if _G is None:
+            raise HTTPException(status_code=503, detail="Graph not loaded")
+        return [
+            {"id": cid, "label": _LABELS.get(cid, f"Community {cid}"),
+             "size": len(nodes),
+             "members": [{"id": n, "label": _G.nodes[n].get("label", n)} for n in nodes[:50]]}
+            for cid, nodes in _COMMUNITIES.items()
+        ]
+
+    @app.post("/api/cypher")
+    def api_cypher(body: dict) -> dict:
+        if _G is None:
+            raise HTTPException(status_code=503, detail="Graph not loaded")
+        from graphify.cypher import execute_cypher, render_results
+        query = body.get("query", "")
+        results = execute_cypher(_G, query)
+        return {"results": results, "rendered": render_results(results)}
+
+    return app
+
+
+def _html_page() -> str:
+    return """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>graphify dashboard</title>
+<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<style>
+body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f0f1a; color: #e0e0e0; }
+#layout { display: flex; height: 100vh; }
+#graph { flex: 1; }
+#sidebar { width: 320px; background: #1a1a2e; border-left: 1px solid #2a2a4e; display: flex; flex-direction: column; overflow: hidden; }
+#search-wrap { padding: 12px; border-bottom: 1px solid #2a2a4e; }
+#search { width: 100%; background: #0f0f1a; border: 1px solid #3a3a5e; color: #e0e0e0; padding: 7px 10px; border-radius: 6px; font-size: 13px; outline: none; }
+#cypher-wrap { padding: 8px 12px; border-bottom: 1px solid #2a2a4e; }
+#cypher { width: 100%; background: #0f0f1a; border: 1px solid #3a3a5e; color: #e0e0e0; padding: 6px 10px; border-radius: 6px; font-size: 12px; outline: none; }
+#info-panel { padding: 14px; border-bottom: 1px solid #2a2a4e; min-height: 140px; overflow-y: auto; }
+#info-panel h3 { font-size: 13px; color: #aaa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+#info-content { font-size: 13px; color: #ccc; line-height: 1.6; }
+#legend-wrap { flex: 1; overflow-y: auto; padding: 12px; }
+#legend-wrap h3 { font-size: 13px; color: #aaa; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
+.legend-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; border-radius: 4px; font-size: 12px; }
+.legend-item:hover { background: #2a2a4e; padding-left: 4px; }
+.legend-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+.neighbor-link { display: block; padding: 2px 6px; margin: 2px 0; border-radius: 3px; cursor: pointer; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 3px solid #333; }
+.neighbor-link:hover { background: #2a2a4e; }
+</style>
+</head>
+<body>
+<div id="layout">
+<div id="graph"></div>
+<div id="sidebar">
+  <div id="search-wrap">
+    <input id="search" type="text" placeholder="Semantic search..." autocomplete="off">
+  </div>
+  <div id="cypher-wrap">
+    <input id="cypher" type="text" placeholder="Cypher: MATCH (n) RETURN n.label" autocomplete="off">
+  </div>
+  <div id="info-panel">
+    <h3>Node Info</h3>
+    <div id="info-content"><i>Click a node to inspect it</i></div>
+  </div>
+  <div id="legend-wrap">
+    <h3>Communities</h3>
+    <div id="legend"></div>
+  </div>
+</div>
+</div>
+<script>
+const COLORS = ["#4E79A7","#F28E2B","#E15759","#76B7B2","#59A14F","#EDC948","#B07AA1","#FF9DA7","#9C755F","#BAB0AC"];
+
+fetch('/api/graph').then(r=>r.json()).then(data=>{
+  const nodes = new vis.DataSet(data.nodes.map(n=>({
+    id:n.id, label:n.label,
+    color:{background:COLORS[n.community%COLORS.length],border:COLORS[n.community%COLORS.length]},
+    size:n.size, font:{size:12,color:'#fff'},
+    title:`${n.label} (${n.community_name})`,
+    ...n
+  })));
+  const edges = new vis.DataSet(data.edges.map((e,i)=>({
+    id:i, from:e.source, to:e.target,
+    title:e.relation+' ['+e.confidence+']',
+    dashes:e.confidence!=='EXTRACTED',
+    width:e.confidence==='EXTRACTED'?2:1,
+    color:{opacity:e.confidence==='EXTRACTED'?0.7:0.35}
+  })));
+
+  const network = new vis.Network(document.getElementById('graph'), {nodes,edges}, {
+    physics:{solver:'forceAtlas2Based',forceAtlas2Based:{gravitationalConstant:-60,centralGravity:0.005,springLength:120,springConstant:0.08,damping:0.4,avoidOverlap:0.8},stabilization:{iterations:200}},
+    interaction:{hover:true,tooltipDelay:100,hideEdgesOnDrag:true},
+    nodes:{shape:'dot',borderWidth:1.5},
+    edges:{smooth:{type:'continuous',roundness:0.2}}
+  });
+
+  network.once('stabilizationIterationsDone',()=>network.setOptions({physics:{enabled:false}}));
+
+  network.on('click',params=>{
+    if(params.nodes.length) showInfo(params.nodes[0]);
+  });
+
+  function showInfo(id){
+    fetch('/api/node/'+encodeURIComponent(id)).then(r=>r.json()).then(d=>{
+      let html=`<b>${d.label||d.id}</b><br>Type: ${d.file_type||'-'}<br>Community: ${d.community_name||'-'}<br>Degree: ${d.degree||'-'}<br>Source: ${d.source_file||'-'}`;
+      if(d.neighbors&&d.neighbors.length){
+        html+='<br><br><b>Neighbors</b>';
+        d.neighbors.forEach(nb=>{
+          html+=`<span class="neighbor-link" onclick="focusNode('${nb.id}')">${nb.label} — ${nb.relation}</span>`;
+        });
+      }
+      document.getElementById('info-content').innerHTML=html;
+    });
+  }
+  window.focusNode=function(id){ network.focus(id,{scale:1.4,animation:true}); network.selectNodes([id]); showInfo(id); };
+
+  document.getElementById('search').addEventListener('keydown',e=>{
+    if(e.key==='Enter'){
+      fetch('/api/search?q='+encodeURIComponent(e.target.value)).then(r=>r.json()).then(list=>{
+        if(list.length) focusNode(list[0].id);
+      });
+    }
+  });
+
+  document.getElementById('cypher').addEventListener('keydown',e=>{
+    if(e.key==='Enter'){
+      fetch('/api/cypher',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({query:e.target.value})}).then(r=>r.json()).then(d=>{
+        document.getElementById('info-content').innerHTML='<pre style="font-size:11px">'+d.rendered+'</pre>';
+      });
+    }
+  });
+
+  // Legend
+  const legend=document.getElementById('legend');
+  const comms=[...new Set(data.nodes.map(n=>n.community))].sort((a,b)=>a-b);
+  comms.forEach(cid=>{
+    const name=data.nodes.find(n=>n.community===cid)?.community_name||('Community '+cid);
+    const el=document.createElement('div');
+    el.className='legend-item';
+    el.innerHTML=`<div class="legend-dot" style="background:${COLORS[cid%COLORS.length]}"></div><span>${name}</span>`;
+    legend.appendChild(el);
+  });
+});
+</script>
+</body>
+</html>"""
+
+
+def main() -> None:
+    import argparse
+    parser = argparse.ArgumentParser(description="graphify web dashboard")
+    parser.add_argument("--graph", default="graphify-out/graph.json", help="Path to graph.json")
+    parser.add_argument("--port", type=int, default=8000, help="Port to serve on")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
+    args = parser.parse_args()
+
+    if not HAS_FASTAPI:
+        print("error: fastapi not installed. Run: pip install fastapi", file=sys.stderr)
+        sys.exit(1)
+
+    import uvicorn
+    app = create_app(args.graph)
+    print(f"Serving graphify dashboard at http://{args.host}:{args.port}/")
+    print(f"Graph: {args.graph}")
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/graphify/dashboard.py
+++ b/graphify/dashboard.py
@@ -62,6 +62,18 @@ def create_app(graph_path: str | Path = "graphify-out/graph.json") -> "FastAPI":
     app = FastAPI(title="graphify dashboard")
     _load_graph(graph_path)
 
+    # Cached embedding index, lazily built on first /api/search hit.
+    # Previously each request rebuilt the index from scratch — with
+    # sentence-transformers installed, that meant reloading the model
+    # on every search, which dominated latency on real graphs.
+    embedding_index_holder: dict = {"idx": None}
+
+    def _get_embedding_index():
+        if embedding_index_holder["idx"] is None:
+            from graphify.embeddings import EmbeddingIndex
+            embedding_index_holder["idx"] = EmbeddingIndex().build(_G)
+        return embedding_index_holder["idx"]
+
     @app.get("/", response_class=HTMLResponse)
     def index() -> str:
         return _html_page()
@@ -97,8 +109,7 @@ def create_app(graph_path: str | Path = "graphify-out/graph.json") -> "FastAPI":
     def api_search(q: str = Query(...), top_k: int = 10) -> list[dict]:
         if _G is None:
             raise HTTPException(status_code=503, detail="Graph not loaded")
-        from graphify.embeddings import EmbeddingIndex
-        idx = EmbeddingIndex().build(_G)
+        idx = _get_embedding_index()
         results = idx.search(q, top_k=top_k)
         return [
             {"id": nid, "score": round(score, 4),

--- a/graphify/diff.py
+++ b/graphify/diff.py
@@ -1,0 +1,317 @@
+# graph diff engine — compare two graph.json snapshots
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+from graphify.analyze import god_nodes
+from graphify.cluster import cluster
+
+
+def _load_graph(path: str | Path) -> nx.Graph:
+    """Load a graph.json file into a NetworkX Graph."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    data = _canonicalize(data)
+    try:
+        return json_graph.node_link_graph(data, edges="links")
+    except TypeError:
+        return json_graph.node_link_graph(data)
+
+
+def _canonicalize(data: dict) -> dict:
+    """Ensure old-format graphs are compatible."""
+    if "links" not in data and "edges" in data:
+        data = dict(data, links=data.pop("edges"))
+    return data
+
+
+def _node_key(node: dict) -> str:
+    return node["id"]
+
+
+def _edge_key(edge: dict) -> tuple:
+    return (edge.get("source"), edge.get("target"), edge.get("relation", ""))
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 1.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def diff_graphs(old_path: str | Path, new_path: str | Path) -> dict:
+    """Compare two graph.json files and return a structured diff.
+
+    Returns dict with:
+      - old_nodes, new_nodes, nodes_added, nodes_removed, nodes_changed
+      - old_edges, new_edges, edges_added, edges_removed
+      - communities_changed (splits/merges)
+      - god_nodes_changed (promoted/demoted)
+    """
+    old_G = _load_graph(old_path)
+    new_G = _load_graph(new_path)
+
+    old_nodes: dict[str, dict] = {n: dict(d) for n, d in old_G.nodes(data=True)}
+    new_nodes: dict[str, dict] = {n: dict(d) for n, d in new_G.nodes(data=True)}
+
+    old_node_ids = set(old_nodes.keys())
+    new_node_ids = set(new_nodes.keys())
+
+    nodes_added = [dict(new_nodes[nid], id=nid) for nid in (new_node_ids - old_node_ids)]
+    nodes_removed = [dict(old_nodes[nid], id=nid) for nid in (old_node_ids - new_node_ids)]
+    nodes_changed = []
+    for nid in (old_node_ids & new_node_ids):
+        old_attrs = old_nodes[nid]
+        new_attrs = new_nodes[nid]
+        changed = {}
+        all_keys = set(old_attrs.keys()) | set(new_attrs.keys())
+        for k in all_keys:
+            if old_attrs.get(k) != new_attrs.get(k):
+                changed[k] = {"old": old_attrs.get(k), "new": new_attrs.get(k)}
+        if changed:
+            nodes_changed.append({"id": nid, "label": new_attrs.get("label", nid), "changes": changed})
+
+    old_edges_raw = [
+        dict(d, source=u, target=v)
+        for u, v, d in old_G.edges(data=True)
+    ]
+    new_edges_raw = [
+        dict(d, source=u, target=v)
+        for u, v, d in new_G.edges(data=True)
+    ]
+    old_edge_map = {_edge_key(e): e for e in old_edges_raw}
+    new_edge_map = {_edge_key(e): e for e in new_edges_raw}
+    old_edge_keys = set(old_edge_map.keys())
+    new_edge_keys = set(new_edge_map.keys())
+
+    edges_added = [new_edge_map[k] for k in (new_edge_keys - old_edge_keys)]
+    edges_removed = [old_edge_map[k] for k in (old_edge_keys - new_edge_keys)]
+
+    communities_changed = _diff_communities(old_G, new_G)
+    god_nodes_changed = _diff_god_nodes(old_G, new_G)
+
+    return {
+        "old_nodes": old_G.number_of_nodes(),
+        "new_nodes": new_G.number_of_nodes(),
+        "nodes_added": nodes_added,
+        "nodes_removed": nodes_removed,
+        "nodes_changed": nodes_changed,
+        "old_edges": old_G.number_of_edges(),
+        "new_edges": new_G.number_of_edges(),
+        "edges_added": edges_added,
+        "edges_removed": edges_removed,
+        "communities_changed": communities_changed,
+        "god_nodes_changed": god_nodes_changed,
+        "schema_version": "0.5.5",
+    }
+
+
+def _existing_communities(G: nx.Graph) -> dict[int, list[str]]:
+    """Reconstruct communities from per-node 'community' attributes."""
+    out: dict[int, list[str]] = {}
+    for nid, data in G.nodes(data=True):
+        cid = data.get("community")
+        if cid is None:
+            continue
+        out.setdefault(int(cid), []).append(nid)
+    return out
+
+
+def _diff_communities(old_G: nx.Graph, new_G: nx.Graph,
+                         old_communities: dict | None = None,
+                         new_communities: dict | None = None) -> list[dict]:
+    """Detect community splits and merges using Jaccard similarity.
+
+    Prefers community assignments already stored on the graph (set by
+    save() during the original build). Re-running cluster() here was
+    non-deterministic — Leiden / Louvain assignments can differ across
+    runs, so two diffs of the same pair of files produced different
+    splits/merges. Only fall back to fresh clustering if neither graph
+    carries community labels.
+    """
+    if old_communities is None:
+        existing = _existing_communities(old_G)
+        old_communities = existing if existing else cluster(old_G)
+    if new_communities is None:
+        existing = _existing_communities(new_G)
+        new_communities = existing if existing else cluster(new_G)
+
+    old_sets = {cid: set(nodes) for cid, nodes in old_communities.items()}
+    new_sets = {cid: set(nodes) for cid, nodes in new_communities.items()}
+
+    changed: list[dict] = []
+    threshold = 0.5
+
+    # Detect splits: one old community → multiple new communities
+    for old_cid, old_set in old_sets.items():
+        matches = []
+        for new_cid, new_set in new_sets.items():
+            sim = _jaccard(old_set, new_set)
+            if sim >= threshold:
+                matches.append((new_cid, sim, new_set))
+        if len(matches) > 1:
+            changed.append({
+                "type": "split",
+                "old_community": old_cid,
+                "old_size": len(old_set),
+                "new_communities": [
+                    {"id": cid, "size": len(ns), "jaccard": round(sim, 2)}
+                    for cid, sim, ns in sorted(matches, key=lambda x: -x[1])
+                ],
+            })
+
+    # Detect merges: multiple old communities → one new community
+    for new_cid, new_set in new_sets.items():
+        matches = []
+        for old_cid, old_set in old_sets.items():
+            sim = _jaccard(old_set, new_set)
+            if sim >= threshold:
+                matches.append((old_cid, sim, old_set))
+        if len(matches) > 1:
+            changed.append({
+                "type": "merge",
+                "new_community": new_cid,
+                "new_size": len(new_set),
+                "old_communities": [
+                    {"id": cid, "size": len(os), "jaccard": round(sim, 2)}
+                    for cid, sim, os in sorted(matches, key=lambda x: -x[1])
+                ],
+            })
+
+    return changed
+
+
+def _diff_god_nodes(old_G: nx.Graph, new_G: nx.Graph, top_n: int = 10) -> dict:
+    """Compare god node rankings between two graphs."""
+    old_gods = {g["id"]: g for g in god_nodes(old_G, top_n)}
+    new_gods = {g["id"]: g for g in god_nodes(new_G, top_n)}
+
+    old_set = set(old_gods.keys())
+    new_set = set(new_gods.keys())
+
+    promoted = [
+        {"id": nid, "label": new_gods[nid]["label"], "degree": new_gods[nid]["degree"]}
+        for nid in (new_set - old_set)
+    ]
+    demoted = [
+        {"id": nid, "label": old_gods[nid]["label"], "degree": old_gods[nid]["degree"]}
+        for nid in (old_set - new_set)
+    ]
+    stable = []
+    for nid in (old_set & new_set):
+        old_deg = old_gods[nid]["degree"]
+        new_deg = new_gods[nid]["degree"]
+        if old_deg != new_deg:
+            stable.append({
+                "id": nid,
+                "label": new_gods[nid]["label"],
+                "old_degree": old_deg,
+                "new_degree": new_deg,
+                "delta": new_deg - old_deg,
+            })
+
+    return {
+        "old_gods": list(old_gods.values()),
+        "new_gods": list(new_gods.values()),
+        "promoted": promoted,
+        "demoted": demoted,
+        "changed": stable,
+    }
+
+
+def render_diff(diff: dict, fmt: str = "markdown") -> str:
+    """Render a diff dict as markdown or json."""
+    if fmt == "json":
+        return json.dumps(diff, indent=2)
+
+    lines: list[str] = [
+        "# Graph Diff Report",
+        "",
+        "## Summary",
+        f"- Nodes: {diff['old_nodes']} → {diff['new_nodes']} ({diff['new_nodes'] - diff['old_nodes']:+,})",
+        f"- Edges: {diff['old_edges']} → {diff['new_edges']} ({diff['new_edges'] - diff['old_edges']:+,})",
+        "",
+    ]
+
+    # Nodes
+    lines += ["## Nodes", ""]
+    if diff["nodes_added"]:
+        lines.append(f"### Added ({len(diff['nodes_added'])})")
+        for n in diff["nodes_added"][:20]:
+            lines.append(f"- `{n['id']}` — {n.get('label', '')}")
+        if len(diff["nodes_added"]) > 20:
+            lines.append(f"- ... and {len(diff['nodes_added']) - 20} more")
+        lines.append("")
+    if diff["nodes_removed"]:
+        lines.append(f"### Removed ({len(diff['nodes_removed'])})")
+        for n in diff["nodes_removed"][:20]:
+            lines.append(f"- `{n['id']}` — {n.get('label', '')}")
+        if len(diff["nodes_removed"]) > 20:
+            lines.append(f"- ... and {len(diff['nodes_removed']) - 20} more")
+        lines.append("")
+    if diff["nodes_changed"]:
+        lines.append(f"### Changed ({len(diff['nodes_changed'])})")
+        for n in diff["nodes_changed"][:20]:
+            changed_keys = ", ".join(n["changes"].keys())
+            lines.append(f"- `{n['id']}` — changed: {changed_keys}")
+        if len(diff["nodes_changed"]) > 20:
+            lines.append(f"- ... and {len(diff['nodes_changed']) - 20} more")
+        lines.append("")
+
+    # Edges
+    lines += ["## Edges", ""]
+    if diff["edges_added"]:
+        lines.append(f"### Added ({len(diff['edges_added'])})")
+        for e in diff["edges_added"][:20]:
+            lines.append(f"- `{e['source']}` --{e.get('relation', '')}--> `{e['target']}`")
+        if len(diff["edges_added"]) > 20:
+            lines.append(f"- ... and {len(diff['edges_added']) - 20} more")
+        lines.append("")
+    if diff["edges_removed"]:
+        lines.append(f"### Removed ({len(diff['edges_removed'])})")
+        for e in diff["edges_removed"][:20]:
+            lines.append(f"- `{e['source']}` --{e.get('relation', '')}--> `{e['target']}`")
+        if len(diff["edges_removed"]) > 20:
+            lines.append(f"- ... and {len(diff['edges_removed']) - 20} more")
+        lines.append("")
+
+    # Communities
+    if diff["communities_changed"]:
+        lines += ["## Communities", ""]
+        for c in diff["communities_changed"]:
+            if c["type"] == "split":
+                lines.append(f"### Split: Community {c['old_community']} ({c['old_size']} nodes)")
+                for nc in c["new_communities"]:
+                    lines.append(f"- → Community {nc['id']} ({nc['size']} nodes, Jaccard {nc['jaccard']})")
+            elif c["type"] == "merge":
+                lines.append(f"### Merge: Community {c['new_community']} ({c['new_size']} nodes)")
+                for oc in c["old_communities"]:
+                    lines.append(f"- ← Community {oc['id']} ({oc['size']} nodes, Jaccard {oc['jaccard']})")
+        lines.append("")
+
+    # God nodes
+    gods = diff["god_nodes_changed"]
+    lines += ["## God Nodes", ""]
+    if gods["promoted"]:
+        lines.append(f"### Promoted ({len(gods['promoted'])})")
+        for g in gods["promoted"]:
+            lines.append(f"- `{g['label']}` — {g['degree']} edges")
+        lines.append("")
+    if gods["demoted"]:
+        lines.append(f"### Demoted ({len(gods['demoted'])})")
+        for g in gods["demoted"]:
+            lines.append(f"- `{g['label']}` — {g['degree']} edges")
+        lines.append("")
+    if gods["changed"]:
+        lines.append(f"### Degree Changed ({len(gods['changed'])})")
+        for g in gods["changed"]:
+            lines.append(f"- `{g['label']}` — {g['old_degree']} → {g['new_degree']} ({g['delta']:+,})")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/graphify/embeddings.py
+++ b/graphify/embeddings.py
@@ -1,0 +1,183 @@
+# Vector embeddings for semantic node search.
+# Optional dependency: sentence-transformers (auto-detected).
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+import numpy as np
+
+
+_DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute cosine similarity between two vectors."""
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(np.dot(a, b) / (norm_a * norm_b))
+
+
+class EmbeddingIndex:
+    """Lightweight embedding index for semantic graph search.
+
+    Uses sentence-transformers if available; falls back to TF-IDF-like
+    bag-of-words vectors for zero-dependency operation.
+    """
+
+    def __init__(self, model_name: str = _DEFAULT_MODEL) -> None:
+        self.model_name = model_name
+        self._model: Any | None = None
+        self._embeddings: dict[str, np.ndarray] = {}
+        self._labels: dict[str, str] = {}
+        # Persisted only on the BoW fallback path so search queries can
+        # be encoded against the same vocabulary as the indexed labels.
+        # Without this, query vectors had a different dim than indexed
+        # vectors and cosine similarity raised a shape error.
+        self._bow_vocab: dict[str, int] | None = None
+
+    def _load_model(self) -> Any:
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer
+            self._model = SentenceTransformer(self.model_name)
+            return self._model
+        except ImportError:
+            return None
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return text.lower().replace("_", " ").replace("-", " ").split()
+
+    def _vectorize_corpus(self, texts: list[str]) -> np.ndarray:
+        """Encode the indexed labels. On the BoW path, also build vocab."""
+        model = self._load_model()
+        if model is not None:
+            return model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
+
+        vocab: dict[str, int] = {}
+        tokenized: list[list[str]] = []
+        for text in texts:
+            tokens = self._tokenize(text)
+            tokenized.append(tokens)
+            for t in tokens:
+                if t not in vocab:
+                    vocab[t] = len(vocab)
+        self._bow_vocab = vocab
+        return self._bow_encode(tokenized, vocab)
+
+    def _vectorize_query(self, text: str) -> np.ndarray:
+        """Encode a single query. On BoW, projects onto the build-time vocab."""
+        model = self._load_model()
+        if model is not None:
+            return model.encode([text], convert_to_numpy=True, show_progress_bar=False)[0]
+
+        vocab = self._bow_vocab or {}
+        if not vocab:
+            return np.zeros(1, dtype=np.float32)
+        vec = np.zeros(len(vocab), dtype=np.float32)
+        for t in self._tokenize(text):
+            idx = vocab.get(t)
+            if idx is not None:
+                vec[idx] += 1.0
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec = vec / norm
+        return vec
+
+    @staticmethod
+    def _bow_encode(tokenized: list[list[str]], vocab: dict[str, int]) -> np.ndarray:
+        dim = len(vocab) or 1
+        mat = np.zeros((len(tokenized), dim), dtype=np.float32)
+        for i, tokens in enumerate(tokenized):
+            for t in tokens:
+                mat[i, vocab[t]] += 1.0
+        norms = np.linalg.norm(mat, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return mat / norms
+
+    def build(self, G: nx.Graph) -> "EmbeddingIndex":
+        """Compute embeddings for all nodes in the graph."""
+        self._embeddings.clear()
+        self._labels.clear()
+        self._bow_vocab = None
+        items: list[tuple[str, str]] = []
+        for nid, data in G.nodes(data=True):
+            label = data.get("label", nid)
+            if label:
+                items.append((nid, label))
+
+        if not items:
+            return self
+
+        nids, labels = zip(*items)
+        vectors = self._vectorize_corpus(list(labels))
+        for nid, vec in zip(nids, vectors):
+            self._embeddings[nid] = vec
+            self._labels[nid] = G.nodes[nid].get("label", nid)
+        return self
+
+    def search(self, query: str, top_k: int = 10) -> list[tuple[str, float]]:
+        """Return the top-k node IDs most semantically similar to the query.
+
+        On the bag-of-words fallback, a query whose tokens don't appear
+        in any indexed label produces a zero vector — every node would
+        score 0.0 and the top-k slice would surface arbitrary nodes that
+        look like matches. Return an empty list in that case rather than
+        fabricated hits, and skip non-positive similarities.
+        """
+        if not self._embeddings:
+            return []
+        query_vec = self._vectorize_query(query)
+        if float(np.linalg.norm(query_vec)) == 0.0:
+            return []
+        scores = []
+        for nid, vec in self._embeddings.items():
+            sim = _cosine_similarity(query_vec, vec)
+            if sim <= 0.0:
+                continue
+            scores.append((nid, sim))
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:top_k]
+
+    def save(self, path: str | Path) -> None:
+        """Serialize embeddings to a JSON file."""
+        on_bow = self._load_model() is None
+        data = {
+            "model": "fallback-bow" if on_bow else self.model_name,
+            "embeddings": {
+                nid: vec.tolist()
+                for nid, vec in self._embeddings.items()
+            },
+            "labels": self._labels,
+            "bow_vocab": self._bow_vocab if on_bow else None,
+        }
+        Path(path).write_text(json.dumps(data), encoding="utf-8")
+
+    def load(self, path: str | Path) -> "EmbeddingIndex":
+        """Load embeddings from a JSON file."""
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        self.model_name = data.get("model", _DEFAULT_MODEL)
+        self._embeddings = {
+            nid: np.array(vec, dtype=np.float32)
+            for nid, vec in data["embeddings"].items()
+        }
+        self._labels = data.get("labels", {})
+        vocab = data.get("bow_vocab")
+        self._bow_vocab = dict(vocab) if vocab else None
+        return self
+
+
+def search_nodes(G: nx.Graph, query: str, top_k: int = 10) -> list[dict]:
+    """Convenience function: build index, search, return node data."""
+    idx = EmbeddingIndex().build(G)
+    results = idx.search(query, top_k=top_k)
+    return [
+        {"id": nid, "score": round(score, 4), **G.nodes[nid]}
+        for nid, score in results
+    ]

--- a/graphify/plugins.py
+++ b/graphify/plugins.py
@@ -1,0 +1,119 @@
+# Plugin architecture for language extractors and custom extensions.
+# Plugins are arbitrary Python imported via importlib, so auto-discovery
+# is OFF by default — set GRAPHIFY_ENABLE_PLUGINS=1 to opt in. Tests and
+# in-process callers can still register extractors directly via
+# register_extractor() without flipping the env var.
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+# Registry: file_suffix → extractor_function
+_EXTRACTOR_REGISTRY: dict[str, Callable[[Path], dict]] = {}
+
+_DEFAULT_PLUGIN_DIRS = [
+    Path.home() / ".graphify" / "plugins",
+    Path(".").resolve() / "graphify-plugins",
+]
+
+
+def _auto_discover_enabled() -> bool:
+    """Return True if file-based plugin discovery is opted in."""
+    return os.environ.get("GRAPHIFY_ENABLE_PLUGINS", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _discover_plugins() -> list[Path]:
+    """Find all .py files in plugin directories."""
+    plugins: list[Path] = []
+    for directory in _DEFAULT_PLUGIN_DIRS:
+        if directory.is_dir():
+            for f in directory.glob("*.py"):
+                if f.name.startswith("_"):
+                    continue
+                plugins.append(f)
+    return plugins
+
+
+def _load_plugin(path: Path) -> dict | None:
+    """Load a single plugin file and return its register() dict."""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"graphify_plugin_{path.stem}", str(path)
+        )
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        # Avoid polluting sys.modules with transient plugin names
+        sys.modules[module.__name__] = module
+        spec.loader.exec_module(module)
+        register = getattr(module, "register", None)
+        if callable(register):
+            return register()
+    except Exception as exc:
+        print(f"[graphify] Plugin error in {path}: {exc}", file=sys.stderr)
+    return None
+
+
+def load_plugins() -> dict[str, Callable[[Path], dict]]:
+    """Discover and load all plugins, returning the merged extractor registry.
+
+    File-based discovery runs only when GRAPHIFY_ENABLE_PLUGINS is set —
+    auto-importing arbitrary Python from ~/.graphify/plugins/ on every
+    invocation is a code-execution sink, so opting in is required.
+    register_extractor() still works without the flag.
+
+    Each plugin must expose a `register()` function that returns a dict mapping
+    file suffixes (e.g. '.hs') to extractor functions:
+
+        def register():
+            return {".hs": extract_haskell}
+
+    Extractor functions receive a Path and return a dict with "nodes" and "edges".
+    """
+    global _EXTRACTOR_REGISTRY
+    if _EXTRACTOR_REGISTRY:
+        return dict(_EXTRACTOR_REGISTRY)
+
+    if not _auto_discover_enabled():
+        return dict(_EXTRACTOR_REGISTRY)
+
+    for plugin_path in _discover_plugins():
+        mapping = _load_plugin(plugin_path)
+        if mapping and isinstance(mapping, dict):
+            for suffix, fn in mapping.items():
+                if callable(fn):
+                    _EXTRACTOR_REGISTRY[suffix] = fn
+                else:
+                    print(
+                        f"[graphify] Plugin {plugin_path}: value for {suffix} is not callable",
+                        file=sys.stderr,
+                    )
+
+    return dict(_EXTRACTOR_REGISTRY)
+
+
+def get_extractor(suffix: str) -> Callable[[Path], dict] | None:
+    """Return the extractor function for a file suffix, or None."""
+    registry = load_plugins()
+    return registry.get(suffix)
+
+
+def list_plugins() -> list[str]:
+    """Return a list of discovered plugin file paths."""
+    return [str(p) for p in _discover_plugins()]
+
+
+def reset_registry() -> None:
+    """Clear the plugin registry (useful for testing)."""
+    global _EXTRACTOR_REGISTRY
+    _EXTRACTOR_REGISTRY = {}
+
+
+def register_extractor(suffix: str, fn: Callable[[Path], dict]) -> None:
+    """Programmatically register an extractor (useful for tests and built-ins)."""
+    _EXTRACTOR_REGISTRY[suffix] = fn

--- a/graphify/store.py
+++ b/graphify/store.py
@@ -1,0 +1,518 @@
+# Graph storage abstraction — MemoryStore (JSON) and SQLiteStore (sqlite3)
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+from graphify.schema import upgrade_graph, SCHEMA_VERSION
+
+
+class GraphStore(ABC):
+    """Abstract base class for graph persistence backends."""
+
+    @abstractmethod
+    def save(self, G: nx.Graph, communities: dict[int, list[str]], metadata: dict | None = None) -> None:
+        """Persist a NetworkX graph with community assignments."""
+        ...
+
+    @abstractmethod
+    def load(self) -> tuple[nx.Graph, dict[int, list[str]], dict]:
+        """Load graph, communities, and metadata."""
+        ...
+
+    @abstractmethod
+    def query_nodes(
+        self,
+        label: str | None = None,
+        file_type: str | None = None,
+        community: int | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        ...
+
+    @abstractmethod
+    def query_edges(
+        self,
+        source: str | None = None,
+        target: str | None = None,
+        relation: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        ...
+
+    @abstractmethod
+    def get_neighbors(self, node_id: str, relation: str | None = None) -> list[dict]:
+        ...
+
+    @abstractmethod
+    def get_stats(self) -> dict:
+        ...
+
+    @abstractmethod
+    def search_nodes(self, query: str, limit: int = 20) -> list[dict]:
+        """Full-text search over node labels (backend-dependent quality)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# MemoryStore — wraps the current JSON-on-disk approach
+# ---------------------------------------------------------------------------
+
+class MemoryStore(GraphStore):
+    """In-memory graph backed by a JSON file."""
+
+    def __init__(self, graph_path: str = "graphify-out/graph.json") -> None:
+        self.graph_path = Path(graph_path)
+        self._G: nx.Graph | None = None
+        self._communities: dict[int, list[str]] | None = None
+        self._metadata: dict = {}
+
+    def _load_if_needed(self) -> None:
+        if self._G is not None:
+            return
+        if not self.graph_path.exists():
+            self._G = nx.Graph()
+            self._communities = {}
+            self._metadata = {}
+            return
+        data = json.loads(self.graph_path.read_text(encoding="utf-8"))
+        data = upgrade_graph(data)
+        try:
+            self._G = json_graph.node_link_graph(data, edges="links")
+        except TypeError:
+            self._G = json_graph.node_link_graph(data)
+        self._metadata = dict(data.get("graph", {}))
+        self._communities = self._reconstruct_communities(data)
+
+    def _reconstruct_communities(self, data: dict) -> dict[int, list[str]]:
+        communities: dict[int, list[str]] = {}
+        for node in data.get("nodes", []):
+            cid = node.get("community")
+            if cid is not None:
+                communities.setdefault(int(cid), []).append(node["id"])
+        return communities
+
+    def save(self, G: nx.Graph, communities: dict[int, list[str]], metadata: dict | None = None) -> None:
+        self._G = G
+        self._communities = communities
+        self._metadata = metadata or {}
+        self.graph_path.parent.mkdir(parents=True, exist_ok=True)
+        # Set community attributes on nodes before serializing
+        node_community = {n: cid for cid, nodes in communities.items() for n in nodes}
+        for nid in G.nodes:
+            G.nodes[nid]["community"] = node_community.get(nid)
+        try:
+            data = json_graph.node_link_data(G, edges="links")
+        except TypeError:
+            data = json_graph.node_link_data(G)
+        data["graph"] = dict(self._metadata, schema_version=SCHEMA_VERSION)
+        self.graph_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def load(self) -> tuple[nx.Graph, dict[int, list[str]], dict]:
+        self._load_if_needed()
+        assert self._G is not None
+        return self._G, self._communities or {}, self._metadata
+
+    def query_nodes(
+        self,
+        label: str | None = None,
+        file_type: str | None = None,
+        community: int | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        self._load_if_needed()
+        results = []
+        for nid, data in self._G.nodes(data=True):  # type: ignore[union-attr]
+            d = dict(data, id=nid)
+            if label and label.lower() not in d.get("label", "").lower():
+                continue
+            if file_type and d.get("file_type") != file_type:
+                continue
+            if community is not None and d.get("community") != community:
+                continue
+            results.append(d)
+            if len(results) >= limit:
+                break
+        return results
+
+    def query_edges(
+        self,
+        source: str | None = None,
+        target: str | None = None,
+        relation: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        self._load_if_needed()
+        results = []
+        for u, v, data in self._G.edges(data=True):  # type: ignore[union-attr]
+            if source and u != source:
+                continue
+            if target and v != target:
+                continue
+            if relation and data.get("relation") != relation:
+                continue
+            results.append(dict(data, source=u, target=v))
+            if len(results) >= limit:
+                break
+        return results
+
+    def get_neighbors(self, node_id: str, relation: str | None = None) -> list[dict]:
+        self._load_if_needed()
+        if node_id not in self._G:  # type: ignore[operator]
+            return []
+        results = []
+        for neighbor in self._G.neighbors(node_id):  # type: ignore[union-attr]
+            data = self._G.nodes[neighbor]  # type: ignore[index]
+            if relation:
+                edge_data = self._G.edges[node_id, neighbor]  # type: ignore[index]
+                if edge_data.get("relation") != relation:
+                    continue
+            results.append(dict(data, id=neighbor))
+        return results
+
+    def get_stats(self) -> dict:
+        self._load_if_needed()
+        return {
+            "nodes": self._G.number_of_nodes(),  # type: ignore[union-attr]
+            "edges": self._G.number_of_edges(),  # type: ignore[union-attr]
+            "communities": len(self._communities or {}),
+            "schema_version": self._metadata.get("schema_version"),
+        }
+
+    def search_nodes(self, query: str, limit: int = 20) -> list[dict]:
+        return self.query_nodes(label=query, limit=limit)
+
+
+# ---------------------------------------------------------------------------
+# SQLiteStore — concurrent-safe, queryable backend
+# ---------------------------------------------------------------------------
+
+_SQLITE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS nodes (
+    id TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    file_type TEXT,
+    source_file TEXT,
+    source_location TEXT,
+    source_url TEXT,
+    captured_at TEXT,
+    author TEXT,
+    contributor TEXT,
+    community INTEGER,
+    norm_label TEXT,
+    attrs TEXT  -- JSON blob for extra attributes
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    relation TEXT NOT NULL,
+    confidence TEXT,
+    confidence_score REAL,
+    source_file TEXT,
+    source_location TEXT,
+    weight REAL,
+    _src TEXT,
+    _tgt TEXT,
+    attrs TEXT,  -- JSON blob for extra attributes
+    PRIMARY KEY (source, target, relation)
+);
+
+CREATE TABLE IF NOT EXISTS communities (
+    id INTEGER PRIMARY KEY,
+    label TEXT,
+    node_count INTEGER,
+    cohesion REAL
+);
+
+CREATE TABLE IF NOT EXISTS metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_community ON nodes(community);
+CREATE INDEX IF NOT EXISTS idx_nodes_file_type ON nodes(file_type);
+CREATE INDEX IF NOT EXISTS idx_nodes_label ON nodes(label);
+CREATE INDEX IF NOT EXISTS idx_edges_relation ON edges(relation);
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target);
+"""
+
+
+class SQLiteStore(GraphStore):
+    """SQLite-backed graph store. One sqlite3 connection per thread.
+
+    The previous implementation cached a single connection with
+    check_same_thread=False and shared it across all callers without a
+    lock — sqlite3 cursors are not safe to interleave that way. We now
+    keep connections in thread-local storage so each thread gets its
+    own, which is the supported sqlite3 pattern for concurrent access.
+    """
+
+    def __init__(self, db_path: str = "graphify-out/graph.db") -> None:
+        self.db_path = Path(db_path)
+        self._tls = threading.local()
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = getattr(self._tls, "conn", None)
+        if conn is None:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self.db_path))
+            conn.row_factory = sqlite3.Row
+            self._tls.conn = conn
+        return conn
+
+    def _ensure_schema(self) -> None:
+        conn = self._connect()
+        conn.executescript(_SQLITE_SCHEMA)
+        conn.commit()
+
+    def _node_to_row(self, node: dict) -> tuple:
+        attrs = {k: v for k, v in node.items() if k not in {
+            "id", "label", "file_type", "source_file", "source_location",
+            "source_url", "captured_at", "author", "contributor", "community", "norm_label"
+        }}
+        return (
+            node["id"],
+            node.get("label", ""),
+            node.get("file_type"),
+            node.get("source_file"),
+            node.get("source_location"),
+            node.get("source_url"),
+            node.get("captured_at"),
+            node.get("author"),
+            node.get("contributor"),
+            node.get("community"),
+            node.get("norm_label"),
+            json.dumps(attrs) if attrs else None,
+        )
+
+    def _edge_to_row(self, edge: dict) -> tuple:
+        attrs = {k: v for k, v in edge.items() if k not in {
+            "source", "target", "relation", "confidence", "confidence_score",
+            "source_file", "source_location", "weight", "_src", "_tgt"
+        }}
+        return (
+            edge["source"],
+            edge["target"],
+            edge.get("relation", ""),
+            edge.get("confidence"),
+            edge.get("confidence_score"),
+            edge.get("source_file"),
+            edge.get("source_location"),
+            edge.get("weight", 1.0),
+            edge.get("_src"),
+            edge.get("_tgt"),
+            json.dumps(attrs) if attrs else None,
+        )
+
+    def save(self, G: nx.Graph, communities: dict[int, list[str]], metadata: dict | None = None) -> None:
+        conn = self._connect()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM edges")
+        cursor.execute("DELETE FROM nodes")
+        cursor.execute("DELETE FROM communities")
+        cursor.execute("DELETE FROM metadata")
+
+        node_community = {n: cid for cid, nodes in communities.items() for n in nodes}
+        for nid, data in G.nodes(data=True):
+            d = dict(data, id=nid)
+            d["community"] = node_community.get(nid)
+            row = self._node_to_row(d)
+            cursor.execute(
+                "INSERT INTO nodes VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                row,
+            )
+
+        for u, v, data in G.edges(data=True):
+            row = self._edge_to_row(dict(data, source=u, target=v))
+            cursor.execute(
+                "INSERT OR REPLACE INTO edges VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                row,
+            )
+
+        for cid, nodes in communities.items():
+            cursor.execute(
+                "INSERT INTO communities VALUES (?,?,?,?)",
+                (cid, None, len(nodes), None),
+            )
+
+        meta = dict(metadata or {}, schema_version=SCHEMA_VERSION)
+        for k, v in meta.items():
+            cursor.execute("INSERT INTO metadata VALUES (?,?)", (k, str(v)))
+
+        conn.commit()
+
+    def load(self) -> tuple[nx.Graph, dict[int, list[str]], dict]:
+        conn = self._connect()
+        cursor = conn.cursor()
+
+        G = nx.Graph()
+        cursor.execute("SELECT * FROM nodes")
+        for row in cursor.fetchall():
+            d = dict(row)
+            nid = d.pop("id")
+            attrs = json.loads(d.pop("attrs") or "{}")
+            G.add_node(nid, **{k: v for k, v in {**d, **attrs}.items() if v is not None})
+
+        cursor.execute("SELECT * FROM edges")
+        for row in cursor.fetchall():
+            d = dict(row)
+            src = d.pop("source")
+            tgt = d.pop("target")
+            attrs = json.loads(d.pop("attrs") or "{}")
+            G.add_edge(src, tgt, **{k: v for k, v in {**d, **attrs}.items() if v is not None})
+
+        communities: dict[int, list[str]] = {}
+        cursor.execute("SELECT id, label FROM communities")
+        for row in cursor.fetchall():
+            communities[row["id"]] = []
+
+        cursor.execute("SELECT id, community FROM nodes WHERE community IS NOT NULL")
+        for row in cursor.fetchall():
+            cid = row["community"]
+            if cid in communities:
+                communities[cid].append(row["id"])
+
+        metadata = {}
+        cursor.execute("SELECT key, value FROM metadata")
+        for row in cursor.fetchall():
+            metadata[row["key"]] = row["value"]
+
+        return G, communities, metadata
+
+    def query_nodes(
+        self,
+        label: str | None = None,
+        file_type: str | None = None,
+        community: int | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        conn = self._connect()
+        where_clauses: list[str] = []
+        params: list[Any] = []
+        if label:
+            where_clauses.append("label LIKE ?")
+            params.append(f"%{label}%")
+        if file_type:
+            where_clauses.append("file_type = ?")
+            params.append(file_type)
+        if community is not None:
+            where_clauses.append("community = ?")
+            params.append(community)
+        sql = "SELECT * FROM nodes"
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+        sql += f" LIMIT {int(limit)}"
+        cursor = conn.execute(sql, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+    def query_edges(
+        self,
+        source: str | None = None,
+        target: str | None = None,
+        relation: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        conn = self._connect()
+        where_clauses: list[str] = []
+        params: list[Any] = []
+        if source:
+            where_clauses.append("source = ?")
+            params.append(source)
+        if target:
+            where_clauses.append("target = ?")
+            params.append(target)
+        if relation:
+            where_clauses.append("relation = ?")
+            params.append(relation)
+        sql = "SELECT * FROM edges"
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+        sql += f" LIMIT {int(limit)}"
+        cursor = conn.execute(sql, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+    def get_neighbors(self, node_id: str, relation: str | None = None) -> list[dict]:
+        conn = self._connect()
+        sql = """
+            SELECT n.* FROM nodes n
+            WHERE n.id IN (
+                SELECT target FROM edges WHERE source = ?
+                UNION
+                SELECT source FROM edges WHERE target = ?
+            )
+        """
+        params = [node_id, node_id]
+        if relation:
+            sql = """
+                SELECT n.* FROM nodes n
+                WHERE n.id IN (
+                    SELECT target FROM edges WHERE source = ? AND relation = ?
+                    UNION
+                    SELECT source FROM edges WHERE target = ? AND relation = ?
+                )
+            """
+            params = [node_id, relation, node_id, relation]
+        cursor = conn.execute(sql, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+    def get_stats(self) -> dict:
+        conn = self._connect()
+        node_count = conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+        edge_count = conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        community_count = conn.execute("SELECT COUNT(*) FROM communities").fetchone()[0]
+        schema_row = conn.execute("SELECT value FROM metadata WHERE key = 'schema_version'").fetchone()
+        return {
+            "nodes": node_count,
+            "edges": edge_count,
+            "communities": community_count,
+            "schema_version": schema_row[0] if schema_row else None,
+        }
+
+    def search_nodes(self, query: str, limit: int = 20) -> list[dict]:
+        return self.query_nodes(label=query, limit=limit)
+
+
+def store_for(path: str) -> GraphStore:
+    """Return the appropriate GraphStore for a path.
+
+    - .db  → SQLiteStore
+    - .json → MemoryStore
+    """
+    p = Path(path)
+    if p.suffix == ".db":
+        return SQLiteStore(str(p))
+    if p.suffix == ".json":
+        return MemoryStore(str(p))
+    raise ValueError(f"Unknown graph store format: {path}. Use .json or .db")
+
+
+def migrate_json_to_sqlite(json_path: str, db_path: str) -> SQLiteStore:
+    """Migrate an existing graph.json to a SQLite database."""
+    store = SQLiteStore(db_path)
+    data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+    data = upgrade_graph(data)
+    try:
+        G = json_graph.node_link_graph(data, edges="links")
+    except TypeError:
+        G = json_graph.node_link_graph(data)
+
+    communities: dict[int, list[str]] = {}
+    for node in data.get("nodes", []):
+        cid = node.get("community")
+        if cid is not None:
+            communities.setdefault(int(cid), []).append(node["id"])
+
+    metadata = dict(data.get("graph", {}))
+    store.save(G, communities, metadata)
+    print(f"Migrated {G.number_of_nodes()} nodes, {G.number_of_edges()} edges → {db_path}")
+    return store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,13 @@ leiden = ["graspologic; python_version < '3.13'"]
 office = ["python-docx", "openpyxl"]
 video = ["faster-whisper", "yt-dlp"]
 kimi = ["openai"]
-all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper", "yt-dlp", "matplotlib", "openai"]
+embeddings = ["numpy", "sentence-transformers"]
+dashboard = ["fastapi", "uvicorn", "numpy"]
+all = ["mcp", "neo4j", "pypdf", "html2text", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper", "yt-dlp", "matplotlib", "openai", "numpy", "sentence-transformers", "fastapi", "uvicorn"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"
+fathomark = "graphify.__main__:main"
 
 [tool.uv]
 # Install via: uv tool install graphifyy

--- a/tests/test_cypher.py
+++ b/tests/test_cypher.py
@@ -1,0 +1,122 @@
+import networkx as nx
+import pytest
+
+from graphify.cypher import _parse_cypher, execute_cypher, render_results
+
+
+@pytest.fixture
+def sample_graph():
+    # _src/_tgt mirror what build_from_json populates so directional
+    # MATCH queries can resolve edge orientation.
+    G = nx.Graph()
+    G.add_node("a", label="Alpha", file_type="code", community=0)
+    G.add_node("b", label="Beta", file_type="code", community=1)
+    G.add_node("c", label="Gamma", file_type="document", community=0)
+    G.add_edge("a", "b", relation="uses", confidence="EXTRACTED", _src="a", _tgt="b")
+    G.add_edge("b", "c", relation="imports", confidence="INFERRED", _src="b", _tgt="c")
+    return G
+
+
+def test_parse_simple_match():
+    parsed = _parse_cypher("MATCH (n) RETURN n")
+    assert len(parsed["match_nodes"]) == 1
+    assert parsed["match_nodes"][0]["var"] == "n"
+    assert parsed["return_fields"] == ["n"]
+
+
+def test_parse_match_with_label():
+    parsed = _parse_cypher("MATCH (n:code) RETURN n.label")
+    assert parsed["match_nodes"][0]["label"] == "code"
+    assert parsed["return_fields"] == ["n.label"]
+
+
+def test_parse_match_edge():
+    parsed = _parse_cypher("MATCH (n)-[r:uses]->(m) RETURN n, m")
+    assert len(parsed["match_nodes"]) == 2
+    assert len(parsed["match_edges"]) == 1
+    assert parsed["match_edges"][0]["type"] == "uses"
+
+
+def test_parse_where():
+    parsed = _parse_cypher("MATCH (n) WHERE n.community = 0 RETURN n")
+    assert len(parsed["where"]) == 1
+    assert parsed["where"][0]["prop"] == "community"
+    assert parsed["where"][0]["value"] == 0
+
+
+def test_parse_limit():
+    parsed = _parse_cypher("MATCH (n) RETURN n LIMIT 5")
+    assert parsed["limit"] == 5
+
+
+def test_execute_all_nodes(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n) RETURN n.label")
+    labels = {r["n.label"] for r in results}
+    assert labels == {"Alpha", "Beta", "Gamma"}
+
+
+def test_execute_label_filter(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n:code) RETURN n.label")
+    labels = {r["n.label"] for r in results}
+    assert labels == {"Alpha", "Beta"}
+
+
+def test_execute_where_equality(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n) WHERE n.community = 0 RETURN n.label")
+    labels = {r["n.label"] for r in results}
+    assert labels == {"Alpha", "Gamma"}
+
+
+def test_execute_edge_query(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n)-[r:uses]->(m) RETURN n.label, m.label")
+    assert len(results) == 1
+    assert results[0]["n.label"] == "Alpha"
+    assert results[0]["m.label"] == "Beta"
+
+
+def test_execute_contains(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n) WHERE n.label CONTAINS 'et' RETURN n.label")
+    labels = {r["n.label"] for r in results}
+    assert "Beta" in labels
+
+
+def test_execute_limit(sample_graph):
+    results = execute_cypher(sample_graph, "MATCH (n) RETURN n.label LIMIT 2")
+    assert len(results) == 2
+
+
+def test_execute_edge_direction_respects_src_tgt():
+    # Build a graph where NetworkX's canonical (u, v) order disagrees with
+    # the original directional intent stored in _src/_tgt. The Cypher
+    # ->m direction should bind n=src, m=tgt regardless of iteration order.
+    G = nx.Graph()
+    G.add_node("alpha", label="Alpha", file_type="code")
+    G.add_node("beta", label="Beta", file_type="code")
+    G.add_edge("beta", "alpha", relation="uses", _src="alpha", _tgt="beta")
+
+    results = execute_cypher(G, "MATCH (n)-[r:uses]->(m) RETURN n.label, m.label")
+    assert len(results) == 1
+    assert results[0]["n.label"] == "Alpha"
+    assert results[0]["m.label"] == "Beta"
+
+
+def test_execute_edge_direction_skips_when_src_tgt_missing():
+    # Without _src/_tgt, a directional MATCH must not silently return
+    # back-edges — it should yield no rows rather than a fake match.
+    G = nx.Graph()
+    G.add_node("a", label="A", file_type="code")
+    G.add_node("b", label="B", file_type="code")
+    G.add_edge("a", "b", relation="uses")  # no _src/_tgt
+
+    results = execute_cypher(G, "MATCH (n)-[r:uses]->(m) RETURN n.label")
+    assert results == []
+
+
+def test_render_results_table():
+    text = render_results([{"a": 1, "b": 2}, {"a": 3, "b": 4}])
+    assert "a | b" in text
+    assert "1 | 2" in text
+
+
+def test_render_results_empty():
+    assert render_results([]) == "(no results)"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from graphify.dashboard import create_app, _load_graph
+
+
+@pytest.fixture
+def sample_graph(tmp_path):
+    G = nx.Graph()
+    G.add_node("a", label="Alpha", file_type="code", community=0)
+    G.add_node("b", label="Beta", file_type="code", community=1)
+    G.add_edge("a", "b", relation="uses", confidence="EXTRACTED")
+
+    data = {
+        "nodes": [{"id": n, **d} for n, d in G.nodes(data=True)],
+        "links": [{"source": u, "target": v, **d} for u, v, d in G.edges(data=True)],
+    }
+    path = tmp_path / "graph.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return str(path)
+
+
+def test_dashboard_index(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "graphify dashboard" in resp.text
+
+
+def test_dashboard_api_graph(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get("/api/graph")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["nodes"]) == 2
+    assert len(data["edges"]) == 1
+
+
+def test_dashboard_api_node(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get("/api/node/a")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "a"
+    assert data["label"] == "Alpha"
+
+
+def test_dashboard_api_communities(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get("/api/communities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) >= 1
+
+
+def test_dashboard_api_cypher(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.post("/api/cypher", json={"query": "MATCH (n) RETURN n.label"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "results" in data
+    assert len(data["results"]) == 2
+
+
+def test_dashboard_search_caches_embedding_index(sample_graph, monkeypatch):
+    # /api/search must reuse a cached index across requests, not rebuild
+    # it per call (rebuilding reloads the sentence-transformers model
+    # every time on real graphs).
+    from graphify import embeddings as embeddings_mod
+    build_calls = {"n": 0}
+    real_build = embeddings_mod.EmbeddingIndex.build
+
+    def counting_build(self, G):
+        build_calls["n"] += 1
+        return real_build(self, G)
+
+    monkeypatch.setattr(embeddings_mod.EmbeddingIndex, "build", counting_build)
+
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    for _ in range(3):
+        resp = client.get("/api/search", params={"q": "Alpha"})
+        assert resp.status_code == 200
+    assert build_calls["n"] == 1
+
+
+def test_dashboard_api_node_missing_returns_404(sample_graph):
+    app = create_app(sample_graph)
+    from fastapi.testclient import TestClient
+    client = TestClient(app)
+    resp = client.get("/api/node/does-not-exist")
+    assert resp.status_code == 404

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,324 @@
+"""Tests for graphify.diff — graph diff engine."""
+from __future__ import annotations
+
+import json
+
+import networkx as nx
+import pytest
+from networkx.readwrite import json_graph
+
+from graphify.diff import (
+    diff_graphs,
+    render_diff,
+    _jaccard,
+    _diff_communities,
+    _diff_god_nodes,
+    _existing_communities,
+)
+
+
+def _save_graph(tmp_path, name: str, G: nx.Graph) -> str:
+    path = tmp_path / name
+    data = json_graph.node_link_data(G, edges="links")
+    data["graph"] = {"schema_version": "0.5.5"}
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# _jaccard
+# ---------------------------------------------------------------------------
+
+def test_jaccard_identical():
+    assert _jaccard({1, 2, 3}, {1, 2, 3}) == 1.0
+
+
+def test_jaccard_disjoint():
+    assert _jaccard({1, 2}, {3, 4}) == 0.0
+
+
+def test_jaccard_half():
+    assert _jaccard({1, 2, 3, 4}, {3, 4, 5, 6}) == 0.3333333333333333
+
+
+# ---------------------------------------------------------------------------
+# diff_graphs — no changes
+# ---------------------------------------------------------------------------
+
+def test_diff_no_changes(tmp_path):
+    G = nx.Graph()
+    G.add_node("a", label="A", file_type="code", source_file="a.py")
+    G.add_node("b", label="B", file_type="code", source_file="b.py")
+    G.add_edge("a", "b", relation="calls", confidence="EXTRACTED", source_file="a.py")
+
+    p = _save_graph(tmp_path, "old.json", G)
+    result = diff_graphs(p, p)
+
+    assert result["old_nodes"] == 2
+    assert result["new_nodes"] == 2
+    assert result["nodes_added"] == []
+    assert result["nodes_removed"] == []
+    assert result["nodes_changed"] == []
+    assert result["edges_added"] == []
+    assert result["edges_removed"] == []
+
+
+# ---------------------------------------------------------------------------
+# diff_graphs — node added / removed
+# ---------------------------------------------------------------------------
+
+def test_diff_node_added(tmp_path):
+    old = nx.Graph()
+    old.add_node("a", label="A", file_type="code", source_file="a.py")
+
+    new = nx.Graph()
+    new.add_node("a", label="A", file_type="code", source_file="a.py")
+    new.add_node("b", label="B", file_type="code", source_file="b.py")
+
+    p1 = _save_graph(tmp_path, "old.json", old)
+    p2 = _save_graph(tmp_path, "new.json", new)
+    result = diff_graphs(p1, p2)
+
+    assert len(result["nodes_added"]) == 1
+    assert result["nodes_added"][0]["id"] == "b"
+    assert result["nodes_removed"] == []
+
+
+def test_diff_node_removed(tmp_path):
+    old = nx.Graph()
+    old.add_node("a", label="A", file_type="code", source_file="a.py")
+    old.add_node("b", label="B", file_type="code", source_file="b.py")
+
+    new = nx.Graph()
+    new.add_node("a", label="A", file_type="code", source_file="a.py")
+
+    p1 = _save_graph(tmp_path, "old.json", old)
+    p2 = _save_graph(tmp_path, "new.json", new)
+    result = diff_graphs(p1, p2)
+
+    assert len(result["nodes_removed"]) == 1
+    assert result["nodes_removed"][0]["id"] == "b"
+    assert result["nodes_added"] == []
+
+
+# ---------------------------------------------------------------------------
+# diff_graphs — node attribute changed
+# ---------------------------------------------------------------------------
+
+def test_diff_node_changed(tmp_path):
+    old = nx.Graph()
+    old.add_node("a", label="A", file_type="code", source_file="a.py", community=0)
+
+    new = nx.Graph()
+    new.add_node("a", label="A", file_type="code", source_file="a.py", community=1)
+
+    p1 = _save_graph(tmp_path, "old.json", old)
+    p2 = _save_graph(tmp_path, "new.json", new)
+    result = diff_graphs(p1, p2)
+
+    assert len(result["nodes_changed"]) == 1
+    assert result["nodes_changed"][0]["id"] == "a"
+    assert result["nodes_changed"][0]["changes"]["community"]["old"] == 0
+    assert result["nodes_changed"][0]["changes"]["community"]["new"] == 1
+
+
+# ---------------------------------------------------------------------------
+# diff_graphs — edges added / removed
+# ---------------------------------------------------------------------------
+
+def test_diff_edge_added(tmp_path):
+    old = nx.Graph()
+    old.add_node("a", label="A", file_type="code", source_file="a.py")
+    old.add_node("b", label="B", file_type="code", source_file="b.py")
+
+    new = nx.Graph()
+    new.add_node("a", label="A", file_type="code", source_file="a.py")
+    new.add_node("b", label="B", file_type="code", source_file="b.py")
+    new.add_edge("a", "b", relation="calls", confidence="EXTRACTED", source_file="a.py")
+
+    p1 = _save_graph(tmp_path, "old.json", old)
+    p2 = _save_graph(tmp_path, "new.json", new)
+    result = diff_graphs(p1, p2)
+
+    assert len(result["edges_added"]) == 1
+    assert result["edges_added"][0]["source"] == "a"
+    assert result["edges_removed"] == []
+
+
+def test_diff_edge_removed(tmp_path):
+    old = nx.Graph()
+    old.add_node("a", label="A", file_type="code", source_file="a.py")
+    old.add_node("b", label="B", file_type="code", source_file="b.py")
+    old.add_edge("a", "b", relation="calls", confidence="EXTRACTED", source_file="a.py")
+
+    new = nx.Graph()
+    new.add_node("a", label="A", file_type="code", source_file="a.py")
+    new.add_node("b", label="B", file_type="code", source_file="b.py")
+
+    p1 = _save_graph(tmp_path, "old.json", old)
+    p2 = _save_graph(tmp_path, "new.json", new)
+    result = diff_graphs(p1, p2)
+
+    assert len(result["edges_removed"]) == 1
+    assert result["edges_removed"][0]["source"] == "a"
+    assert result["edges_added"] == []
+
+
+# ---------------------------------------------------------------------------
+# _diff_communities — split / merge
+# ---------------------------------------------------------------------------
+
+def test_community_split_detected():
+    old_G = nx.Graph()
+    old_G.add_nodes_from(["a", "b", "c", "d", "e", "f"])
+    new_G = nx.Graph()
+    new_G.add_nodes_from(["a", "b", "c", "d", "e", "f"])
+
+    old_communities = {0: ["a", "b", "c", "d", "e", "f"]}
+    new_communities = {0: ["a", "b", "c"], 1: ["d", "e", "f"]}
+
+    changed = _diff_communities(old_G, new_G, old_communities, new_communities)
+    assert any(c["type"] == "split" for c in changed)
+
+
+def test_community_merge_detected():
+    old_G = nx.Graph()
+    old_G.add_nodes_from(["a", "b", "c", "d", "e", "f"])
+    new_G = nx.Graph()
+    new_G.add_nodes_from(["a", "b", "c", "d", "e", "f"])
+
+    old_communities = {0: ["a", "b", "c"], 1: ["d", "e", "f"]}
+    new_communities = {0: ["a", "b", "c", "d", "e", "f"]}
+
+    changed = _diff_communities(old_G, new_G, old_communities, new_communities)
+    assert any(c["type"] == "merge" for c in changed)
+
+
+# ---------------------------------------------------------------------------
+# _diff_god_nodes
+# ---------------------------------------------------------------------------
+
+def test_god_node_promoted():
+    old_G = nx.Graph()
+    old_G.add_node("a", label="A", source_file="a.py")
+    old_G.add_node("b", label="B", source_file="b.py")
+    old_G.add_edge("a", "b", relation="calls", confidence="EXTRACTED", source_file="x.py")
+
+    new_G = nx.Graph()
+    new_G.add_node("a", label="A", source_file="a.py")
+    new_G.add_node("b", label="B", source_file="b.py")
+    new_G.add_node("c", label="C", source_file="c.py")
+    new_G.add_node("d", label="D", source_file="d.py")
+    new_G.add_edges_from([
+        ("a", "b", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+        ("a", "c", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+        ("b", "c", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+        ("c", "d", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+        ("d", "a", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+    ])
+    # c now has degree 3, a and d have degree 2, b has degree 2
+    # In old_G, a and b both have degree 1
+    # In new_G, top 2 are c (3) and one of a/b/d (2)
+    # So c should be promoted when going old -> new
+
+    result_forward = _diff_god_nodes(old_G, new_G, top_n=2)
+    assert any(g["id"] == "c" for g in result_forward["promoted"])
+
+
+def test_god_node_demoted():
+    old_G = nx.Graph()
+    old_G.add_node("a", label="A")
+    old_G.add_node("b", label="B")
+    old_G.add_edges_from([
+        ("a", "b", {"relation": "calls", "confidence": "EXTRACTED", "source_file": "x.py"}),
+    ])
+
+    new_G = nx.Graph()
+    new_G.add_node("a", label="A")
+    new_G.add_node("b", label="B")
+
+    result = _diff_god_nodes(old_G, new_G, top_n=2)
+    # Both nodes lost their edge; depending on ranking, one may be demoted
+    assert len(result["demoted"]) >= 0  # just ensure it runs without error
+
+
+# ---------------------------------------------------------------------------
+# render_diff
+# ---------------------------------------------------------------------------
+
+def test_render_diff_markdown():
+    diff = {
+        "old_nodes": 2,
+        "new_nodes": 3,
+        "nodes_added": [{"id": "c", "label": "C"}],
+        "nodes_removed": [],
+        "nodes_changed": [],
+        "old_edges": 1,
+        "new_edges": 2,
+        "edges_added": [{"source": "b", "target": "c", "relation": "calls"}],
+        "edges_removed": [],
+        "communities_changed": [],
+        "god_nodes_changed": {
+            "old_gods": [],
+            "new_gods": [],
+            "promoted": [],
+            "demoted": [],
+            "changed": [],
+        },
+        "schema_version": "0.5.5",
+    }
+    text = render_diff(diff, fmt="markdown")
+    assert "# Graph Diff Report" in text
+    assert "Nodes: 2 → 3" in text
+    assert "Edges: 1 → 2" in text
+    assert "Added (1)" in text
+
+
+def test_render_diff_json():
+    diff = {"old_nodes": 1, "new_nodes": 1, "nodes_added": [], "nodes_removed": [], "nodes_changed": [],
+            "old_edges": 0, "new_edges": 0, "edges_added": [], "edges_removed": [],
+            "communities_changed": [], "god_nodes_changed": {"old_gods": [], "new_gods": [], "promoted": [], "demoted": [], "changed": []},
+            "schema_version": "0.5.5"}
+    text = render_diff(diff, fmt="json")
+    parsed = json.loads(text)
+    assert parsed["old_nodes"] == 1
+
+
+def test_existing_communities_reads_from_node_attrs():
+    G = nx.Graph()
+    G.add_node("a", community=0)
+    G.add_node("b", community=0)
+    G.add_node("c", community=1)
+    G.add_node("d")  # no community attr — must be ignored
+    out = _existing_communities(G)
+    assert sorted(out[0]) == ["a", "b"]
+    assert out[1] == ["c"]
+    assert "d" not in {n for nodes in out.values() for n in nodes}
+
+
+def test_diff_communities_uses_stored_assignments():
+    # When both graphs already carry community labels, diff must use them
+    # verbatim instead of re-running cluster() — re-clustering is
+    # non-deterministic and would yield unstable splits/merges.
+    old_G = nx.Graph()
+    old_G.add_node("a", community=0)
+    old_G.add_node("b", community=0)
+    old_G.add_node("c", community=0)
+    old_G.add_node("d", community=0)
+    old_G.add_edge("a", "b")
+    old_G.add_edge("c", "d")
+
+    new_G = nx.Graph()
+    new_G.add_node("a", community=0)
+    new_G.add_node("b", community=0)
+    new_G.add_node("c", community=1)
+    new_G.add_node("d", community=1)
+    new_G.add_edge("a", "b")
+    new_G.add_edge("c", "d")
+
+    changes = _diff_communities(old_G, new_G)
+    splits = [c for c in changes if c["type"] == "split"]
+    assert len(splits) == 1
+    assert splits[0]["old_community"] == 0
+    new_ids = {nc["id"] for nc in splits[0]["new_communities"]}
+    assert new_ids == {0, 1}

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,70 @@
+import networkx as nx
+import numpy as np
+import pytest
+
+from graphify.embeddings import EmbeddingIndex, search_nodes
+
+
+def test_embedding_index_builds():
+    G = nx.Graph()
+    G.add_node("a", label="HTTP client")
+    G.add_node("b", label="Database connection")
+    G.add_node("c", label="File parser")
+
+    idx = EmbeddingIndex().build(G)
+    assert len(idx._embeddings) == 3
+
+
+def test_embedding_search():
+    G = nx.Graph()
+    G.add_node("a", label="HTTP client")
+    G.add_node("b", label="Database connection")
+    G.add_node("c", label="File parser")
+
+    idx = EmbeddingIndex().build(G)
+    results = idx.search("network request", top_k=2)
+    assert len(results) == 2
+    # HTTP client should be most relevant
+    ids = [r[0] for r in results]
+    assert "a" in ids
+
+
+def test_embedding_save_load(tmp_path):
+    G = nx.Graph()
+    G.add_node("a", label="HTTP client")
+
+    idx = EmbeddingIndex().build(G)
+    path = tmp_path / "embeddings.json"
+    idx.save(path)
+
+    idx2 = EmbeddingIndex().load(path)
+    assert len(idx2._embeddings) == 1
+    assert np.allclose(idx._embeddings["a"], idx2._embeddings["a"])
+
+
+def test_search_nodes_convenience():
+    G = nx.Graph()
+    G.add_node("a", label="HTTP client")
+    G.add_node("b", label="Database connection")
+
+    results = search_nodes(G, "web request", top_k=1)
+    assert len(results) == 1
+    assert results[0]["id"] == "a"
+
+
+def test_search_returns_empty_when_query_has_no_token_overlap():
+    # BoW fallback builds vocab from indexed labels only. A query with
+    # zero overlap must not surface arbitrary top-k nodes with score=0.
+    G = nx.Graph()
+    G.add_node("a", label="HTTP client")
+    G.add_node("b", label="Database connection")
+
+    idx = EmbeddingIndex()
+    # Force the BoW path regardless of whether sentence-transformers is
+    # installed in this environment.
+    idx._model = None
+    idx._load_model = lambda: None  # type: ignore[method-assign]
+    idx.build(G)
+
+    results = idx.search("xyzzy_unknown_token", top_k=5)
+    assert results == []

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,122 @@
+"""Tests for graphify.plugins — plugin discovery and registration."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.plugins import (
+    load_plugins,
+    get_extractor,
+    list_plugins,
+    reset_registry,
+    register_extractor,
+)
+
+
+def test_register_and_get_extractor():
+    reset_registry()
+
+    def fake_extract(path: Path) -> dict:
+        return {"nodes": [{"id": "fake", "label": "Fake", "file_type": "code", "source_file": str(path)}], "edges": []}
+
+    register_extractor(".fake", fake_extract)
+    fn = get_extractor(".fake")
+    assert fn is not None
+    result = fn(Path("test.fake"))
+    assert result["nodes"][0]["id"] == "fake"
+
+
+def test_get_extractor_unknown():
+    reset_registry()
+    assert get_extractor(".nonexistent") is None
+
+
+def test_load_plugins_from_directory(tmp_path, monkeypatch):
+    reset_registry()
+    monkeypatch.setenv("GRAPHIFY_ENABLE_PLUGINS", "1")
+    plugin_dir = tmp_path / ".graphify" / "plugins"
+    plugin_dir.mkdir(parents=True)
+
+    plugin_file = plugin_dir / "test_plugin.py"
+    plugin_file.write_text(
+        '''
+def register():
+    return {".test": extract_test}
+
+def extract_test(path):
+    return {"nodes": [{"id": "test", "label": "Test", "file_type": "code", "source_file": str(path)}], "edges": []}
+''',
+        encoding="utf-8",
+    )
+
+    # Override default plugin dirs temporarily
+    import graphify.plugins as plugins_mod
+    original_dirs = plugins_mod._DEFAULT_PLUGIN_DIRS
+    plugins_mod._DEFAULT_PLUGIN_DIRS = [plugin_dir]
+    try:
+        registry = load_plugins()
+        assert ".test" in registry
+        result = registry[".test"](Path("x.test"))
+        assert result["nodes"][0]["id"] == "test"
+    finally:
+        plugins_mod._DEFAULT_PLUGIN_DIRS = original_dirs
+        reset_registry()
+
+
+def test_load_plugins_disabled_by_default(tmp_path, monkeypatch):
+    # Without GRAPHIFY_ENABLE_PLUGINS set, a plugin file on disk must not
+    # be auto-imported — auto-discovery would be a code-execution sink.
+    reset_registry()
+    monkeypatch.delenv("GRAPHIFY_ENABLE_PLUGINS", raising=False)
+    plugin_dir = tmp_path / ".graphify" / "plugins"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "evil.py").write_text(
+        "raise RuntimeError('plugin should not have been imported')",
+        encoding="utf-8",
+    )
+
+    import graphify.plugins as plugins_mod
+    original_dirs = plugins_mod._DEFAULT_PLUGIN_DIRS
+    plugins_mod._DEFAULT_PLUGIN_DIRS = [plugin_dir]
+    try:
+        registry = load_plugins()
+        assert registry == {}
+    finally:
+        plugins_mod._DEFAULT_PLUGIN_DIRS = original_dirs
+        reset_registry()
+
+
+def test_list_plugins(tmp_path):
+    reset_registry()
+    plugin_dir = tmp_path / "graphify-plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "foo.py").write_text("# plugin", encoding="utf-8")
+    (plugin_dir / "_private.py").write_text("# private", encoding="utf-8")
+
+    import graphify.plugins as plugins_mod
+    original_dirs = plugins_mod._DEFAULT_PLUGIN_DIRS
+    plugins_mod._DEFAULT_PLUGIN_DIRS = [plugin_dir]
+    try:
+        found = list_plugins()
+        assert any("foo.py" in p for p in found)
+        assert not any("_private.py" in p for p in found)
+    finally:
+        plugins_mod._DEFAULT_PLUGIN_DIRS = original_dirs
+        reset_registry()
+
+
+def test_plugin_bad_register_is_graceful(tmp_path, monkeypatch):
+    reset_registry()
+    monkeypatch.setenv("GRAPHIFY_ENABLE_PLUGINS", "1")
+    plugin_dir = tmp_path / ".graphify" / "plugins"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "bad.py").write_text("# no register function", encoding="utf-8")
+
+    import graphify.plugins as plugins_mod
+    original_dirs = plugins_mod._DEFAULT_PLUGIN_DIRS
+    plugins_mod._DEFAULT_PLUGIN_DIRS = [plugin_dir]
+    try:
+        registry = load_plugins()
+        assert ".bad" not in registry  # gracefully skipped
+    finally:
+        plugins_mod._DEFAULT_PLUGIN_DIRS = original_dirs
+        reset_registry()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,224 @@
+"""Tests for graphify.store — GraphStore abstraction layer."""
+from __future__ import annotations
+
+import json
+
+import networkx as nx
+import pytest
+from networkx.readwrite import json_graph
+
+from graphify.store import MemoryStore, SQLiteStore, store_for, migrate_json_to_sqlite
+
+
+def _make_graph() -> nx.Graph:
+    G = nx.Graph()
+    G.add_node("a", label="A", file_type="code", source_file="a.py")
+    G.add_node("b", label="B", file_type="code", source_file="b.py")
+    G.add_node("c", label="C", file_type="document", source_file="c.md")
+    G.add_edge("a", "b", relation="calls", confidence="EXTRACTED", source_file="a.py")
+    G.add_edge("b", "c", relation="references", confidence="INFERRED", source_file="b.py")
+    return G
+
+
+# ---------------------------------------------------------------------------
+# MemoryStore
+# ---------------------------------------------------------------------------
+
+def test_memory_store_roundtrip(tmp_path):
+    G = _make_graph()
+    communities = {0: ["a", "b"], 1: ["c"]}
+    path = tmp_path / "graph.json"
+    store = MemoryStore(str(path))
+    store.save(G, communities, {"key": "value"})
+
+    G2, comm2, meta = store.load()
+    assert G2.number_of_nodes() == 3
+    assert G2.number_of_edges() == 2
+    assert comm2 == communities
+    assert meta.get("key") == "value"
+    assert path.exists()
+
+
+def test_memory_store_query_nodes_by_label(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {})
+    results = store.query_nodes(label="A")
+    assert len(results) == 1
+    assert results[0]["id"] == "a"
+
+
+def test_memory_store_query_nodes_by_file_type(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {})
+    results = store.query_nodes(file_type="document")
+    assert len(results) == 1
+    assert results[0]["id"] == "c"
+
+
+def test_memory_store_query_nodes_by_community(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {0: ["a"], 1: ["b", "c"]})
+    results = store.query_nodes(community=1)
+    assert len(results) == 2
+
+
+def test_memory_store_query_edges_by_relation(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {})
+    results = store.query_edges(relation="calls")
+    assert len(results) == 1
+    assert results[0]["source"] == "a"
+
+
+def test_memory_store_get_neighbors(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {})
+    neighbors = store.get_neighbors("a")
+    assert len(neighbors) == 1
+    assert neighbors[0]["id"] == "b"
+
+
+def test_memory_store_get_stats(tmp_path):
+    G = _make_graph()
+    store = MemoryStore(str(tmp_path / "g.json"))
+    store.save(G, {0: ["a", "b", "c"]}, {})
+    stats = store.get_stats()
+    assert stats["nodes"] == 3
+    assert stats["edges"] == 2
+    assert stats["communities"] == 1
+
+
+# ---------------------------------------------------------------------------
+# SQLiteStore
+# ---------------------------------------------------------------------------
+
+def test_sqlite_store_roundtrip(tmp_path):
+    G = _make_graph()
+    communities = {0: ["a", "b"], 1: ["c"]}
+    db = tmp_path / "graph.db"
+    store = SQLiteStore(str(db))
+    store.save(G, communities, {"key": "value"})
+
+    G2, comm2, meta = store.load()
+    assert G2.number_of_nodes() == 3
+    assert G2.number_of_edges() == 2
+    assert sorted(comm2[0]) == ["a", "b"]
+    assert sorted(comm2[1]) == ["c"]
+    assert meta.get("key") == "value"
+    assert db.exists()
+
+
+def test_sqlite_store_query_nodes_by_label(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {})
+    results = store.query_nodes(label="B")
+    assert len(results) == 1
+    assert results[0]["id"] == "b"
+
+
+def test_sqlite_store_query_nodes_by_file_type(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {})
+    results = store.query_nodes(file_type="document")
+    assert len(results) == 1
+    assert results[0]["id"] == "c"
+
+
+def test_sqlite_store_query_nodes_by_community(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {0: ["a"], 1: ["b", "c"]})
+    results = store.query_nodes(community=1)
+    ids = {r["id"] for r in results}
+    assert ids == {"b", "c"}
+
+
+def test_sqlite_store_query_edges_by_relation(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {})
+    results = store.query_edges(relation="references")
+    assert len(results) == 1
+    assert results[0]["source"] == "b"
+
+
+def test_sqlite_store_get_neighbors(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {})
+    neighbors = store.get_neighbors("b")
+    ids = {n["id"] for n in neighbors}
+    assert ids == {"a", "c"}
+
+
+def test_sqlite_store_get_stats(tmp_path):
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {0: ["a", "b", "c"]}, {})
+    stats = store.get_stats()
+    assert stats["nodes"] == 3
+    assert stats["edges"] == 2
+    assert stats["communities"] == 1
+
+
+def test_migrate_json_to_sqlite(tmp_path):
+    G = _make_graph()
+    data = json_graph.node_link_data(G, edges="links")
+    data["graph"] = {"schema_version": "0.5.5"}
+    json_path = tmp_path / "graph.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+
+    db_path = tmp_path / "graph.db"
+    store = migrate_json_to_sqlite(str(json_path), str(db_path))
+    stats = store.get_stats()
+    assert stats["nodes"] == 3
+    assert stats["edges"] == 2
+    assert db_path.exists()
+
+
+def test_store_for_dispatch():
+    assert isinstance(store_for("graph.json"), MemoryStore)
+    assert isinstance(store_for("graph.db"), SQLiteStore)
+    with pytest.raises(ValueError):
+        store_for("graph.xml")
+
+
+def test_sqlite_store_concurrent_reads(tmp_path):
+    # Each worker thread must get its own sqlite3 connection. Sharing a
+    # single connection across threads (the previous behavior) raises
+    # ProgrammingError on cursor reuse — a regression here surfaces as
+    # any thread reporting a non-3 node count or any exception.
+    import threading
+
+    G = _make_graph()
+    store = SQLiteStore(str(tmp_path / "g.db"))
+    store.save(G, {0: ["a", "b", "c"]})
+
+    errors: list[BaseException] = []
+    counts: list[int] = []
+
+    def worker():
+        try:
+            for _ in range(20):
+                stats = store.get_stats()
+                counts.append(stats["nodes"])
+                rows = store.query_nodes(file_type="code")
+                assert len(rows) == 2
+        except BaseException as exc:  # noqa: BLE001 — surface any error
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert counts and all(c == 3 for c in counts)


### PR DESCRIPTION
## Summary

Repo audit on `v5` surfaced a CI gap, several silent-failure paths, and a few APIs whose docstrings overpromised what the implementation delivered. This PR addresses 9 of them in atomic commits.

## What changed

| # | Fix | Why |
|---|---|---|
| 1 | CI triggers on `v5` + adds `dashboard`/`embeddings` extras | CI was listed for v1..v4+main only — no tests ran on `v5`. Dashboard/embedding tests also need `fastapi`/`numpy` installed. |
| 2 | Dashboard `assert _G is not None` → `HTTPException` | Asserts are stripped under `python -O`, leaving handlers to AttributeError on `None`. |
| 3 | Cypher direction enforced via `_src`/`_tgt` | Parser never recorded `->`; execution iterated NetworkX canonical order, so directional MATCH silently returned back-edges. |
| 4 | Embeddings: persist BoW vocab + drop zero-norm queries | BoW search rebuilt vocab per call (dim mismatch crashed search), and even when shapes lined up, no-overlap queries returned arbitrary top-k with `score=0.0`. |
| 5 | Plugin auto-discovery gated by `GRAPHIFY_ENABLE_PLUGINS=1` | `~/.graphify/plugins/*.py` was auto-`exec_module`'d on every run — code-execution sink, especially with the post-commit hook installed. |
| 6 | `.gitignore` `graph.db` and `_debug_ts.py` | Both leaked into the working tree as untracked dev artifacts. |
| 7 | `SQLiteStore` per-thread connections via `threading.local` | Cached one connection with `check_same_thread=False` and no lock — class doc claimed concurrent-safe, it wasn't. |
| 8 | `_diff_communities` prefers stored community attrs | Re-running Leiden/Louvain made `splits/merges` non-deterministic; two diffs of the same pair produced different reports. |
| 9 | Dashboard caches `EmbeddingIndex` across `/api/search` | Each request rebuilt the index — with sentence-transformers installed, that meant reloading the model every search. |

## Test plan

- [x] `pytest tests/ --ignore=tests/test_install.py` → 529 passed, 5 skipped
- [x] New regression tests added for items 3, 4, 5, 7, 8, 9 (direction skip, BoW no-overlap, plugin gate, threaded reads, stored-community diff, cached index)
- [x] Verified item 2 under `python -O` — handlers raise 503 instead of stripped-assert AttributeError
- [x] Verified item 4 BoW path explicitly with `_load_model` stubbed to None
- [ ] CI green on the new `v5` trigger

## Notes

Out of scope but flagged in the audit and worth a follow-up:
- `SQLiteStore.search_nodes` claims FTS but uses `LIKE '%q%'` — needs an FTS5 virtual table.
- `extract_incremental` has dead delta logic (`to_extract` computed and unused).
- `plugins.load_plugins` caches the registry forever; new plugin files dropped mid-session aren't picked up until process restart.
- `compress.expand_super_node` returns a lossy graph without signaling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)