### PR TITLE
fix(extract): emit symbol-level edges for TS/JS named imports

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -182,6 +182,7 @@ def _import_python(node, source: bytes, file_nid: str, stem: str, edges: list, s
 
 
 def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:
+    resolved_path: "Path | None" = None
     for child in node.children:
         if child.type == "string":
             raw = _read_text(child, source).strip("'\"` ")
@@ -197,6 +198,7 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                 elif resolved.suffix == ".jsx":
                     resolved = resolved.with_suffix(".tsx")
                 tgt_nid = _make_id(str(resolved))
+                resolved_path = resolved
             else:
                 # Check tsconfig.json path aliases (e.g. "@/" → "src/") before treating as external (#575)
                 aliases = _load_tsconfig_aliases(Path(str_path).parent)
@@ -208,6 +210,7 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                         break
                 if resolved_alias is not None:
                     tgt_nid = _make_id(str(resolved_alias))
+                    resolved_path = resolved_alias
                 else:
                     # Bare/scoped import (node_modules) - use last segment; dropped as external
                     module_name = raw.split("/")[-1]
@@ -224,6 +227,32 @@ def _import_js(node, source: bytes, file_nid: str, stem: str, edges: list, str_p
                 "weight": 1.0,
             })
             break
+
+    # Emit symbol-level edges for named imports from local/aliased files.
+    # e.g. `import { Foo, type Bar } from './bar'` → file → Foo, file → Bar (EXTRACTED)
+    # Uses the same _make_id(target_stem, name) key that _extract_generic emits when
+    # defining the symbol, so these edges wire importers directly to existing symbol nodes.
+    if resolved_path is not None:
+        target_stem = _file_stem(resolved_path)
+        line = node.start_point[0] + 1
+        for child in node.children:
+            if child.type == "import_clause":
+                for sub in child.children:
+                    if sub.type == "named_imports":
+                        for spec in sub.children:
+                            if spec.type == "import_specifier":
+                                name_node = spec.child_by_field_name("name")
+                                if name_node:
+                                    sym = _read_text(name_node, source)
+                                    edges.append({
+                                        "source": file_nid,
+                                        "target": _make_id(target_stem, sym),
+                                        "relation": "imports",
+                                        "confidence": "EXTRACTED",
+                                        "source_file": str_path,
+                                        "source_location": f"L{line}",
+                                        "weight": 1.0,
+                                    })
 
 
 def _import_java(node, source: bytes, file_nid: str, stem: str, edges: list, str_path: str) -> None:


### PR DESCRIPTION
## Problem

`_import_js` creates a file→file `imports_from` edge but never walks the `import_clause` to emit edges for individual named specifiers. This leaves named imported symbols — error classes, type aliases, constants — as degree-1 orphans connected only to their defining file, with no edges to any of their consumers.

**Example:** `import { CookieJarCorruptionError } from '../pipeline/cookie-jar.js'` produced no edge between `wb-source.ts` and the `CookieJarCorruptionError` node. The symbol appeared isolated in the graph despite being actively used.

## Fix

Track `resolved_path` when the import target resolves to a local file (relative path or tsconfig alias). After emitting the file-level `imports_from` edge, walk:

```
import_statement → import_clause → named_imports → import_specifier → name
```

For each specifier, emit a `file → symbol` `EXTRACTED` edge using `_make_id(target_stem, name)` — the same key `_extract_generic` uses when defining the symbol. This wires importer files directly to existing symbol nodes with no new node creation.

`type`-only import specifiers are included (they are structural dependencies). Renamed imports (`Foo as Bar`) use the original name `Foo` via `child_by_field_name("name")`. External package imports (no `resolved_path`) are unaffected.

## Impact

Tested on a 1,696-file TypeScript monorepo:

| Metric | Before | After |
|---|---|---|
| Edges | 8,530 | 11,267 |
| New edges | — | +2,737 |
| Communities | 878 | 604 |

The 274 fewer communities reflect formerly isolated symbols now correctly grouped with their consumers.