### PR TITLE
Fix #535: re-add Godot .gd script file detection

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,7 +18,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r', '.gd'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4008,6 +4008,7 @@ def collect_files(target: Path, *, follow_symlinks: bool = False, root: Path | N
         ".rb", ".cs", ".kt", ".kts", ".scala", ".php", ".swift",
         ".lua", ".toc", ".zig", ".ps1",
         ".m", ".mm",
+        ".gd",
     }
     from graphify.detect import _load_graphifyignore, _is_ignored
     ignore_root = root if root is not None else target

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -9,6 +9,11 @@ def test_classify_python():
 def test_classify_typescript():
     assert classify_file(Path("bar.ts")) == FileType.CODE
 
+def test_classify_godot_gd():
+    # GDScript files (.gd) are Godot engine scripts and should be treated as code
+    assert classify_file(Path("Player.gd")) == FileType.CODE
+    assert classify_file(Path("scenes/Enemy.gd")) == FileType.CODE
+
 def test_classify_markdown():
     assert classify_file(Path("README.md")) == FileType.DOCUMENT
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -62,7 +62,7 @@ def test_collect_files_from_dir():
                  ".java", ".c", ".cpp", ".cc", ".cxx", ".rb",
                  ".cs", ".kt", ".kts", ".scala", ".php", ".h", ".hpp",
                  ".swift", ".lua", ".toc", ".zig", ".ps1", ".ex", ".exs",
-                 ".m", ".mm"}
+                 ".m", ".mm", ".gd"}
     assert all(f.suffix in supported for f in files)
     assert len(files) > 0
 
@@ -71,6 +71,15 @@ def test_collect_files_skips_hidden():
     files = collect_files(FIXTURES)
     for f in files:
         assert not any(part.startswith(".") for part in f.parts)
+
+
+def test_collect_files_picks_up_godot_gd(tmp_path):
+    # Regression test for #535 - Godot .gd script files were not being
+    # picked up by collect_files() after upgrade.
+    gd_file = tmp_path / "Player.gd"
+    gd_file.write_text("extends Node\n\nfunc _ready():\n    pass\n")
+    files = collect_files(tmp_path)
+    assert gd_file in files
 
 
 def test_collect_files_follows_symlinked_directory(tmp_path):


### PR DESCRIPTION
## Summary

Regression fix: `.gd` files were detected in v0.4.26 but silently dropped after upgrade, causing Godot users to see *"No code files found - nothing to rebuild"* even when `.gd` files were present in their project.

Add `.gd` to:
- `CODE_EXTENSIONS` in `detect.py` so `detect()` classifies Godot scripts as code
- `_EXTENSIONS` in `extract.collect_files()` so recursive directory scans pick them up

GDScript has no tree-sitter binding on PyPI, so AST extraction silently skips `.gd` files (existing behavior for unmapped extensions). The files now appear in detect output again and are processed by the LLM-based semantic extraction subagents as code, restoring the pre-regression behavior.

Closes #535

## Test plan
- [x] `tests/test_detect.py::test_classify_godot_gd` — verifies `classify_file()` returns `FileType.CODE` for `.gd` paths
- [x] `tests/test_extract.py::test_collect_files_picks_up_godot_gd` — verifies `collect_files()` finds `.gd` files in a directory scan
- [x] Updated `test_collect_files_from_dir` supported set to include `.gd`
- [x] No regressions in existing tests