### PR TITLE
Surface tree-sitter version-mismatch hint instead of bare TypeError

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -863,6 +863,15 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
         language = Language(lang_fn())
     except ImportError:
         return {"nodes": [], "edges": [], "error": f"{config.ts_module} not installed"}
+    except TypeError as e:
+        # tree-sitter version mismatch: old Language() expects (lib_path),
+        # new Language() expects (language_capsule, name). Surface a hint
+        # so users see the upgrade path instead of a bare TypeError.
+        hint = (
+            f"tree-sitter version mismatch for {config.ts_module}: {e}. "
+            "Try: pip install --upgrade tree-sitter tree-sitter-languages"
+        )
+        return {"nodes": [], "edges": [], "error": hint}
     except Exception as e:
         return {"nodes": [], "edges": [], "error": str(e)}
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -197,3 +197,35 @@ def test_cross_file_calls_skip_ambiguous_duplicate_labels(tmp_path):
         nodes[e["source"]]["label"] == "run()" and nodes[e["target"]]["label"] == "log()"
         for e in calls
     )
+
+
+def test_extract_generic_surfaces_tree_sitter_version_mismatch_hint(monkeypatch):
+    """When Language() raises TypeError (e.g. old tree-sitter binding meets a
+    new tree-sitter API), the error message should point users at the upgrade
+    path instead of leaving a bare 'missing 1 required positional argument'.
+    """
+    import sys
+    import types
+    from graphify.extract import _extract_generic, LanguageConfig
+
+    # Build a fake tree_sitter module whose Language() raises TypeError -
+    # this is exactly what users see when an older tree-sitter is paired
+    # with a newer language binding.
+    fake_ts = types.ModuleType("tree_sitter")
+    def _raise(*args, **kwargs):
+        raise TypeError("missing 1 required positional argument: 'name'")
+    fake_ts.Language = _raise
+    fake_ts.Parser = None
+    monkeypatch.setitem(sys.modules, "tree_sitter", fake_ts)
+
+    # Stub the language module so import_module returns something with .language
+    fake_lang_mod = types.ModuleType("fake_ts_lang")
+    fake_lang_mod.language = lambda: object()
+    monkeypatch.setitem(sys.modules, "fake_ts_lang", fake_lang_mod)
+
+    config = LanguageConfig(ts_module="fake_ts_lang", ts_language_fn="language")
+    result = _extract_generic(Path("dummy.txt"), config)
+
+    assert "error" in result
+    assert "tree-sitter version mismatch" in result["error"]
+    assert "pip install --upgrade" in result["error"]


### PR DESCRIPTION
## Summary

When a user has an older `tree-sitter` paired with a newer language binding (or vice versa), `Language()` raises `TypeError` with messages like *"missing 1 required positional argument: 'name'"*. The current catch-all `except Exception` in `_extract_generic()` stores that bare message in the per-file `error` field, leaving users no actionable signal.

Add a dedicated `TypeError` branch that returns the upgrade hint:

> tree-sitter version mismatch for `tree_sitter_python`: missing 1 required positional argument: 'name'. Try: `pip install --upgrade tree-sitter tree-sitter-languages`

Behavior is unchanged for all non-version-mismatch errors — the broader `Exception` handler still runs.

This PR replaces the old #96 (which targeted stale v3 and bundled three changes). The other two changes from #96 are no longer needed:
- Progress logging — already implemented in v6 (parallel/sequential extraction emit it).
- HTML sampling — overlaps with v6's `GRAPHIFY_VIZ_NODE_LIMIT` env-var approach, so leaving v6's design as-is.

## Test plan
- [x] New `tests/test_extract.py::test_extract_generic_surfaces_tree_sitter_version_mismatch_hint` — uses `monkeypatch.setitem(sys.modules, ...)` to inject a fake `tree_sitter` whose `Language()` raises `TypeError`, then asserts the returned error contains both `"tree-sitter version mismatch"` and `"pip install --upgrade"`.
- [x] All existing tests still pass; no behavior change for any path that doesn't hit `TypeError`.