### PR TITLE
Add --force flag (and GRAPHIFY_FORCE env var) to graphify update + git hooks

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1001,6 +1001,8 @@ def main() -> None:
         print("    --dir <path>            target directory (default: ./raw)")
         print("  watch <path>            watch a folder and rebuild the graph on code changes")
         print("  update <path>           re-extract code files and update the graph (no LLM needed)")
+        print("    --force                 overwrite graph.json even if the rebuild has fewer nodes")
+        print("                            (also: GRAPHIFY_FORCE=1 env var; use after refactors that delete code)")
         print("  cluster-only <path>     rerun clustering on an existing graph.json and regenerate report")
         print("  query \"<question>\"       BFS traversal of graph.json for a question")
         print("    --dfs                   use depth-first instead of breadth-first")
@@ -1411,8 +1413,17 @@ def main() -> None:
         print(f"Done — {len(communities)} communities. GRAPH_REPORT.md, graph.json and graph.html updated.")
 
     elif cmd == "update":
-        if len(sys.argv) > 2:
-            watch_path = Path(sys.argv[2])
+        # Strip optional --force flag (or honor GRAPHIFY_FORCE env var) before
+        # interpreting positional <path>. Force bypasses the node-count safety
+        # check in to_json — use it after refactors that legitimately shrink
+        # the graph (renames, package deletions).
+        force = os.environ.get("GRAPHIFY_FORCE", "").lower() in ("1", "true", "yes")
+        argv = list(sys.argv)
+        if "--force" in argv[2:]:
+            force = True
+            argv = [a for a in argv if a != "--force"]
+        if len(argv) > 2:
+            watch_path = Path(argv[2])
         else:
             # Try to recover the scan root saved by the last full build
             saved = Path("graphify-out/.graphify_root")
@@ -1425,7 +1436,7 @@ def main() -> None:
             sys.exit(1)
         from graphify.watch import _rebuild_code
         print(f"Re-extracting code files in {watch_path} (no LLM needed)...")
-        ok = _rebuild_code(watch_path)
+        ok = _rebuild_code(watch_path, force=force)
         if ok:
             print("Code graph updated. For doc/paper/image changes run /graphify --update in your AI assistant.")
             if not os.environ.get("MOONSHOT_API_KEY") and not os.environ.get("GRAPHIFY_NO_TIPS"):

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -75,7 +75,8 @@ print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
 
 try:
     from graphify.watch import _rebuild_code
-    _rebuild_code(Path('.'))
+    force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _rebuild_code(Path('.'), force=force)
 except Exception as exc:
     print(f'[graphify hook] Rebuild failed: {exc}')
     sys.exit(1)
@@ -115,9 +116,10 @@ echo "[graphify] Branch switched - rebuilding knowledge graph (code files)..."
 $GRAPHIFY_PYTHON -c "
 from graphify.watch import _rebuild_code
 from pathlib import Path
-import sys
+import os, sys
 try:
-    _rebuild_code(Path('.'))
+    force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _rebuild_code(Path('.'), force=force)
 except Exception as exc:
     print(f'[graphify] Rebuild failed: {exc}')
     sys.exit(1)

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -33,8 +33,12 @@ def _relativize_source_files(payload: dict, root: Path) -> None:
                 continue
 
 
-def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
+def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False, force: bool = False) -> bool:
     """Re-run AST extraction + build + cluster + report for code files. No LLM needed.
+
+    When ``force`` is True, the node-count safety check in ``to_json`` is bypassed
+    and the rebuilt graph overwrites ``graph.json`` even if it has fewer nodes.
+    Use this for legitimate shrinks (refactors that delete code).
 
     Returns True on success, False on error.
     """
@@ -100,7 +104,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False) -> bool:
         out.mkdir(exist_ok=True)
         (out / ".graphify_root").write_text(str(watch_root), encoding="utf-8")
 
-        json_written = to_json(G, communities, str(out / "graph.json"))
+        json_written = to_json(G, communities, str(out / "graph.json"), force=force)
         if not json_written:
             return False
 


### PR DESCRIPTION
## Summary

The node-count safety check in `to_json` (added in #479) refuses to overwrite `graph.json` when the rebuild has fewer nodes. The warning text directs users to *\"Pass force=True to override\"* — but `force` was only reachable from the Python API, with **no CLI escape hatch**.

This is painful for legitimate shrinks: refactors that delete or rename packages produce a smaller graph by design. Without a CLI flag, users get stuck unless they monkey-patch `to_json`.

## Changes

- `watch._rebuild_code`: accept `force` kwarg, propagate to `to_json`.
- `__main__` update handler: parse `--force`; also honor `GRAPHIFY_FORCE` env var.
- Hooks (post-commit + post-checkout): honor `GRAPHIFY_FORCE` env var, so automated rebuilds can opt in without editing the hook script. (Useful when a refactor PR's commit triggers the post-commit hook.)
- Help text updated.

## Reproduction (before this PR)

```bash
# After a refactor that legitimately deletes packages:
$ graphify update .
[graphify] WARNING: new graph has 1125 nodes but existing graph.json has 1139.
  Refusing to overwrite — you may be missing chunk files from a previous session.
  Pass force=True to override.
Nothing to update or rebuild failed — check output above.

# No CLI flag accepted:
$ graphify update . --force
(same warning — flag silently ignored)

$ FORCE=1 graphify update .
(same warning)
```

The only escape was a Python monkey-patch:

```python
import graphify.export as ex
orig = ex.to_json
ex.to_json = lambda *a, **k: orig(*a, force=True)
```

## After this PR

```bash
$ graphify update . --force
[graphify watch] Rebuilt: 1125 nodes, 1591 edges, 90 communities
[graphify watch] graph.json, graph.html and GRAPH_REPORT.md updated in graphify-out

# or
$ GRAPHIFY_FORCE=1 graphify update .
(same — works)

# or for the post-commit hook:
$ GRAPHIFY_FORCE=1 git commit -m \"refactor: delete dead package\"
(rebuild succeeds, no manual intervention)
```

## Tested

Verified all three paths against a real corpus (200 files, ~187k words) on macOS / Python 3.12:

- No flag → still refuses (existing behavior preserved)
- `--force` → overwrites cleanly
- `GRAPHIFY_FORCE=1` → overwrites cleanly
- Help text shows the new option

## Test plan

- [ ] `graphify update . --force` overwrites a smaller graph
- [ ] `GRAPHIFY_FORCE=1 graphify update .` overwrites a smaller graph
- [ ] `graphify update .` (no flag) still refuses on shrink — safety preserved
- [ ] `GRAPHIFY_FORCE=1` honored by the post-commit hook script

## Notes

- Watch mode (`graphify watch`) intentionally **not** changed. The continuous file watcher is incremental by nature; forcing every rebuild would defeat the safety check entirely. If desired in a follow-up PR, it can read `GRAPHIFY_FORCE` at startup.
- Closes the gap referenced by the warning text in #479.