### PR TITLE
Codex skill fork verification and scope guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,55 @@
-## graphify
+# Graphify Fork Operating Notes
 
-This project has a graphify knowledge graph at graphify-out/.
+This repository is Mase's fork of upstream Graphify.
 
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+## Remotes
+
+- `origin`: `https://github.com/matzls/graphify.git`
+- `upstream`: `https://github.com/safishamsi/graphify.git`
+
+Keep upstream mirror branches such as `v6` clean. Put local customizations on
+`mase/local-fixes` unless a task explicitly creates a narrower PR branch.
+
+## Local Development
+
+- Do not patch the uv tool site-packages copy directly.
+- Make source changes in this repository.
+- Run targeted tests before reinstalling the active CLI.
+- Install the active CLI from this checkout when local fixes should be used:
+
+```bash
+uv tool install --force --reinstall /Users/mase/Codebase/Personal-Projects/graphify \
+  --with faster-whisper \
+  --with yt-dlp \
+  --with watchdog
+```
+
+## Upstream Sync
+
+To take upstream changes while preserving local fixes:
+
+```bash
+git fetch upstream
+git checkout v6
+git merge --ff-only upstream/v6
+git checkout mase/local-fixes
+git rebase v6
+uv run pytest tests/test_watch.py tests/test_transcribe.py tests/test_hooks.py
+uv tool install --force --reinstall /Users/mase/Codebase/Personal-Projects/graphify \
+  --with faster-whisper \
+  --with yt-dlp \
+  --with watchdog
+```
+
+If upstream includes equivalent fixes, drop the matching local commits from
+`mase/local-fixes`.
+
+## Local Patch Goals
+
+Current local fixes should stay small and upstream-friendly:
+
+- Preserve semantic community labels during code-only rebuilds.
+- Avoid transcript filename collisions for same-stem media files.
+
+Prefer tests in `tests/test_watch.py`, `tests/test_transcribe.py`, and
+`tests/test_hooks.py` for these patches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,19 @@ uv tool install --force --reinstall /Users/mase/Codebase/Personal-Projects/graph
   --with watchdog
 ```
 
+Verify the active tool still points to this checkout before bootstrapping
+Graphify in another repo:
+
+```bash
+graphify doctor --require-source /Users/mase/Codebase/Personal-Projects/graphify
+```
+
+A repo-local Git hook cannot reliably prevent `uv tool upgrade graphifyy`,
+because that command mutates the global uv tool installation outside this git
+repo. Use the verifier above before repo bootstraps. If a hard block is ever
+needed, add it as an explicit shell wrapper or Codex command hook rather than as
+a Graphify repo Git hook.
+
 ## Upstream Sync
 
 To take upstream changes while preserving local fixes:

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -6,13 +6,60 @@ import platform
 import re
 import shutil
 import sys
+import urllib.parse
 from pathlib import Path
 
 try:
+    from importlib.metadata import distribution as _pkg_distribution
     from importlib.metadata import version as _pkg_version
     __version__ = _pkg_version("graphifyy")
 except Exception:
+    _pkg_distribution = None
     __version__ = "unknown"
+
+
+def _install_source() -> Path | str | None:
+    """Return the direct install source for graphifyy when package metadata records it."""
+    if _pkg_distribution is None:
+        return None
+    try:
+        dist = _pkg_distribution("graphifyy")
+        text = dist.read_text("direct_url.json") or "{}"
+        data = json.loads(text)
+    except Exception:
+        return None
+    url = data.get("url")
+    if not url:
+        return None
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme == "file":
+        return Path(urllib.parse.unquote(parsed.path)).resolve()
+    return url
+
+
+def _doctor(require_source: str | None = None) -> int:
+    """Print install diagnostics and return a process exit code."""
+    source = _install_source()
+    module_path = Path(__file__).resolve()
+    print(f"graphify version: {__version__}")
+    print(f"graphify module: {module_path}")
+    print(f"graphify install source: {source or '<unknown>'}")
+
+    if require_source:
+        expected = Path(require_source).expanduser().resolve()
+        module_under_expected = False
+        try:
+            module_path.relative_to(expected)
+            module_under_expected = True
+        except ValueError:
+            pass
+        if source != expected and not (source is None and module_under_expected):
+            print(
+                f"error: expected install source {expected}, got {source or '<unknown>'}",
+                file=sys.stderr,
+            )
+            return 1
+    return 0
 
 
 def _check_skill_version(skill_dst: Path) -> None:
@@ -189,7 +236,7 @@ def install(platform: str = "claude") -> None:
             print(f"  CLAUDE.md        ->  created at {claude_md}")
 
     if platform == "opencode":
-        _install_opencode_plugin(Path("."))
+        _install_opencode_plugin(Path.home())
 
     # Refresh version stamps in all other previously-installed skill dirs so
     # stale-version warnings don't fire for platforms not explicitly re-installed.
@@ -1043,6 +1090,8 @@ def main() -> None:
         print("Usage: graphify <command>")
         print()
         print("Commands:")
+        print("  doctor                  print install diagnostics")
+        print("    --require-source DIR   fail unless package was installed from DIR")
         print("  install [--platform P]  copy skill to platform config dir (claude|windows|codex|opencode|aider|claw|droid|trae|trae-cn|gemini|cursor|antigravity|hermes|kiro|pi)")
         print("  path \"A\" \"B\"            shortest path between two nodes in graph.json")
         print("    --graph <path>          path to graph.json (default graphify-out/graph.json)")
@@ -1122,7 +1171,17 @@ def main() -> None:
         return
 
     cmd = sys.argv[1]
-    if cmd == "install":
+    if cmd == "doctor":
+        args = sys.argv[2:]
+        require_source = None
+        if "--require-source" in args:
+            idx = args.index("--require-source")
+            if idx + 1 >= len(args):
+                print("Usage: graphify doctor [--require-source DIR]", file=sys.stderr)
+                sys.exit(1)
+            require_source = args[idx + 1]
+        sys.exit(_doctor(require_source=require_source))
+    elif cmd == "install":
         # Default to windows platform on Windows, claude elsewhere
         default_platform = "windows" if platform.system() == "Windows" else "claude"
         chosen_platform = default_platform

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -224,10 +224,27 @@ _AGENTS_MD_SECTION = """\
 This project has a graphify knowledge graph at graphify-out/.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- Before answering architecture or codebase questions, read
+  `graphify-out/GRAPH_REPORT.md` for god nodes and community structure.
+- If `graphify-out/wiki/index.md` exists, navigate it before reading raw files.
+- For cross-module "how does X relate to Y" questions, prefer
+  `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or
+  `graphify explain "<concept>"` over grep. These traverse EXTRACTED and
+  INFERRED graph edges instead of only scanning file text.
+- This repo can use repo-local Graphify Git hooks. They refresh code graph
+  outputs after commits and branch switches, but they do not semantically
+  refresh docs, media, images, or research notes.
+- For longer active coding sessions, consider running `graphify watch .` in a
+  separate terminal. It watches live file changes while the process is running:
+  code changes trigger a code-only graph rebuild, and non-code changes write
+  `graphify-out/needs_update`.
+- Do not assume `graphify watch .` is already running. Check before relying on
+  live graph freshness, and avoid starting duplicate watchers in the same repo.
+- If `graphify-out/needs_update` exists, run `graphify . --update` before
+  relying on docs/media/image relationships. This semantic update can spend LLM
+  tokens.
+- Treat Git hooks and `graphify watch .` as freshness helpers. When report
+  quality matters, prefer a full `graphify . --update`.
 """
 
 _AGENTS_MD_MARKER = "## graphify"

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -55,6 +55,40 @@ If no path was given, use `.` (current directory). Do not ask the user for a pat
 
 Follow these steps in order. Do not skip steps.
 
+### Step 0 - Preflight target repo and active install
+
+Run this preflight from the target repo before building or activating Graphify.
+Summarize the results before writing new files.
+
+```bash
+git status --short --branch 2>/dev/null || true
+find . -maxdepth 2 \( -name AGENTS.md -o -name .codex -o -name .graphifyignore -o -name graphify-out \) -print
+```
+
+Review existing `AGENTS.md`, `.codex/hooks.json`, `.graphifyignore`, and
+`graphify-out/` if present. If `.graphifyignore` is missing, draft one before
+the first graph build when the repo contains generated, cache, virtualenv,
+secret, or broad artifact paths.
+
+In Mase's Codex setup, verify the active CLI still points to the local fork
+before graphing another repo:
+
+```bash
+graphify doctor --require-source /Users/mase/Codebase/Personal-Projects/graphify
+```
+
+If this check fails, stop and reinstall from the fork before continuing:
+
+```bash
+uv tool install --force --reinstall /Users/mase/Codebase/Personal-Projects/graphify \
+  --with faster-whisper \
+  --with yt-dlp \
+  --with watchdog
+```
+
+Do not continue by running a plain `pip install graphifyy` or
+`uv tool upgrade graphifyy` when Mase's fork fixes are still required.
+
 ### Step 1 - Ensure graphify is installed
 
 ```bash

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -38,6 +38,11 @@ Turn any folder of files into a navigable knowledge graph with community detecti
 
 graphify is built around Andrej Karpathy's /raw folder workflow: drop anything into a folder - papers, tweets, screenshots, code, notes - and get a structured knowledge graph that shows you what you didn't know was connected.
 
+Graphify is not specific to Second Brain. Treat it as a repo or corpus analysis
+layer that can be applied to bounded targets. Treat `graphify-out/` as derived
+evidence, not canonical project state, durable memory, or an automatic input to
+Second Brain reflection.
+
 Three things it does that your AI assistant alone cannot:
 1. **Persistent graph** - relationships are stored in `graphify-out/graph.json` and survive across sessions. Ask questions weeks later without re-reading everything.
 2. **Honest audit trail** - every edge is tagged EXTRACTED, INFERRED, or AMBIGUOUS. You know what was found vs invented.
@@ -55,10 +60,22 @@ If no path was given, use `.` (current directory). Do not ask the user for a pat
 
 Follow these steps in order. Do not skip steps.
 
-### Step 0 - Preflight target repo and active install
+### Step 0 - Preflight target, ignore rules, and active install
 
 Run this preflight from the target repo before building or activating Graphify.
-Summarize the results before writing new files.
+Summarize the results before writing new files. Do not scan a broad workspace
+root such as `/Users/mase/Codebase`; choose a bounded repo, package, docs
+folder, or corpus root.
+
+Scope rule:
+- For cross-layer repo understanding, prefer the repo root with a strict
+  `.graphifyignore`. This preserves links between implementation, tests, PRDs,
+  plans, and docs.
+- Use a narrower root only when the user asks about one isolated subsystem,
+  such as only a router, one package, or one docs folder.
+- For Second Brain-style repos, do not default to tiny slices just because some
+  paths are private or noisy. Exclude those paths explicitly and keep the
+  useful repo-level context.
 
 ```bash
 git status --short --branch 2>/dev/null || true
@@ -69,6 +86,37 @@ Review existing `AGENTS.md`, `.codex/hooks.json`, `.graphifyignore`, and
 `graphify-out/` if present. If `.graphifyignore` is missing, draft one before
 the first graph build when the repo contains generated, cache, virtualenv,
 secret, or broad artifact paths.
+
+Minimum exclusions to consider for code repos:
+
+```gitignore
+.git/
+.venv/
+.pytest_cache/
+.worktrees/
+__pycache__/
+.env
+graphify-out/
+```
+
+Add repo-specific generated or sensitive paths before scanning. For Second
+Brain-style repos, consider excluding runtime data, private integration caches,
+and broad artifacts unless the user intentionally asks to graph them.
+
+Second Brain-style strict ignore starter:
+
+```gitignore
+.git/
+.venv/
+__pycache__/
+.pytest_cache/
+graphify-out/
+.claude/data/
+Memory/
+artifacts/
+*.log
+.env
+```
 
 In Mase's Codex setup, verify the active CLI still points to the local fork
 before graphing another repo:
@@ -92,17 +140,20 @@ Do not continue by running a plain `pip install graphifyy` or
 ### Step 1 - Ensure graphify is installed
 
 ```bash
-# Detect the correct Python interpreter (handles pipx, venv, system installs)
+# Detect the verified graphify interpreter. Do not fall back to PyPI here.
 GRAPHIFY_BIN=$(which graphify 2>/dev/null)
-if [ -n "$GRAPHIFY_BIN" ]; then
-    PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
-    case "$PYTHON" in
-        *[!a-zA-Z0-9/_.-]*) PYTHON="python3" ;;
-    esac
-else
-    PYTHON="python3"
+if [ -z "$GRAPHIFY_BIN" ]; then
+    echo "graphify CLI not found. Install from Mase's fork, then rerun doctor."
+    exit 1
 fi
-"$PYTHON" -c "import graphify" 2>/dev/null || "$PYTHON" -m pip install graphifyy -q 2>/dev/null || "$PYTHON" -m pip install graphifyy -q --break-system-packages 2>&1 | tail -3
+PYTHON=$(head -1 "$GRAPHIFY_BIN" | tr -d '#!')
+case "$PYTHON" in
+    *[!a-zA-Z0-9/_.-]*) PYTHON="python3" ;;
+esac
+"$PYTHON" -c "import graphify" 2>/dev/null || {
+    echo "graphify import failed from the verified CLI interpreter. Reinstall from Mase's fork."
+    exit 1
+}
 # Write interpreter path for all subsequent steps
 "$PYTHON" -c "import sys; from pathlib import Path; Path('graphify-out').mkdir(exist_ok=True); Path('.graphify_python').write_text(sys.executable); Path('graphify-out/.graphify_python').write_text(sys.executable)"
 ```
@@ -119,8 +170,11 @@ import json
 from graphify.detect import detect
 from pathlib import Path
 result = detect(Path('INPUT_PATH'))
-print(json.dumps(result))
-" > .graphify_detect.json
+payload = json.dumps(result)
+Path('.graphify_detect.json').write_text(payload)
+Path('graphify-out').mkdir(exist_ok=True)
+Path('graphify-out/.graphify_detect.json').write_text(payload)
+"
 ```
 
 Replace INPUT_PATH with the actual path the user provided. Do NOT cat or print the JSON - read it silently and present a clean summary instead:
@@ -777,6 +831,17 @@ If graphify saved you time, consider supporting it: https://github.com/sponsors/
 
 Replace PATH_TO_DIR with the actual absolute path of the directory that was processed.
 
+Before offering any repo activation, verify the success checklist:
+- `graphify-out/GRAPH_REPORT.md` exists and includes plausible god nodes,
+  community labels, surprising connections, and suggested questions.
+- `graphify-out/graph.json` exists and has non-empty nodes and edges unless the
+  corpus was intentionally tiny.
+- `graphify-out/graph.html` exists if visualization was not disabled.
+
+Only after that checklist passes should you offer optional repo-local activation
+with `graphify codex install` or Git hooks. A successful scan does not imply the
+repo should install reminders or hooks.
+
 Then paste these sections from GRAPH_REPORT.md directly into the chat:
 - God Nodes
 - Surprising Connections
@@ -1283,7 +1348,8 @@ If a post-commit hook already exists, graphify appends to it rather than replaci
 
 ## For native Codex AGENTS.md integration
 
-Run once per project after the first graph has been built:
+Optional. Run only after the first graph has been built and the success
+checklist above passed:
 
 ```bash
 graphify codex install

--- a/graphify/skill-codex.md
+++ b/graphify/skill-codex.md
@@ -70,7 +70,7 @@ else
 fi
 "$PYTHON" -c "import graphify" 2>/dev/null || "$PYTHON" -m pip install graphifyy -q 2>/dev/null || "$PYTHON" -m pip install graphifyy -q --break-system-packages 2>&1 | tail -3
 # Write interpreter path for all subsequent steps
-"$PYTHON" -c "import sys; open('graphify-out/.graphify_python', 'w').write(sys.executable)"
+"$PYTHON" -c "import sys; from pathlib import Path; Path('graphify-out').mkdir(exist_ok=True); Path('.graphify_python').write_text(sys.executable); Path('graphify-out/.graphify_python').write_text(sys.executable)"
 ```
 
 If the import succeeds, print nothing and move straight to Step 2.
@@ -499,6 +499,7 @@ questions = suggest_questions(G, communities, labels)
 report = generate(G, communities, cohesion, labels, analysis['gods'], analysis['surprises'], detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 Path('.graphify_labels.json').write_text(json.dumps({str(k): v for k, v in labels.items()}))
+Path('graphify-out/community_labels.json').write_text(json.dumps({str(k): v for k, v in labels.items()}, indent=2, sort_keys=True) + '\n')
 print('Report updated with community labels')
 "
 ```
@@ -1222,13 +1223,13 @@ Debounce (default 3s): waits until file activity stops before triggering, so a w
 
 Press Ctrl+C to stop.
 
-For agentic workflows: run `--watch` in a background terminal. Code changes from agent waves are picked up automatically between waves. If agents are also writing docs or notes, you'll need a manual `/graphify --update` after those waves.
+For agentic workflows: run `--watch` in a separate terminal. Code changes from agent waves are picked up automatically between waves. If agents are also writing docs or notes, you'll need a manual `/graphify --update` after those waves. A Codex reminder hook can surface `graphify-out/needs_update`, but it does not watch files by itself.
 
 ---
 
 ## For git commit hook
 
-Install a post-commit hook that auto-rebuilds the graph after every commit. No background process needed - triggers once per commit, works with any editor.
+Install repo-local Git hooks that trigger a code-only graph rebuild after commits and branch switches. No watcher process is needed for these triggers.
 
 ```bash
 graphify hook install    # install
@@ -1236,9 +1237,50 @@ graphify hook uninstall  # remove
 graphify hook status     # check
 ```
 
-After every `git commit`, the hook detects which code files changed (via `git diff HEAD~1`), re-runs AST extraction on those files, and rebuilds `graph.json` and `GRAPH_REPORT.md`. Doc/image changes are ignored by the hook - run `/graphify --update` manually for those.
+After every `git commit`, the hook detects changed files (via `git diff HEAD~1`), launches a detached `_rebuild_code(Path('.'))`, and rebuilds `graph.json` and `GRAPH_REPORT.md` without LLM tokens. On branch switches, `post-checkout` does the same when `graphify-out/` already exists.
+
+The code-only rebuild preserves semantic nodes, edges, and community labels from the previous graph. Use the Git hooks for code freshness, not as a replacement for `/graphify --update` when docs/media changed or when report quality matters.
+
+Doc/image/media changes are not semantically refreshed by the Git hooks. Use `graphify watch INPUT_PATH` to write `graphify-out/needs_update` when non-code files change, then run `/graphify --update` manually.
 
 If a post-commit hook already exists, graphify appends to it rather than replacing it.
+
+---
+
+## For native Codex AGENTS.md integration
+
+Run once per project after the first graph has been built:
+
+```bash
+graphify codex install
+graphify hook install
+graphify hook status
+```
+
+This writes or updates the repo-local `AGENTS.md` Graphify section and creates
+repo-local `.codex/hooks.json` reminders. After installation, review the
+generated `## graphify` section and make sure it includes the local freshness
+model:
+
+- The Codex reminder hook is passive. It reminds the agent when
+  `graphify-out/graph.json` exists or when `graphify-out/needs_update` exists.
+- The Git hooks are repo-local. They refresh code graph outputs after commits
+  and branch switches, but they do not semantically refresh docs, media, images,
+  or research notes.
+- `graphify watch .` is optional and foreground. Use it in a separate terminal
+  for longer active coding sessions; it watches live file changes while running,
+  rebuilds for code changes, and writes `graphify-out/needs_update` for
+  non-code changes.
+- Do not assume `graphify watch .` is already running. Check before relying on
+  live graph freshness and avoid duplicate watchers in the same repo.
+- If `graphify-out/needs_update` exists, run `graphify . --update` before
+  relying on docs/media/image relationships. This semantic update can spend LLM
+  tokens.
+- Treat Git hooks and `graphify watch .` as freshness helpers. When report
+  quality matters, prefer a full `graphify . --update`.
+
+Keep this guidance in the repo-local `AGENTS.md`; it is part of the standard
+bootstrap for Graphify-enabled repos.
 
 ---
 

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -553,6 +553,7 @@ questions = suggest_questions(G, communities, labels)
 report = generate(G, communities, cohesion, labels, analysis['gods'], analysis['surprises'], detection, tokens, 'INPUT_PATH', suggested_questions=questions)
 Path('graphify-out/GRAPH_REPORT.md').write_text(report)
 Path('graphify-out/.graphify_labels.json').write_text(json.dumps({str(k): v for k, v in labels.items()}))
+Path('graphify-out/community_labels.json').write_text(json.dumps({str(k): v for k, v in labels.items()}, indent=2, sort_keys=True) + '\n')
 print('Report updated with community labels')
 "
 ```

--- a/graphify/transcribe.py
+++ b/graphify/transcribe.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import hashlib
+import re
 from pathlib import Path
 
 
@@ -113,6 +115,15 @@ def build_whisper_prompt(god_nodes: list[dict]) -> str:
     return f"Technical discussion about {topics}. Use proper punctuation and paragraph breaks."
 
 
+def _transcript_path(audio_path: Path, out_dir: Path) -> Path:
+    """Return a stable transcript path that cannot collide on same-stem media."""
+    suffix = audio_path.suffix.lower().lstrip(".") or "media"
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", audio_path.stem).strip("._") or "media"
+    identity = str(audio_path.resolve() if audio_path.exists() else audio_path)
+    digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:10]
+    return out_dir / f"{stem}__{suffix}__{digest}.txt"
+
+
 def transcribe(
     video_path: Path | str,
     output_dir: Path | None = None,
@@ -136,7 +147,7 @@ def transcribe(
     else:
         audio_path = Path(video_path)
 
-    transcript_path = out_dir / (audio_path.stem + ".txt")
+    transcript_path = _transcript_path(audio_path, out_dir)
     if transcript_path.exists() and not force:
         return transcript_path
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -1,6 +1,7 @@
 # monitor a folder and auto-trigger --update when files change
 from __future__ import annotations
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -10,6 +11,50 @@ from graphify.detect import CODE_EXTENSIONS, DOC_EXTENSIONS, PAPER_EXTENSIONS, I
 
 _WATCHED_EXTENSIONS = CODE_EXTENSIONS | DOC_EXTENSIONS | PAPER_EXTENSIONS | IMAGE_EXTENSIONS
 _CODE_EXTENSIONS = CODE_EXTENSIONS
+
+
+def _parse_report_community_labels(report_path: Path) -> dict[int, str]:
+    """Recover semantic community labels from an existing GRAPH_REPORT.md."""
+    if not report_path.exists():
+        return {}
+    labels: dict[int, str] = {}
+    pattern = re.compile(r'^### Community\s+(\d+)\s+-\s+"([^"]+)"\s*$')
+    for line in report_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = pattern.match(line.strip())
+        if not match:
+            continue
+        labels[int(match.group(1))] = match.group(2)
+    return labels
+
+
+def _load_community_labels(out: Path) -> dict[int, str]:
+    """Load durable labels, falling back to the previous human report."""
+    candidates = [
+        out / "community_labels.json",
+        out / ".graphify_labels.json",
+        out.parent / ".graphify_labels.json",
+    ]
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            raw = json.loads(candidate.read_text(encoding="utf-8"))
+            return {int(k): str(v) for k, v in raw.items()}
+        except Exception:
+            continue
+    return _parse_report_community_labels(out / "GRAPH_REPORT.md")
+
+
+def _save_community_labels(out: Path, labels: dict[int, str]) -> None:
+    """Persist labels for future code-only rebuilds."""
+    if not labels:
+        return
+    out.mkdir(exist_ok=True)
+    payload = {str(k): v for k, v in sorted(labels.items())}
+    (out / "community_labels.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _report_root_label(watch_path: Path) -> str:
@@ -103,11 +148,16 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False, force: boo
         cohesion = score_all(G, communities)
         gods = god_nodes(G)
         surprises = surprising_connections(G, communities)
-        labels = {cid: "Community " + str(cid) for cid in communities}
+        preserved_labels = _load_community_labels(out)
+        labels = {
+            cid: preserved_labels.get(cid, "Community " + str(cid))
+            for cid in communities
+        }
         questions = suggest_questions(G, communities, labels)
 
         out.mkdir(exist_ok=True)
         (out / ".graphify_root").write_text(str(watch_root), encoding="utf-8")
+        _save_community_labels(out, labels)
 
         json_written = to_json(G, communities, str(out / "graph.json"), force=force)
         if not json_written:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -98,6 +98,26 @@ def test_all_skill_files_exist_in_package():
         assert (pkg / name).exists(), f"Missing: {name}"
 
 
+def test_doctor_accepts_required_matching_source(tmp_path, monkeypatch, capsys):
+    from graphify import __main__ as main_mod
+
+    monkeypatch.setattr(main_mod, "_install_source", lambda: tmp_path.resolve())
+    assert main_mod._doctor(require_source=str(tmp_path)) == 0
+    assert f"graphify install source: {tmp_path.resolve()}" in capsys.readouterr().out
+
+
+def test_doctor_rejects_required_mismatched_source(tmp_path, monkeypatch, capsys):
+    from graphify import __main__ as main_mod
+
+    actual = tmp_path / "actual"
+    expected = tmp_path / "expected"
+    monkeypatch.setattr(main_mod, "_install_source", lambda: actual.resolve())
+    assert main_mod._doctor(require_source=str(expected)) == 1
+    captured = capsys.readouterr()
+    assert f"graphify install source: {actual.resolve()}" in captured.out
+    assert f"expected install source {expected.resolve()}" in captured.err
+
+
 def test_claude_install_registers_claude_md(tmp_path):
     """Claude platform install writes CLAUDE.md; others do not."""
     _install(tmp_path, "claude")

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -12,6 +12,7 @@ from graphify.transcribe import (
     build_whisper_prompt,
     transcribe,
     transcribe_all,
+    _transcript_path,
 )
 
 
@@ -71,7 +72,7 @@ def test_transcribe_uses_cache(tmp_path):
     video.write_bytes(b"fake")
     out_dir = tmp_path / "transcripts"
     out_dir.mkdir()
-    cached = out_dir / "lecture.txt"
+    cached = _transcript_path(video, out_dir)
     cached.write_text("Cached transcript content.")
 
     result = transcribe(video, output_dir=out_dir)
@@ -84,7 +85,7 @@ def test_transcribe_force_reruns(tmp_path):
     video.write_bytes(b"fake")
     out_dir = tmp_path / "transcripts"
     out_dir.mkdir()
-    (out_dir / "talk.txt").write_text("Old transcript.")
+    _transcript_path(video, out_dir).write_text("Old transcript.")
 
     fake_segment = MagicMock()
     fake_segment.text = "New transcript segment."
@@ -125,12 +126,28 @@ def test_transcribe_all_uses_cache(tmp_path):
     video.write_bytes(b"fake")
     out_dir = tmp_path / "transcripts"
     out_dir.mkdir()
-    cached = out_dir / "lecture.txt"
+    cached = _transcript_path(video, out_dir)
     cached.write_text("Cached.")
 
     results = transcribe_all([str(video)], output_dir=out_dir)
     assert len(results) == 1
     assert str(cached) in results[0]
+
+
+def test_transcript_paths_do_not_collide_for_same_stem(tmp_path):
+    """Same-stem media with different suffixes get distinct transcript files."""
+    mp3 = tmp_path / "sample.mp3"
+    mp4 = tmp_path / "sample.mp4"
+    mp3.write_bytes(b"fake mp3")
+    mp4.write_bytes(b"fake mp4")
+    out_dir = tmp_path / "transcripts"
+
+    mp3_path = _transcript_path(mp3, out_dir)
+    mp4_path = _transcript_path(mp4, out_dir)
+
+    assert mp3_path != mp4_path
+    assert mp3_path.name.startswith("sample__mp3__")
+    assert mp4_path.name.startswith("sample__mp4__")
 
 
 def test_transcribe_all_skips_failed(tmp_path):

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -3,7 +3,13 @@ import time
 from pathlib import Path
 import pytest
 
-from graphify.watch import _notify_only, _WATCHED_EXTENSIONS
+from graphify.watch import (
+    _load_community_labels,
+    _notify_only,
+    _parse_report_community_labels,
+    _save_community_labels,
+    _WATCHED_EXTENSIONS,
+)
 
 
 # --- _notify_only ---
@@ -94,3 +100,41 @@ def test_watch_raises_without_watchdog(tmp_path, monkeypatch):
     from graphify.watch import watch
     with pytest.raises(ImportError, match="watchdog not installed"):
         watch(tmp_path)
+
+
+# --- community label preservation ---
+
+def test_parse_report_community_labels(tmp_path):
+    report = tmp_path / "GRAPH_REPORT.md"
+    report.write_text(
+        '### Community 0 - "Runtime Configuration"\n'
+        '### Community 12 - "Auth And Query Scope"\n',
+        encoding="utf-8",
+    )
+
+    assert _parse_report_community_labels(report) == {
+        0: "Runtime Configuration",
+        12: "Auth And Query Scope",
+    }
+
+
+def test_load_community_labels_prefers_durable_json(tmp_path):
+    out = tmp_path / "graphify-out"
+    _save_community_labels(out, {0: "Durable Label"})
+    (out / "GRAPH_REPORT.md").write_text(
+        '### Community 0 - "Report Label"\n',
+        encoding="utf-8",
+    )
+
+    assert _load_community_labels(out) == {0: "Durable Label"}
+
+
+def test_load_community_labels_falls_back_to_report(tmp_path):
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    (out / "GRAPH_REPORT.md").write_text(
+        '### Community 3 - "Media Chunking Pipeline"\n',
+        encoding="utf-8",
+    )
+
+    assert _load_community_labels(out) == {3: "Media Chunking Pipeline"}


### PR DESCRIPTION
## Summary
- preserve local fork fixes on top of upstream v0.6.7
- add install-source diagnostics for verifying fork-based installs
- refine Codex skill guidance for bounded repo scans, strict ignore rules, and optional activation

## Validation
- uv run --with pytest python -m pytest tests/test_watch.py tests/test_transcribe.py tests/test_hooks.py -q
- graphify doctor --require-source /Users/mase/Codebase/Personal-Projects/graphify

## Notes
- Draft PR opened for review before deciding whether these local-fork behaviors should go upstream.