### PR TITLE
filter cross-language INFERRED calls in Surprising Connections (#630)

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -123,6 +123,61 @@ def _file_category(path: str) -> str:
     return "doc"
 
 
+# Map a file extension to its language ecosystem. Files in the same ecosystem
+# can plausibly call each other directly (TS↔JS, Kotlin↔Java, ObjC↔C/C++).
+# Files in different ecosystems generally cannot — a Python→TypeScript `calls`
+# edge with no import bridge is almost always resolver pollution from a
+# shared function name.
+_LANG_ECOSYSTEM = {
+    ".ts": "js", ".tsx": "js", ".js": "js", ".jsx": "js",
+    ".mjs": "js", ".ejs": "js", ".vue": "js", ".svelte": "js",
+    ".java": "jvm", ".kt": "jvm", ".kts": "jvm", ".scala": "jvm",
+    ".c": "c", ".cpp": "c", ".cc": "c", ".cxx": "c",
+    ".h": "c", ".hpp": "c", ".m": "c", ".mm": "c",
+    ".py": "python", ".pyi": "python",
+    ".rs": "rust",
+    ".go": "go",
+    ".rb": "ruby",
+    ".swift": "swift",
+    ".cs": "csharp",
+    ".php": "php",
+    ".lua": "lua",
+    ".zig": "zig",
+    ".ps1": "powershell",
+    ".ex": "elixir", ".exs": "elixir",
+    ".jl": "julia",
+    ".dart": "dart",
+    ".v": "v", ".sv": "v",
+}
+
+
+def _file_ecosystem(path: str) -> str | None:
+    """Return the language ecosystem for a source file path, or None if not code."""
+    ext = ("." + path.rsplit(".", 1)[-1].lower()) if "." in path else ""
+    return _LANG_ECOSYSTEM.get(ext)
+
+
+def _is_cross_language_call(u_source: str, v_source: str) -> bool:
+    """True when both files are code in different language ecosystems."""
+    eu = _file_ecosystem(u_source)
+    ev = _file_ecosystem(v_source)
+    return eu is not None and ev is not None and eu != ev
+
+
+def _bridged_file_pairs(G: nx.Graph) -> set[frozenset[str]]:
+    """Source-file pairs connected by an explicit import edge — evidence the
+    two files actually interoperate, regardless of language."""
+    pairs: set[frozenset[str]] = set()
+    for u, v, data in G.edges(data=True):
+        if data.get("relation") not in ("imports", "imports_from"):
+            continue
+        u_src = G.nodes[u].get("source_file", "")
+        v_src = G.nodes[v].get("source_file", "")
+        if u_src and v_src and u_src != v_src:
+            pairs.add(frozenset({u_src, v_src}))
+    return pairs
+
+
 def _top_level_dir(path: str) -> str:
     """Return the first path component - used to detect cross-repo edges."""
     return path.split("/")[0] if "/" in path else path
@@ -199,6 +254,7 @@ def _cross_file_surprises(G: nx.Graph, communities: dict[int, list[str]], top_n:
     Each result includes a 'why' field explaining what makes it non-obvious.
     """
     node_community = _node_community_map(communities)
+    bridged_pairs = _bridged_file_pairs(G)
     candidates = []
 
     for u, v, data in G.edges(data=True):
@@ -214,6 +270,17 @@ def _cross_file_surprises(G: nx.Graph, communities: dict[int, list[str]], top_n:
         v_source = G.nodes[v].get("source_file", "")
 
         if not u_source or not v_source or u_source == v_source:
+            continue
+
+        # Skip cross-language INFERRED `calls` edges with no import bridge.
+        # Without runtime/FFI evidence these are almost always resolver
+        # pollution from a function name shared across languages (#630).
+        if (
+            relation == "calls"
+            and data.get("confidence") == "INFERRED"
+            and _is_cross_language_call(u_source, v_source)
+            and frozenset({u_source, v_source}) not in bridged_pairs
+        ):
             continue
 
         score, reasons = _surprise_score(G, u, v, data, node_community, u_source, v_source)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -160,6 +160,64 @@ def test_is_concept_node_real_file():
     assert _is_concept_node(G, "n1") is False
 
 
+def test_surprising_connections_filters_cross_language_inferred_calls():
+    """A Python→TypeScript INFERRED `calls` edge with no import bridge must
+    not be promoted in Surprising Connections — it is almost always resolver
+    pollution from a shared function name (#630)."""
+    G = nx.Graph()
+    # Python helper
+    G.add_node("py_normalize", label="normalize", source_file="scripts/build.py", file_type="code")
+    # TypeScript route handler with a colliding name
+    G.add_node("ts_normalize", label="normalize", source_file="src/app/api/report/route.ts", file_type="code")
+    # An unrelated, plausible cross-file edge so the function still has candidates to choose from
+    G.add_node("py_a", label="parse_args", source_file="scripts/build.py", file_type="code")
+    G.add_node("py_b", label="load_config", source_file="scripts/config.py", file_type="code")
+    G.add_edge("py_a", "py_b", relation="calls", confidence="INFERRED",
+               source_file="scripts/build.py", weight=1.0)
+    # The bogus cross-language inferred call
+    G.add_edge("py_normalize", "ts_normalize", relation="calls", confidence="INFERRED",
+               source_file="scripts/build.py", weight=1.0)
+
+    surprises = surprising_connections(G, {})
+    for s in surprises:
+        files = set(s["source_files"])
+        assert files != {"scripts/build.py", "src/app/api/report/route.ts"}, (
+            "cross-language INFERRED calls edge should be filtered out"
+        )
+
+
+def test_surprising_connections_keeps_cross_language_call_with_import_bridge():
+    """If an explicit import edge connects the two source files, a cross-language
+    INFERRED `calls` edge between them is plausible interop and should be kept."""
+    G = nx.Graph()
+    G.add_node("py_fn", label="run", source_file="bridge/host.py", file_type="code")
+    G.add_node("ts_fn", label="run", source_file="bridge/worker.ts", file_type="code")
+    # Module-level nodes carrying the import edge between the two files
+    G.add_node("py_mod", label="host", source_file="bridge/host.py", file_type="code")
+    G.add_node("ts_mod", label="worker", source_file="bridge/worker.ts", file_type="code")
+    G.add_edge("py_mod", "ts_mod", relation="imports", confidence="EXTRACTED",
+               source_file="bridge/host.py", weight=1.0)
+    G.add_edge("py_fn", "ts_fn", relation="calls", confidence="INFERRED",
+               source_file="bridge/host.py", weight=1.0)
+
+    surprises = surprising_connections(G, {})
+    file_pairs = {frozenset(s["source_files"]) for s in surprises}
+    assert frozenset({"bridge/host.py", "bridge/worker.ts"}) in file_pairs
+
+
+def test_surprising_connections_keeps_same_ecosystem_inferred_calls():
+    """TS↔JS calls share an ecosystem and remain valid even when INFERRED."""
+    G = nx.Graph()
+    G.add_node("ts_fn", label="render", source_file="src/page.tsx", file_type="code")
+    G.add_node("js_fn", label="render", source_file="src/util.js", file_type="code")
+    G.add_edge("ts_fn", "js_fn", relation="calls", confidence="INFERRED",
+               source_file="src/page.tsx", weight=1.0)
+
+    surprises = surprising_connections(G, {})
+    file_pairs = {frozenset(s["source_files"]) for s in surprises}
+    assert frozenset({"src/page.tsx", "src/util.js"}) in file_pairs
+
+
 def test_surprising_connections_have_required_keys():
     G = make_graph()
     communities = cluster(G)


### PR DESCRIPTION
## Summary

Fixes #630.

`GRAPH_REPORT.md`'s "Surprising Connections" section can promote impossible cross-language `INFERRED calls` edges (e.g. a Python helper named `normalize` linked to a TypeScript handler with a colliding name) over real, mundane edges, because `_surprise_score` rewards `INFERRED` confidence and cross-file location without checking whether the source/target language pair is plausible.

This PR filters those edges in `_cross_file_surprises()` unless an explicit import bridge between the two source files provides interop evidence.

## Approach

- Added a `_LANG_ECOSYSTEM` map grouping freely-interoperable extensions: TS/JS family, JVM (Java/Kotlin/Scala), C/C++/ObjC. Same-ecosystem inferred calls remain untouched.
- Added `_bridged_file_pairs(G)` which collects source-file pairs connected by `imports` / `imports_from` edges — concrete evidence the two files actually interop (FFI, generated bindings, configured bridge, etc.).
- In `_cross_file_surprises`, skip an edge when **all** of the following hold:
  - `relation == "calls"`
  - `confidence == "INFERRED"`
  - the two source files are in different ecosystems
  - no import edge connects the two files

This preserves the underlying graph as an audit artifact (the edge is still there for tooling that wants it) while keeping the report's first-pass navigation signal cleaner. AMBIGUOUS edges, EXTRACTED edges, semantic-similarity edges, and same-ecosystem inferred calls are all unaffected.

## Test plan

- [x] New regression test: Python→TypeScript `INFERRED calls` with no bridge is filtered out of Surprising Connections.
- [x] New regression test: cross-language `INFERRED calls` with an `imports` edge between the source files is kept (interop is plausible).
- [x] New regression test: TS↔JS `INFERRED calls` (same ecosystem) is kept.
- [x] Full suite green: `444 passed`.