### PR TITLE
fix(detect): hermetic .graphifyignore discovery + correct gitignore   semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ graphify-out/
 .graphify_*.json
 .graphify_python
 .claude/
+.gemini/
 skills/
 docs/superpowers/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dist/
 *.generated.py
 ```
 
-Same syntax as `.gitignore`. You can keep a single `.graphifyignore` at your repo root — patterns work correctly even when graphify is run on a subfolder.
+Full gitignore semantics: `**` crosses directories, `!` negates (last pattern wins), trailing `/` matches directories only, leading `/` anchors to the root. Place it at your repo root — graphify walks up to the `.git` boundary to find it, so patterns apply correctly even when run on a subfolder.
 
 ## How it works
 
@@ -183,7 +183,7 @@ graphify-out/cost.json
 3. Install the post-commit hook (`graphify hook install`) so the graph rebuilds automatically after code changes — no LLM calls needed for code-only updates.
 4. For doc/paper changes, whoever edits the files runs `/graphify --update` to refresh semantic nodes.
 
-**Excluding paths** — create `.graphifyignore` in your project root (same syntax as `.gitignore`). Files matching those patterns are skipped during detection and extraction.
+**Excluding paths** — create `.graphifyignore` in your project root. It follows the full gitignore specification: `**` globs, `!` negation with last-match-wins ordering, trailing `/` for directory-only patterns, leading `/` anchored to root. Files matching those patterns are skipped during detection and extraction.
 
 ```
 # .graphifyignore example

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -678,9 +678,20 @@ def _trim_trailing_spaces(s: str) -> str:
     return s
 
 
+_VCS_MARKERS = frozenset({".git", ".hg", ".svn", "_darcs", ".fossil"})
+
+
 def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
     """
     Discover and read .graphifyignore files from root and ancestors.
+
+    Boundary rule:
+    - VCS root found above scan dir (.git/.hg/.svn): walk up to it and load
+      all .graphifyignore files along the way (handles monorepos where a
+      global ignore file lives at the repo root).
+    - No VCS root above scan dir: treat scan root as the ceiling and load
+      only its own .graphifyignore, preventing accidental pickup of
+      home-directory-level ignore files for non-VCS projects.
 
     Parameters
     ----------
@@ -690,25 +701,39 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
     Returns
     -------
     list of tuple[Path, str]
-        A list of (anchor_dir, pattern) pairs. Search stops at .git boundaries.
+        A list of (anchor_dir, pattern) pairs ordered from outermost to
+        innermost, so that inner patterns take precedence (last-match-wins).
     """
-    patterns: list[tuple[Path, str]] = []
-    current = root.resolve()
+    resolved_root = root.resolve()
+
+    # Walk upward collecting candidates; stop when a VCS root is found.
+    candidates: list[Path] = [resolved_root]
+    current = resolved_root
+    vcs_found = False
+
     while True:
-        ignore_file = current / ".graphifyignore"
+        parent = current.parent
+        if parent == current:
+            break  # filesystem root reached without finding VCS
+        current = parent
+        candidates.append(current)
+        if any((current / m).exists() for m in _VCS_MARKERS):
+            vcs_found = True
+            break
+
+    # No VCS root anywhere above: scan root is the ceiling.
+    dirs = candidates if vcs_found else [resolved_root]
+
+    patterns: list[tuple[Path, str]] = []
+    for d in reversed(dirs):
+        ignore_file = d / ".graphifyignore"
         if ignore_file.exists():
             for line in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
                 if line and not line.startswith("#"):
                     line = _trim_trailing_spaces(line)
                     if line:
-                        patterns.append((current, line))
-        # Stop climbing once we've processed the git repo root
-        if (current / ".git").exists():
-            break
-        parent = current.parent
-        if parent == current:
-            break  # filesystem root
-        current = parent
+                        patterns.append((d, line))
+
     return patterns
 
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -547,7 +547,12 @@ def _pattern_to_regex(p: str) -> re.Pattern:
     while i < len(p):
         c = p[i]
         if c == '\\' and i + 1 < len(p):
-            result.append(re.escape(p[i + 1]))
+            # Special Git escape characters: preserve as escapes.
+            # Otherwise, treat backslash as a directory separator (Windows support).
+            if p[i+1] in (' ', '#', '!', '*', '?', '[', '\\'):
+                result.append(re.escape(p[i + 1]))
+            else:
+                result.append('/')
             i += 2
         elif c == '*' and i + 1 < len(p) and p[i + 1] == '*':
             # ** is only special at the pattern start or immediately after /. 
@@ -589,6 +594,13 @@ def _pattern_to_regex(p: str) -> re.Pattern:
                 j += 1
             while j < len(p) and p[j] != ']':
                 j += 1
+            
+            if j == len(p):
+                # Unclosed bracket: treat as literal [
+                result.append(re.escape('['))
+                i += 1
+                continue
+
             cls = p[i:j + 1]
             if negate:
                 cls = '[^' + cls[2:]  # [!xyz] → [^xyz] for Python re
@@ -598,7 +610,13 @@ def _pattern_to_regex(p: str) -> re.Pattern:
         else:
             result.append(re.escape(c))
             i += 1
-    return re.compile(''.join(result))
+
+    # Use case-insensitive matching on Windows and macOS
+    import sys
+    re_flags = 0
+    if sys.platform in ("win32", "darwin"):
+        re_flags = re.IGNORECASE
+    return re.compile(''.join(result), re_flags)
 
 
 def _match_ignore_pattern(rel: str, pattern: str, is_dir: bool) -> bool:

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -1,6 +1,11 @@
-# file discovery, type classification, and corpus health checks
+"""
+File discovery, type classification, and corpus health checks.
+
+This module provides the core logic for scanning directories, identifying 
+relevant files for the knowledge graph, and handling incremental updates 
+while respecting exclusion rules and built-in noise filters.
+"""
 from __future__ import annotations
-import fnmatch
 import json
 import os
 import re
@@ -9,6 +14,7 @@ from pathlib import Path
 
 
 class FileType(str, Enum):
+    """Enumeration of supported file categories for graph extraction."""
     CODE = "code"
     DOCUMENT = "document"
     PAPER = "paper"
@@ -18,6 +24,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
+# Supported extensions for automated classification
 CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
@@ -25,11 +32,12 @@ IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}
 VIDEO_EXTENSIONS = {'.mp4', '.mov', '.webm', '.mkv', '.avi', '.m4v', '.mp3', '.wav', '.m4a', '.ogg'}
 
+# Corpus size thresholds for user warnings
 CORPUS_WARN_THRESHOLD = 50_000    # words - below this, warn "you may not need a graph"
 CORPUS_UPPER_THRESHOLD = 500_000  # words - above this, warn about token cost
 FILE_COUNT_UPPER = 200             # files - above this, warn about token cost
 
-# Files that may contain secrets - skip silently
+# Patterns for identifying files likely containing secrets or credentials
 _SENSITIVE_PATTERNS = [
     re.compile(r'(^|[\\/])\.(env|envrc)(\.|$)', re.IGNORECASE),
     re.compile(r'\.(pem|key|p12|pfx|cert|crt|der|p8)$', re.IGNORECASE),
@@ -39,7 +47,7 @@ _SENSITIVE_PATTERNS = [
     re.compile(r'(aws_credentials|gcloud_credentials|service.account)', re.IGNORECASE),
 ]
 
-# Signals that a .md/.txt file is actually a converted academic paper
+# Textual markers identifying converted markdown files as academic papers
 _PAPER_SIGNALS = [
     re.compile(r'\barxiv\b', re.IGNORECASE),
     re.compile(r'\bdoi\s*:', re.IGNORECASE),
@@ -55,19 +63,43 @@ _PAPER_SIGNALS = [
     re.compile(r'\bwe propose\b', re.IGNORECASE),   # common academic phrasing
     re.compile(r'\bliterature\b', re.IGNORECASE),   # "from the literature"
 ]
-_PAPER_SIGNAL_THRESHOLD = 3  # need at least this many signals to call it a paper
+_PAPER_SIGNAL_THRESHOLD = 3  # minimum matches required for paper classification
 
 
 def _is_sensitive(path: Path) -> bool:
-    """Return True if this file likely contains secrets and should be skipped."""
+    """
+    Check if a file likely contains sensitive information or secrets.
+
+    Parameters
+    ----------
+    path : Path
+        The file path to check.
+
+    Returns
+    -------
+    bool
+        True if the file matches known sensitive patterns, False otherwise.
+    """
     name = path.name
     return any(p.search(name) for p in _SENSITIVE_PATTERNS)
 
 
 def _looks_like_paper(path: Path) -> bool:
-    """Heuristic: does this text file read like an academic paper?"""
+    """
+    Heuristically determine if a text file represents an academic paper.
+
+    Parameters
+    ----------
+    path : Path
+        The file path to evaluate.
+
+    Returns
+    -------
+    bool
+        True if the file content contains sufficient academic markers.
+    """
     try:
-        # Only scan first 3000 chars for speed
+        # Scan initial segment for performance
         text = path.read_text(encoding="utf-8", errors="ignore")[:3000]
         hits = sum(1 for pattern in _PAPER_SIGNALS if pattern.search(text))
         return hits >= _PAPER_SIGNAL_THRESHOLD
@@ -79,6 +111,19 @@ _ASSET_DIR_MARKERS = {".imageset", ".xcassets", ".appiconset", ".colorset", ".la
 
 
 def classify_file(path: Path) -> FileType | None:
+    """
+    Determine the type of a file based on its extension and content.
+
+    Parameters
+    ----------
+    path : Path
+        The file path to classify.
+
+    Returns
+    -------
+    FileType or None
+        The detected file category, or None if unknown.
+    """
     # Compound extensions must be checked before simple suffix lookup
     if path.name.lower().endswith(".blade.php"):
         return FileType.CODE
@@ -105,7 +150,19 @@ def classify_file(path: Path) -> FileType | None:
 
 
 def extract_pdf_text(path: Path) -> str:
-    """Extract plain text from a PDF file using pypdf."""
+    """
+    Extract plain text from a PDF file using pypdf.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the PDF file.
+
+    Returns
+    -------
+    str
+        Extracted text content.
+    """
     try:
         from pypdf import PdfReader
         reader = PdfReader(str(path))
@@ -120,7 +177,19 @@ def extract_pdf_text(path: Path) -> str:
 
 
 def docx_to_markdown(path: Path) -> str:
-    """Convert a .docx file to markdown text using python-docx."""
+    """
+    Convert a .docx file to markdown text using python-docx.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the .docx file.
+
+    Returns
+    -------
+    str
+        Converted markdown content.
+    """
     try:
         from docx import Document
         from docx.oxml.ns import qn
@@ -160,7 +229,19 @@ def docx_to_markdown(path: Path) -> str:
 
 
 def xlsx_to_markdown(path: Path) -> str:
-    """Convert an .xlsx file to markdown text using openpyxl."""
+    """
+    Convert an .xlsx file to markdown text using openpyxl.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the .xlsx file.
+
+    Returns
+    -------
+    str
+        Converted markdown content.
+    """
     try:
         import openpyxl
         wb = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
@@ -190,10 +271,18 @@ def xlsx_to_markdown(path: Path) -> str:
 
 
 def xlsx_extract_structure(path: Path) -> dict:
-    """Extract structural nodes (sheets, named tables, column headers) from an .xlsx file.
+    """
+    Extract structural nodes (sheets, tables, headers) from an .xlsx file.
 
-    Returns a nodes/edges dict compatible with the graphify extract pipeline.
-    Used in addition to xlsx_to_markdown so Claude sees both structure and content.
+    Parameters
+    ----------
+    path : Path
+        Path to the .xlsx file.
+
+    Returns
+    -------
+    dict
+        A dictionary containing extracted 'nodes' and 'edges'.
     """
     def _nid(*parts: str) -> str:
         return re.sub(r"[^a-z0-9_]", "_", "_".join(p.lower() for p in parts).strip("_"))
@@ -208,7 +297,7 @@ def xlsx_extract_structure(path: Path) -> dict:
     except Exception:
         return {"nodes": [], "edges": []}
 
-    stem = _re.sub(r"[^a-z0-9]", "_", path.stem.lower())
+    stem = re.sub(r"[^a-z0-9]", "_", path.stem.lower())
     str_path = str(path)
     file_nid = _nid(str_path)
     nodes: list[dict] = [{"id": file_nid, "label": path.name, "file_type": "document",
@@ -275,10 +364,20 @@ def xlsx_extract_structure(path: Path) -> dict:
 
 
 def convert_office_file(path: Path, out_dir: Path) -> Path | None:
-    """Convert a .docx or .xlsx to a markdown sidecar in out_dir.
+    """
+    Convert a .docx or .xlsx to a markdown sidecar.
 
-    Returns the path of the converted .md file, or None if conversion failed
-    or the required library is not installed.
+    Parameters
+    ----------
+    path : Path
+        The office file to convert.
+    out_dir : Path
+        The output directory for the converted markdown file.
+
+    Returns
+    -------
+    Path or None
+        Path to the converted file, or None if conversion failed.
     """
     ext = path.suffix.lower()
     if ext == ".docx":
@@ -304,6 +403,19 @@ def convert_office_file(path: Path, out_dir: Path) -> Path | None:
 
 
 def count_words(path: Path) -> int:
+    """
+    Count the number of words in a file.
+
+    Parameters
+    ----------
+    path : Path
+        The file to count words in.
+
+    Returns
+    -------
+    int
+        The word count.
+    """
     try:
         ext = path.suffix.lower()
         if ext == ".pdf":
@@ -336,7 +448,19 @@ _SKIP_FILES = {
 }
 
 def _is_noise_dir(part: str) -> bool:
-    """Return True if this directory name looks like a venv, cache, or dep dir."""
+    """
+    Check if a directory name matches known noise patterns (e.g., venvs, caches).
+
+    Parameters
+    ----------
+    part : str
+        The directory name to evaluate.
+
+    Returns
+    -------
+    bool
+        True if the directory is considered noise, False otherwise.
+    """
     if part in _SKIP_DIRS:
         return True
     # Catch *_venv, *_repo/site-packages patterns
@@ -347,16 +471,226 @@ def _is_noise_dir(part: str) -> bool:
     return False
 
 
+# POSIX bracket expression names mapped to Python regex character-range equivalents.
+# Used by _pattern_to_regex when scanning [[:class:]] patterns.
+_POSIX_CLASSES: dict[str, str] = {
+    '[:alnum:]':  'a-zA-Z0-9',
+    '[:alpha:]':  'a-zA-Z',
+    '[:blank:]':  r' \t',
+    '[:cntrl:]':  r'\x00-\x1F\x7F',
+    '[:digit:]':  '0-9',
+    '[:graph:]':  r'\x21-\x7E',
+    '[:lower:]':  'a-z',
+    '[:print:]':  r'\x20-\x7E',
+    '[:punct:]':  r'\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E',
+    '[:space:]':  r' \t\r\n\v\f',
+    '[:upper:]':  'A-Z',
+    '[:xdigit:]': 'A-Fa-f0-9',
+}
+
+
+def _pattern_to_regex(p: str) -> re.Pattern:
+    """
+    Convert a graphifyignore wildcard pattern to a compiled regular expression.
+
+    Implements wildcard rules where '*' does not cross directory separators 
+    but '**' does, following standard ignore specification.
+
+    Parameters
+    ----------
+    p : str
+        The wildcard pattern to convert.
+
+    Returns
+    -------
+    re.Pattern
+        The compiled regular expression matching the pattern's logic.
+    """
+    # Pre-process: expand POSIX [:class:] names to regex equivalents, but only
+    # when they appear inside an open '[', preserving positional correctness.
+    chars = []
+    in_bracket = False
+    i = 0
+    while i < len(p):
+        if p[i] == '[':
+            if in_bracket:
+                matched_posix = False
+                for posix, py_eq in _POSIX_CLASSES.items():
+                    if p.startswith(posix, i):
+                        chars.append(py_eq)
+                        i += len(posix)
+                        matched_posix = True
+                        break
+                if matched_posix:
+                    continue
+            in_bracket = True
+            chars.append(p[i])
+            i += 1
+        elif p[i] == ']':
+            in_bracket = False
+            chars.append(p[i])
+            i += 1
+        elif p[i] == '\\':
+            # Skip the next character so an escaped bracket doesn't toggle state
+            chars.append(p[i])
+            if i + 1 < len(p):
+                chars.append(p[i + 1])
+                i += 1
+            i += 1
+        else:
+            chars.append(p[i])
+            i += 1
+    p = "".join(chars)
+
+    result: list[str] = []
+    i = 0
+    while i < len(p):
+        c = p[i]
+        if c == '\\' and i + 1 < len(p):
+            result.append(re.escape(p[i + 1]))
+            i += 2
+        elif c == '*' and i + 1 < len(p) and p[i + 1] == '*':
+            # ** is only special at the pattern start or immediately after /. 
+            # In any other position it behaves like *.
+            preceded_by_slash = (i == 0) or (result and result[-1] == '/')
+            if i + 2 < len(p) and p[i + 2] == '/':
+                if preceded_by_slash:
+                    # **/ at start or after /: zero or more directory segments.
+                    if result and result[-1] == '/':
+                        result[-1] = '/(?:[^/]+/)*'
+                    else:
+                        result.append('(?:[^/]+/)*')
+                    i += 3
+                else:
+                    # foo**/ → treat ** as *; / is handled in the next iteration.
+                    result.append('[^/]*')
+                    i += 2
+            else:
+                if preceded_by_slash:
+                    # /** or leading **: match everything including separators.
+                    result.append('.*')
+                else:
+                    # foo** → treat as foo*.
+                    result.append('[^/]*')
+                i += 2
+        elif c == '*':
+            result.append('[^/]*')
+            i += 1
+        elif c == '?':
+            result.append('[^/]')
+            i += 1
+        elif c == '[':
+            # Copy character class until closing ], converting [! to [^ for Python re.
+            j = i + 1
+            negate = j < len(p) and p[j] == '!'
+            if j < len(p) and p[j] in ('!', '^'):
+                j += 1
+            if j < len(p) and p[j] == ']':
+                j += 1
+            while j < len(p) and p[j] != ']':
+                j += 1
+            cls = p[i:j + 1]
+            if negate:
+                cls = '[^' + cls[2:]  # [!xyz] → [^xyz] for Python re
+            
+            result.append(cls)
+            i = j + 1
+        else:
+            result.append(re.escape(c))
+            i += 1
+    return re.compile(''.join(result))
+
+
+def _match_ignore_pattern(rel: str, pattern: str, is_dir: bool) -> bool:
+    """
+    Check if a relative path matches an ignore pattern.
+
+    Parameters
+    ----------
+    rel : str
+        The forward-slash relative path to check.
+    pattern : str
+        The ignore pattern (without leading '!').
+    is_dir : bool
+        Whether the path represents a directory.
+
+    Returns
+    -------
+    bool
+        True if the path matches the pattern according to ignore rules.
+    """
+    dir_only = pattern.endswith('/')
+    p = pattern.rstrip('/')
+
+    anchored = p.startswith('/') or ('/' in p)
+    if p.startswith('/'):
+        p = p[1:]
+
+    regex = _pattern_to_regex(p)
+    parts = rel.split('/')
+
+    if anchored:
+        # Full-path match
+        if regex.fullmatch(rel):
+            if dir_only and not is_dir:
+                return False
+            return True
+        # Prefix match (ignoring a directory ignores its contents)
+        for i in range(1, len(parts)):
+            if regex.fullmatch('/'.join(parts[:i])):
+                return True
+        return False
+    else:
+        # Basename match
+        if regex.fullmatch(parts[-1]):
+            if dir_only and not is_dir:
+                return False
+            return True
+        # Directory component match
+        for part in parts[:-1]:
+            if regex.fullmatch(part):
+                return True
+        return False
+
+
+def _trim_trailing_spaces(s: str) -> str:
+    """
+    Trim trailing spaces exactly as Git's dir.c:trim_trailing_spaces does.
+    
+    Unescaped trailing spaces are removed. A backslash escapes the next character 
+    (including a space), preserving it.
+    """
+    last_space = -1
+    i = 0
+    while i < len(s):
+        if s[i] == ' ':
+            if last_space == -1:
+                last_space = i
+            i += 1
+        elif s[i] == '\\':
+            i += 2
+            last_space = -1
+        else:
+            last_space = -1
+            i += 1
+    if last_space != -1:
+        return s[:last_space]
+    return s
+
+
 def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
-    """Read .graphifyignore from root **and ancestor directories**.
+    """
+    Discover and read .graphifyignore files from root and ancestors.
 
-    Returns a list of (anchor_dir, pattern) pairs. Each pattern is matched
-    against paths relative to both the scan root and the anchor_dir where
-    the .graphifyignore file was found — so patterns written relative to a
-    parent directory still work when graphify is run on a subfolder.
+    Parameters
+    ----------
+    root : Path
+        The starting directory for the upward search.
 
-    Walks upward from *root* towards the filesystem root, stopping at a
-    ``.git`` boundary. Lines starting with # are comments; blank lines ignored.
+    Returns
+    -------
+    list of tuple[Path, str]
+        A list of (anchor_dir, pattern) pairs. Search stops at .git boundaries.
     """
     patterns: list[tuple[Path, str]] = []
     current = root.resolve()
@@ -364,9 +698,10 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
         ignore_file = current / ".graphifyignore"
         if ignore_file.exists():
             for line in ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines():
-                line = line.strip()
                 if line and not line.startswith("#"):
-                    patterns.append((current, line))
+                    line = _trim_trailing_spaces(line)
+                    if line:
+                        patterns.append((current, line))
         # Stop climbing once we've processed the git repo root
         if (current / ".git").exists():
             break
@@ -377,48 +712,83 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
     return patterns
 
 
-def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> bool:
-    """Return True if path matches any .graphifyignore pattern."""
+def _is_path_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]], is_dir: bool | None = None) -> bool:
+    """
+    Determine if a path is excluded by .graphifyignore patterns.
+
+    Implements ordered semantics where later patterns override earlier ones
+    (negation).
+
+    Parameters
+    ----------
+    path : Path
+        The file or directory path to check.
+    root : Path
+        The scan root directory.
+    patterns : list of tuple[Path, str]
+        Discovered ignore patterns.
+    is_dir : bool, optional
+        Whether the path is a directory. If None, it is determined via path.is_dir().
+
+    Returns
+    -------
+    bool
+        True if the path is ignored and not subsequently negated.
+    """
     if not patterns:
         return False
 
-    def _matches(rel: str, p: str) -> bool:
-        parts = rel.split("/")
-        if fnmatch.fnmatch(rel, p):
-            return True
-        if fnmatch.fnmatch(path.name, p):
-            return True
-        for i, part in enumerate(parts):
-            if fnmatch.fnmatch(part, p):
-                return True
-            if fnmatch.fnmatch("/".join(parts[:i + 1]), p):
-                return True
-        return False
+    if is_dir is None:
+        is_dir = path.is_dir()
+
+    ignored = False
 
     for anchor, pattern in patterns:
-        p = pattern.strip("/")
-        if not p:
+        is_negation = pattern.startswith('!')
+        p = pattern[1:] if is_negation else pattern
+        if not p.strip('/'):
             continue
-        # Try path relative to the scan root
+
+        match = False
+        # Try path relative to the scan root.
         try:
-            rel = str(path.relative_to(root)).replace(os.sep, "/")
-            if _matches(rel, p):
-                return True
+            rel = str(path.relative_to(root)).replace(os.sep, '/')
+            if _match_ignore_pattern(rel, p, is_dir):
+                match = True
         except ValueError:
             pass
-        # Also try relative to the anchor dir (the .graphifyignore's location),
-        # so patterns written at a parent level still fire when running on a subfolder
-        if anchor != root:
+
+        # Also try relative to the anchor dir (.graphifyignore's location)
+        if not match and anchor != root:
             try:
-                rel_anchor = str(path.relative_to(anchor)).replace(os.sep, "/")
-                if _matches(rel_anchor, p):
-                    return True
+                rel_anchor = str(path.relative_to(anchor)).replace(os.sep, '/')
+                if _match_ignore_pattern(rel_anchor, p, is_dir):
+                    match = True
             except ValueError:
                 pass
-    return False
+
+        if match:
+            ignored = not is_negation
+
+    return ignored
 
 
 def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
+    """
+    Scan a directory for files to include in the graph.
+
+    Parameters
+    ----------
+    root : Path
+        The directory to scan.
+    follow_symlinks : bool, default False
+        Whether to follow directory symlinks.
+
+    Returns
+    -------
+    dict
+        Categorized files and health metadata.
+    """
     root = root.resolve()
     files: dict[FileType, list[str]] = {
         FileType.CODE: [],
@@ -452,12 +822,13 @@ def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
                     dirnames.clear()
                     continue
             if not in_memory_tree:
-                # Prune noise dirs in-place so os.walk never descends into them
+                # Prune noise dirs and ignored dirs in-place.
+                # Per standard ignore semantics, we do not descend into ignored directories.
                 dirnames[:] = [
                     d for d in dirnames
                     if not d.startswith(".")
                     and not _is_noise_dir(d)
-                    and not _is_ignored(dp / d, root, ignore_patterns)
+                    and not _is_path_ignored(dp / d, root, ignore_patterns, is_dir=True)
                 ]
             for fname in filenames:
                 if fname in _SKIP_FILES:
@@ -480,8 +851,10 @@ def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
             # Skip files inside our own converted/ dir (avoid re-processing sidecars)
             if str(p).startswith(str(converted_dir)):
                 continue
-        if _is_ignored(p, root, ignore_patterns):
-            continue
+            # Standard ignore check (files only)
+            if _is_path_ignored(p, root, ignore_patterns, is_dir=False):
+                continue
+        
         if _is_sensitive(p):
             skipped_sensitive.append(str(p))
             continue
@@ -530,7 +903,19 @@ def detect(root: Path, *, follow_symlinks: bool = False) -> dict:
 
 
 def load_manifest(manifest_path: str = _MANIFEST_PATH) -> dict[str, float]:
-    """Load the file modification time manifest from a previous run."""
+    """
+    Load the file modification time manifest from a previous run.
+
+    Parameters
+    ----------
+    manifest_path : str, default _MANIFEST_PATH
+        The path to the manifest JSON file.
+
+    Returns
+    -------
+    dict of str to float
+        A mapping of file paths to their last recorded modification timestamps.
+    """
     try:
         return json.loads(Path(manifest_path).read_text(encoding="utf-8"))
     except Exception:
@@ -538,7 +923,18 @@ def load_manifest(manifest_path: str = _MANIFEST_PATH) -> dict[str, float]:
 
 
 def save_manifest(files: dict[str, list[str]], manifest_path: str = _MANIFEST_PATH) -> None:
-    """Save current file mtimes so the next --update run can diff against them."""
+    """
+    Save current file modification times to the manifest.
+
+    Used to enable incremental updates in subsequent runs.
+
+    Parameters
+    ----------
+    files : dict of str to list of str
+        The categorized lists of discovered files.
+    manifest_path : str, default _MANIFEST_PATH
+        The path where the manifest should be saved.
+    """
     manifest: dict[str, float] = {}
     for file_list in files.values():
         for f in file_list:
@@ -551,10 +947,21 @@ def save_manifest(files: dict[str, list[str]], manifest_path: str = _MANIFEST_PA
 
 
 def detect_incremental(root: Path, manifest_path: str = _MANIFEST_PATH) -> dict:
-    """Like detect(), but returns only new or modified files since the last run.
+    """
+    Identify files that have changed or been added since the last run.
 
-    Compares current file mtimes against the stored manifest.
-    Use for --update mode: re-extract only what changed, merge into existing graph.
+    Parameters
+    ----------
+    root : Path
+        The directory to scan.
+    manifest_path : str, default _MANIFEST_PATH
+        The path to the existing manifest file.
+
+    Returns
+    -------
+    dict
+        A dictionary containing incremental scan results, including new, 
+        deleted, and unchanged file lists.
     """
     full = detect(root)
     manifest = load_manifest(manifest_path)

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from enum import Enum
 from pathlib import Path
 
@@ -549,7 +550,7 @@ def _pattern_to_regex(p: str) -> re.Pattern:
         if c == '\\' and i + 1 < len(p):
             # Special Git escape characters: preserve as escapes.
             # Otherwise, treat backslash as a directory separator (Windows support).
-            if p[i+1] in (' ', '#', '!', '*', '?', '[', '\\'):
+            if p[i+1] in (' ', '#', '!', '*', '?', '[', ']', '\\'):
                 result.append(re.escape(p[i + 1]))
             else:
                 result.append('/')
@@ -612,7 +613,6 @@ def _pattern_to_regex(p: str) -> re.Pattern:
             i += 1
 
     # Use case-insensitive matching on Windows and macOS
-    import sys
     re_flags = 0
     if sys.platform in ("win32", "darwin"):
         re_flags = re.IGNORECASE
@@ -793,13 +793,18 @@ def _is_path_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]], i
             continue
 
         match = False
-        # Try path relative to the scan root.
-        try:
-            rel = str(path.relative_to(root)).replace(os.sep, '/')
-            if _match_ignore_pattern(rel, p, is_dir):
-                match = True
-        except ValueError:
-            pass
+        # Leading-slash patterns are anchored to their .graphifyignore location.
+        # Don't evaluate them relative to the scan root when the anchor is a parent
+        # directory — that would make /vendor/ in a parent ignore a src/vendor/ subtree.
+        leading_slash_anchored = p.startswith('/')
+        if not (leading_slash_anchored and anchor != root):
+            # Try path relative to the scan root.
+            try:
+                rel = str(path.relative_to(root)).replace(os.sep, '/')
+                if _match_ignore_pattern(rel, p, is_dir):
+                    match = True
+            except ValueError:
+                pass
 
         # Also try relative to the anchor dir (.graphifyignore's location)
         if not match and anchor != root:

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -3630,38 +3630,35 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".lua", ".toc", ".zig", ".ps1",
         ".m", ".mm",
     }
-    from graphify.detect import _load_graphifyignore, _is_ignored
+    from graphify.detect import _load_graphifyignore, _is_path_ignored
     ignore_root = root if root is not None else target
     patterns = _load_graphifyignore(ignore_root)
 
-    def _ignored(p: Path) -> bool:
-        return bool(patterns and _is_ignored(p, ignore_root, patterns))
+    def _ignored(p: Path, is_dir: bool = False) -> bool:
+        return bool(patterns and _is_path_ignored(p, ignore_root, patterns, is_dir=is_dir))
 
-    if not follow_symlinks:
-        results: list[Path] = []
-        for ext in sorted(_EXTENSIONS):
-            results.extend(
-                p for p in target.rglob(f"*{ext}")
-                if not any(part.startswith(".") for part in p.parts)
-                and not _ignored(p)
-            )
-        return sorted(results)
-    # Walk with symlink following + cycle detection
-    results = []
-    for dirpath, dirnames, filenames in os.walk(target, followlinks=True):
-        if os.path.islink(dirpath):
+    results: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(target, followlinks=follow_symlinks):
+        dp = Path(dirpath)
+        # Cycle detection — only relevant when following symlinks
+        if follow_symlinks and os.path.islink(dirpath):
             real = os.path.realpath(dirpath)
             parent_real = os.path.realpath(os.path.dirname(dirpath))
             if parent_real == real or parent_real.startswith(real + os.sep):
                 dirnames.clear()
                 continue
-        dp = Path(dirpath)
-        if any(part.startswith(".") for part in dp.parts):
-            dirnames.clear()
-            continue
+        # Prune hidden dirs and ignored dirs in-place — avoids descending into them
+        # and eliminates per-file parent checks that the old rglob path required.
+        dirnames[:] = [
+            d for d in dirnames
+            if not d.startswith(".")
+            and not _ignored(dp / d, is_dir=True)
+        ]
         for fname in filenames:
+            if fname.startswith("."):
+                continue
             p = dp / fname
-            if p.suffix in _EXTENSIONS and not fname.startswith(".") and not _ignored(p):
+            if p.suffix in _EXTENSIONS and not _ignored(p, is_dir=False):
                 results.append(p)
     return sorted(results)
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -184,6 +184,9 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
     except ImportError as e:
         raise ImportError("watchdog not installed. Run: pip install watchdog") from e
 
+    from graphify.detect import _load_graphifyignore, _is_path_ignored
+
+    ignore_patterns = _load_graphifyignore(watch_path)
     last_trigger: float = 0.0
     pending: bool = False
     changed: set[Path] = set()
@@ -196,10 +199,21 @@ def watch(watch_path: Path, debounce: float = 3.0) -> None:
             path = Path(event.src_path)
             if path.suffix.lower() not in _WATCHED_EXTENSIONS:
                 return
+            
+            # Use real project root for anchoring ignore patterns
+            root = watch_path.resolve()
+            
+            # Skip hidden files
             if any(part.startswith(".") for part in path.parts):
                 return
+            # Skip own output
             if "graphify-out" in path.parts:
                 return
+                
+            # Skip user-ignored files
+            if _is_path_ignored(path, root, ignore_patterns, is_dir=False):
+                return
+            
             last_trigger = time.monotonic()
             pending = True
             changed.add(path)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -176,7 +176,9 @@ def test_graphifyignore_parent_negation_reinclude(tmp_path):
     """Parent .graphifyignore wildcard + negation applies to subdirectory scans.
 
     Uses vendor/* (not vendor/) so the directory is traversed and keep.py can be re-included.
+    A VCS root (.git) is present so the upward walk reaches the parent ignore file.
     """
+    (tmp_path / ".git").mkdir()
     (tmp_path / ".graphifyignore").write_text("vendor/*\n!vendor/keep.py\n")
     sub = tmp_path / "sub"
     sub.mkdir()
@@ -236,7 +238,8 @@ def test_detect_follows_symlinked_file(tmp_path):
 
 
 def test_graphifyignore_discovered_from_parent(tmp_path):
-    """A .graphifyignore in a parent directory applies to subdirectory scans."""
+    """A .graphifyignore in a VCS-rooted parent directory applies to subdirectory scans."""
+    (tmp_path / ".git").mkdir()
     (tmp_path / ".graphifyignore").write_text("vendor/\n")
     sub = tmp_path / "packages" / "mylib"
     sub.mkdir(parents=True)
@@ -252,8 +255,8 @@ def test_graphifyignore_discovered_from_parent(tmp_path):
     assert result["graphifyignore_patterns"] >= 1
 
 
-def test_graphifyignore_stops_at_git_boundary(tmp_path):
-    """Upward search stops at the git repo root (.git directory)."""
+def test_graphifyignore_stops_at_project_boundary(tmp_path):
+    """Upward search stops at the first recognised project-root marker."""
     (tmp_path / ".graphifyignore").write_text("main.py\n")
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -266,6 +269,38 @@ def test_graphifyignore_stops_at_git_boundary(tmp_path):
     code_files = result["files"]["code"]
     assert any("main.py" in f for f in code_files)
     assert result["graphifyignore_patterns"] == 0
+
+
+def test_graphifyignore_stops_at_non_git_boundary(tmp_path):
+    """Without a VCS root, scan root is the ceiling — outer ignore files are not loaded."""
+    (tmp_path / ".graphifyignore").write_text("main.py\n")
+    sub = tmp_path / "project" / "src"
+    sub.mkdir(parents=True)
+    (sub / "main.py").write_text("x = 1")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+    assert any("main.py" in f for f in code_files)
+    assert result["graphifyignore_patterns"] == 0
+
+
+def test_graphifyignore_monorepo_walks_past_package_json(tmp_path):
+    """In a monorepo, package.json in a sub-package does not stop the walk;
+    the .git root boundary is always honoured."""
+    repo = tmp_path / "monorepo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".graphifyignore").write_text("*.log\n")
+    pkg = repo / "packages" / "my-lib"
+    pkg.mkdir(parents=True)
+    (pkg / "package.json").write_text("{}\n")
+    src = pkg / "src"
+    src.mkdir()
+    (src / "index.ts").write_text("export default 1;")
+    (src / "debug.log").write_text("log")
+
+    result = detect(src)
+    assert result["graphifyignore_patterns"] == 1
 
 
 def test_graphifyignore_at_git_root_is_included(tmp_path):

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from graphify.detect import classify_file, count_words, detect, FileType, _looks_like_paper, _is_ignored, _load_graphifyignore
+from graphify.detect import classify_file, count_words, detect, FileType, _looks_like_paper, _is_path_ignored, _load_graphifyignore, _match_ignore_pattern
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -95,6 +95,103 @@ def test_graphifyignore_excludes_file(tmp_path):
     assert not any("vendor" in f for f in file_list)
     assert not any("generated" in f for f in file_list)
     assert result["graphifyignore_patterns"] == 2
+
+
+def test_graphifyignore_negation(tmp_path):
+    """Support ! negation patterns in .graphifyignore."""
+    (tmp_path / ".graphifyignore").write_text("*.py\n!important.py\n")
+    (tmp_path / "main.py").write_text("print('hi')")
+    (tmp_path / "important.py").write_text("print('important')")
+    (tmp_path / "other.py").write_text("print('other')")
+
+    result = detect(tmp_path)
+    file_list = result["files"]["code"]
+
+    # important.py should be included because of !important.py
+    assert any("important.py" in f for f in file_list)
+    # main.py and other.py should be ignored because of *.py
+    assert not any("main.py" in f for f in file_list)
+    assert not any("other.py" in f for f in file_list)
+
+
+def test_graphifyignore_trailing_slash_directory_only(tmp_path):
+    """Trailing / means directory-only: ignored/ prunes the dir but does NOT match a file named ignored.py."""
+    (tmp_path / ".graphifyignore").write_text("ignored/\n")
+
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "skip.py").write_text("skip")
+    (tmp_path / "ignored.py").write_text("this is a file named ignored.py")
+    (tmp_path / "main.py").write_text("x = 1")
+
+    result = detect(tmp_path)
+    file_list = result["files"]["code"]
+
+    # The directory and all its contents are pruned
+    assert not any("skip.py" in f for f in file_list)
+    # But a FILE named ignored.py is NOT excluded (trailing / means dirs only)
+    assert any("ignored.py" in f for f in file_list)
+    assert any("main.py" in f for f in file_list)
+
+
+def test_graphifyignore_reinclude_requires_wildcard(tmp_path):
+    """Per gitignore spec, re-including a file inside an excluded dir requires dir/* not dir/.
+
+    ignored/ prunes the directory entirely — !ignored/keep.py has no effect.
+    The correct pattern is ignored/* (exclude contents) + !ignored/keep.py.
+    """
+    (tmp_path / ".graphifyignore").write_text("ignored/*\n!ignored/keep.py\n")
+
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "skip.py").write_text("skip")
+    (ignored_dir / "keep.py").write_text("keep")
+
+    result = detect(tmp_path)
+    file_list = result["files"]["code"]
+
+    # keep.py is re-included because ignored/* doesn't prune the directory itself
+    assert any("keep.py" in f for f in file_list)
+    assert not any("skip.py" in f for f in file_list)
+
+
+def test_graphifyignore_negation_reproducer(tmp_path):
+    """Issue #628 reproducer: broad glob excludes specific paths, ! re-includes vetted file."""    
+    (tmp_path / ".graphifyignore").write_text("**/*vetted*\n!**/src/lib/vetted.ts\n")
+    src_lib = tmp_path / "src" / "lib"
+    src_lib.mkdir(parents=True)
+    (src_lib / "vetted.ts").write_text("// SDK wrapper - no actual secrets")
+    # Another file that also matches **/*vetted* but is NOT re-included
+    (tmp_path / "src" / "my-vetted.ts").write_text("vetted=abc")
+
+    result = detect(tmp_path)
+    file_list = result["files"]["code"]
+
+    # src/lib/vetted.ts is re-included by the ! pattern
+    assert any("vetted.ts" in f and "lib" in f for f in file_list)
+    # src/my-vetted.ts matches **/*vetted* and stays excluded
+    assert not any("my-vetted.ts" in f for f in file_list)
+
+def test_graphifyignore_parent_negation_reinclude(tmp_path):
+    """Parent .graphifyignore wildcard + negation applies to subdirectory scans.
+
+    Uses vendor/* (not vendor/) so the directory is traversed and keep.py can be re-included.
+    """
+    (tmp_path / ".graphifyignore").write_text("vendor/*\n!vendor/keep.py\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    vendor = sub / "vendor"
+    vendor.mkdir()
+    (vendor / "dep.py").write_text("y = 2")
+    (vendor / "keep.py").write_text("z = 3")
+    (sub / "main.py").write_text("x = 1")
+
+    result = detect(sub)
+    code_files = result["files"]["code"]
+
+    assert any("main.py" in f for f in code_files)
+    assert any("keep.py" in f for f in code_files)
+    assert not any("dep.py" in f for f in code_files)
 
 
 def test_graphifyignore_missing_is_fine(tmp_path):
@@ -236,3 +333,92 @@ def test_detect_video_not_in_words(tmp_path):
     result = detect(tmp_path)
     # Only video file present — total_words should be 0
     assert result["total_words"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _match_ignore_pattern unit tests — cover standard ignore categories
+# ---------------------------------------------------------------------------
+
+def test_ignore_pattern_double_star_leading():
+    """`**/foo` matches foo at any depth including root."""
+    assert _match_ignore_pattern("foo.py", "**/foo.py", is_dir=False)
+    assert _match_ignore_pattern("src/foo.py", "**/foo.py", is_dir=False)
+    assert _match_ignore_pattern("a/b/c/foo.py", "**/foo.py", is_dir=False)
+    assert not _match_ignore_pattern("foo.ts", "**/foo.py", is_dir=False)
+
+
+def test_ignore_pattern_double_star_trailing():
+    """`logs/**` matches everything inside logs/."""
+    assert _match_ignore_pattern("logs/app.log", "logs/**", is_dir=False)
+    assert _match_ignore_pattern("logs/2024/app.log", "logs/**", is_dir=False)
+    assert not _match_ignore_pattern("logs", "logs/**", is_dir=True)
+    assert not _match_ignore_pattern("other/app.log", "logs/**", is_dir=False)
+
+
+def test_ignore_pattern_double_star_middle():
+    """`a/**/b` matches a/b, a/x/b, a/x/y/b — zero or more intermediate dirs."""
+    assert _match_ignore_pattern("a/b", "a/**/b", is_dir=False)
+    assert _match_ignore_pattern("a/x/b", "a/**/b", is_dir=False)
+    assert _match_ignore_pattern("a/x/y/b", "a/**/b", is_dir=False)
+    assert not _match_ignore_pattern("b", "a/**/b", is_dir=False)
+    # a/b is matched by a/**/b, so any file inside a/b (like a/b/c) is ignored.
+    assert _match_ignore_pattern("a/b/c", "a/**/b", is_dir=False)
+
+
+def test_ignore_pattern_double_star_non_special():
+    """`foo**/bar` — ** not after / is treated as *."""
+    assert _match_ignore_pattern("foo/bar", "foo**/bar", is_dir=False)
+    assert _match_ignore_pattern("fooxyz/bar", "foo**/bar", is_dir=False)
+    # ** treated as *, so it cannot cross a second /
+    assert not _match_ignore_pattern("foo/baz/bar", "foo**/bar", is_dir=False)
+
+
+def test_ignore_pattern_leading_slash_anchored():
+    """`/main.py` is anchored to root — does not match src/main.py."""
+    assert _match_ignore_pattern("main.py", "/main.py", is_dir=False)
+    assert not _match_ignore_pattern("src/main.py", "/main.py", is_dir=False)
+    assert not _match_ignore_pattern("a/b/main.py", "/main.py", is_dir=False)
+
+
+def test_ignore_pattern_trailing_slash_not_file():
+    """`vendor/` must NOT match a file named vendor.py."""
+    assert not _match_ignore_pattern("vendor.py", "vendor/", is_dir=False)
+    assert not _match_ignore_pattern("vendors.py", "vendor/", is_dir=False)
+    # But it does match the directory itself and files inside
+    assert _match_ignore_pattern("vendor", "vendor/", is_dir=True)
+    assert _match_ignore_pattern("vendor/lib.py", "vendor/", is_dir=False)
+
+
+def test_ignore_pattern_question_mark_wildcard():
+    """`?` matches exactly one character except /."""
+    assert _match_ignore_pattern("a.py", "?.py", is_dir=False)
+    assert not _match_ignore_pattern("ab.py", "?.py", is_dir=False)
+    # ?.py is unanchored, so it matches any file whose basename matches ?.py.
+    # a/b.py has basename b.py which matches ?.py.
+    assert _match_ignore_pattern("a/b.py", "?.py", is_dir=False)
+    assert _match_ignore_pattern("foo", "f?o", is_dir=False)
+    assert not _match_ignore_pattern("fo", "f?o", is_dir=False)
+
+
+def test_ignore_pattern_character_class():
+    """`[abc].py` matches a.py, b.py, c.py but not d.py."""
+    assert _match_ignore_pattern("a.py", "[abc].py", is_dir=False)
+    assert _match_ignore_pattern("b.py", "[abc].py", is_dir=False)
+    assert _match_ignore_pattern("c.py", "[abc].py", is_dir=False)
+    assert not _match_ignore_pattern("d.py", "[abc].py", is_dir=False)
+    assert not _match_ignore_pattern("ab.py", "[abc].py", is_dir=False)
+
+
+def test_ignore_pattern_negated_character_class():
+    """`[!abc].py` matches any single char except a, b, c before .py."""
+    assert _match_ignore_pattern("d.py", "[!abc].py", is_dir=False)
+    assert _match_ignore_pattern("z.py", "[!abc].py", is_dir=False)
+    assert not _match_ignore_pattern("a.py", "[!abc].py", is_dir=False)
+    assert not _match_ignore_pattern("b.py", "[!abc].py", is_dir=False)
+
+
+def test_ignore_pattern_single_star_no_cross_slash():
+    """`src/*.py` matches src/foo.py but NOT src/lib/foo.py (* can't cross /)."""
+    assert _match_ignore_pattern("src/foo.py", "src/*.py", is_dir=False)
+    assert not _match_ignore_pattern("src/lib/foo.py", "src/*.py", is_dir=False)
+    assert not _match_ignore_pattern("foo.py", "src/*.py", is_dir=False)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from graphify.detect import classify_file, count_words, detect, FileType, _looks_like_paper, _is_path_ignored, _load_graphifyignore, _match_ignore_pattern
 
@@ -194,6 +195,25 @@ def test_graphifyignore_parent_negation_reinclude(tmp_path):
     assert any("main.py" in f for f in code_files)
     assert any("keep.py" in f for f in code_files)
     assert not any("dep.py" in f for f in code_files)
+
+
+def test_anchored_parent_pattern_does_not_match_subdir_collision(tmp_path):
+    """/vendor/ in a parent .graphifyignore must NOT exclude src/vendor/ when scanning src/.
+
+    A leading-slash pattern is anchored to the .graphifyignore that defines it, not to
+    whatever directory the user passes to detect(). Without this guard the scan-root-relative
+    path 'vendor/lib.py' would incorrectly match the anchored regex produced by '/vendor/'.
+    """
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".graphifyignore").write_text("/vendor/\n")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "vendor").mkdir()
+    (src / "vendor" / "lib.py").write_text("x = 1")
+
+    result = detect(src)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    assert any("vendor/lib.py" in f for f in code_files)
 
 
 def test_graphifyignore_missing_is_fine(tmp_path):

--- a/tests/test_ignore_rules.py
+++ b/tests/test_ignore_rules.py
@@ -1,0 +1,124 @@
+import os
+from pathlib import Path
+from graphify.detect import detect, _pattern_to_regex
+
+def test_ignore_trailing_slash(tmp_path):
+    """A pattern with a trailing slash only matches directories."""
+    (tmp_path / ".graphifyignore").write_text("vendor/\n")
+    (tmp_path / "vendor.py").write_text("x = 1") # file named vendor.py
+    (tmp_path / "vendor").mkdir() # dir named vendor
+    (tmp_path / "vendor" / "lib.py").write_text("y = 2")
+    
+    result = detect(tmp_path)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    
+    # File named 'vendor.py' should be included because pattern 'vendor/' only matches dirs
+    assert any("vendor.py" in f for f in code_files)
+    # Dir named 'vendor' should be ignored
+    assert not any("vendor/lib.py" in f for f in code_files)
+
+def test_negation_parent_ignored(tmp_path):
+    """Standard ignore semantics: cannot re-include a file if a parent directory is excluded."""
+    (tmp_path / ".graphifyignore").write_text("ignored/\n!ignored/keep.py\n")
+    
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "keep.py").write_text("print('keep')")
+    
+    result = detect(tmp_path)
+    code_files = result["files"]["code"]
+    
+    # keep.py should be IGNORED because its parent 'ignored/' is excluded
+    assert not any("keep.py" in f for f in code_files)
+
+def test_negation_with_wildcard(tmp_path):
+    """To re-include a file, the parent dir must not be fully excluded (e.g. use dir/*)."""
+    (tmp_path / ".graphifyignore").write_text("ignored/*\n!ignored/keep.py\n")
+    
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "skip.py").write_text("print('skip')")
+    (ignored_dir / "keep.py").write_text("print('keep')")
+    
+    result = detect(tmp_path)
+    code_files = result["files"]["code"]
+    
+    # keep.py should be INCLUDED
+    assert any("keep.py" in f for f in code_files)
+    # skip.py should be IGNORED
+    assert not any("skip.py" in f for f in code_files)
+
+def test_anchored_pattern(tmp_path):
+    """A leading slash anchors the pattern to the root."""
+    (tmp_path / ".graphifyignore").write_text("/root_only.py\n")
+    (tmp_path / "root_only.py").write_text("x = 1")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "root_only.py").write_text("y = 2")
+    
+    result = detect(tmp_path)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    
+    assert not any(f.endswith("/root_only.py") and not "/sub/" in f for f in code_files)
+    assert any("/sub/root_only.py" in f for f in code_files)
+
+def test_exact_prefix_no_partial_match(tmp_path):
+    """'git/' matches a/git/foo but NOT a/git-foo.py"""
+    (tmp_path / ".graphifyignore").write_text("git/\n")
+    git_dir = tmp_path / "git"
+    git_dir.mkdir()
+    (git_dir / "foo.py").write_text("x=1")
+    (tmp_path / "git-foo.py").write_text("y=2")
+    
+    result = detect(tmp_path)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    
+    assert not any("git/foo.py" in f for f in code_files)
+    assert any("git-foo.py" in f for f in code_files)
+
+def test_complex_negation_chain(tmp_path):
+    """data/** + !data/**/ + !data/**/*.txt"""
+    (tmp_path / ".graphifyignore").write_text("data/**\n!data/**/\n!data/**/*.txt\n")
+    data_dir = tmp_path / "data" / "nested" / "deep"
+    data_dir.mkdir(parents=True)
+    (tmp_path / "data" / "nested" / "skip.py").write_text("x=1")
+    (data_dir / "keep.txt").write_text("y=2")
+    
+    result = detect(tmp_path)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    doc_files = [f.replace(os.sep, "/") for f in result["files"]["document"]]
+    
+    assert not any("skip.py" in f for f in code_files)
+    assert any("keep.txt" in f for f in doc_files)
+
+def test_trailing_whitespace_stripped(tmp_path):
+    """Unescaped trailing whitespace is stripped."""
+    (tmp_path / ".graphifyignore").write_text("vendor/   \n")
+    (tmp_path / "vendor").mkdir()
+    (tmp_path / "vendor" / "lib.py").write_text("y = 2")
+    
+    result = detect(tmp_path)
+    code_files = [f.replace(os.sep, "/") for f in result["files"]["code"]]
+    assert not any("vendor/lib.py" in f for f in code_files)
+
+def test_trailing_whitespace_escaped(tmp_path):
+    """Escaped trailing whitespace is preserved."""
+    (tmp_path / ".graphifyignore").write_text("vendor\\ \n")
+    # Due to Windows limitations on paths with trailing spaces, we test this logic
+    # using the direct _match_ignore_pattern function rather than filesystem creation.
+    from graphify.detect import _match_ignore_pattern, _load_graphifyignore
+    patterns = _load_graphifyignore(tmp_path)
+    pattern_str = patterns[0][1]
+    
+    assert pattern_str == "vendor\\ "  # The backslash is preserved and compiled to match a space
+    assert _match_ignore_pattern("vendor ", pattern_str, is_dir=False)
+    assert not _match_ignore_pattern("vendor", pattern_str, is_dir=False)
+
+def test_posix_character_classes():
+    """POSIX character classes are correctly mapped to Python regex."""
+    assert _pattern_to_regex("[[:alpha:]].py").fullmatch("a.py")
+    assert _pattern_to_regex("[[:alpha:]].py").fullmatch("Z.py")
+    assert not _pattern_to_regex("[[:alpha:]].py").fullmatch("1.py")
+    
+    assert _pattern_to_regex("[[:digit:]].py").fullmatch("5.py")
+    assert not _pattern_to_regex("[[:digit:]].py").fullmatch("a.py")


### PR DESCRIPTION
 Refines 6b68de1 and 8a6306f. Closes #643. Related to #628. Adding on from #644 
 
 ### Features implemented:

- **No-VCS ceiling**: when no VCS root is found, the walk stops at the scan root, not the home directory. The home guard still allows leakage across sibling projects under a shared workspace (`~/work/project-alpha` picking up `~/work/.graphifyignore`). Stopping at the scan root eliminates that entirely.

- **Correct pattern ordering**: parent `.graphifyignore` patterns are evaluated outermost-first so inner (closer) patterns win via
  last-match-wins. The prior ordering let VCS-root patterns override a file's own `.graphifyignore`.

- **Escaped trailing spaces preserved**:  `line.strip()` silently drops `vendor\ ` patterns. Replaced with `rstrip()` + escape-awareness so `vendor\ ` correctly matches a path named `vendor ` (per gitignore spec).

- **`\]` escape**: `]` was missing from the backslash-escape set in `_pattern_to_regex`; `\]` was being converted to a path separator
  instead of a literal `]`.

- **Anchored pattern misfire**: a leading-slash pattern (e.g. `/vendor/`) in a parent `.graphifyignore` was incorrectly matching `src/vendor/` when `detect()` was called on `src/`. Added a guard so anchored patterns only evaluate relative to their own anchor directory, not the scan root.