### PR TITLE
Fix #228: emit mixed [[label]](filename.md) wiki links for non-Obsidian agents

### DIFF
--- a/graphify/wiki.py
+++ b/graphify/wiki.py
@@ -21,6 +21,17 @@ def _safe_filename(name: str) -> str:
     return s[:200] if s else 'unnamed'
 
 
+def _wikilink(label: str, slug_map: dict[str, str] | None = None) -> str:
+    """Render a wiki reference. If slug_map[label] is a known article filename,
+    emit the mixed [[label]](filename.md) form so non-Obsidian agents can
+    follow the link as plain markdown (#228). Otherwise fall back to a bare
+    [[label]] wikilink for nodes that don't have their own article.
+    """
+    if slug_map and label in slug_map:
+        return f"[[{label}]]({slug_map[label]}.md)"
+    return f"[[{label}]]"
+
+
 def _cross_community_links(G: nx.Graph, nodes: list[str], own_cid: int, labels: dict[int, str]) -> list[tuple[str, int]]:
     """Return (community_label, edge_count) pairs for cross-community connections, sorted descending."""
     counts: dict[str, int] = Counter()
@@ -40,6 +51,7 @@ def _community_article(
     label: str,
     labels: dict[int, str],
     cohesion: float | None,
+    slug_map: dict[str, str] | None = None,
 ) -> str:
     top_nodes = sorted(nodes, key=lambda n: G.degree(n), reverse=True)[:25]
     cross = _cross_community_links(G, nodes, cid, labels)
@@ -78,7 +90,7 @@ def _community_article(
     lines += ["## Relationships", ""]
     if cross:
         for other_label, count in cross[:12]:
-            lines.append(f"- [[{other_label}]] ({count} shared connections)")
+            lines.append(f"- {_wikilink(other_label, slug_map)} ({count} shared connections)")
     else:
         lines.append("- No strong cross-community connections detected")
     lines.append("")
@@ -100,7 +112,7 @@ def _community_article(
     return "\n".join(lines)
 
 
-def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str]) -> str:
+def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str], slug_map: dict[str, str] | None = None) -> str:
     d = G.nodes[nid]
     node_label = d.get("label", nid)
     src = d.get("source_file", "")
@@ -112,7 +124,7 @@ def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str]) -> str:
     lines += [f"> God node · {G.degree(nid)} connections · `{src}`", ""]
 
     if community_name:
-        lines += [f"**Community:** [[{community_name}]]", ""]
+        lines += [f"**Community:** {_wikilink(community_name, slug_map)}", ""]
 
     # Group neighbors by relation type
     by_relation: dict[str, list[str]] = {}
@@ -123,7 +135,7 @@ def _god_node_article(G: nx.Graph, nid: str, labels: dict[int, str]) -> str:
         neighbor_label = nd.get("label", neighbor)
         conf = ed.get("confidence", "")
         conf_str = f" `{conf}`" if conf else ""
-        by_relation.setdefault(rel, []).append(f"[[{neighbor_label}]]{conf_str}")
+        by_relation.setdefault(rel, []).append(f"{_wikilink(neighbor_label, slug_map)}{conf_str}")
 
     lines += ["## Connections by Relation", ""]
     for rel, targets in sorted(by_relation.items()):
@@ -142,6 +154,7 @@ def _index_md(
     god_nodes_data: list[dict],
     total_nodes: int,
     total_edges: int,
+    slug_map: dict[str, str] | None = None,
 ) -> str:
     lines: list[str] = [
         "# Knowledge Graph Index",
@@ -159,13 +172,13 @@ def _index_md(
 
     for cid, nodes in sorted(communities.items(), key=lambda x: -len(x[1])):
         label = labels.get(cid, f"Community {cid}")
-        lines.append(f"- [[{label}]] — {len(nodes)} nodes")
+        lines.append(f"- {_wikilink(label, slug_map)} — {len(nodes)} nodes")
     lines.append("")
 
     if god_nodes_data:
         lines += ["## God Nodes", "(most connected concepts — the load-bearing abstractions)", ""]
         for node in god_nodes_data:
-            lines.append(f"- [[{node['label']}]] — {node['degree']} connections")
+            lines.append(f"- {_wikilink(node['label'], slug_map)} — {node['degree']} connections")
         lines.append("")
 
     lines += [
@@ -221,11 +234,30 @@ def to_wiki(
         used_slugs.add(slug)
         return slug
 
+    # Pre-compute the label -> slug map (#228) so that each generated article
+    # can emit mixed [[label]](filename.md) links — Obsidian still parses the
+    # [[ ]] portion, while standard markdown renderers and agents follow the
+    # explicit relative path.
+    slug_map: dict[str, str] = {}
+    community_slugs: dict[int, str] = {}
+    for cid, nodes in communities.items():
+        label = labels.get(cid, f"Community {cid}")
+        slug = _unique_slug(_safe_filename(label))
+        community_slugs[cid] = slug
+        slug_map[label] = slug
+    god_node_slugs: dict[str, str] = {}
+    for node_data in god_nodes_data:
+        nid = node_data.get("id")
+        if nid and nid in G:
+            slug = _unique_slug(_safe_filename(node_data['label']))
+            god_node_slugs[nid] = slug
+            slug_map[node_data['label']] = slug
+
     # Community articles
     for cid, nodes in communities.items():
         label = labels.get(cid, f"Community {cid}")
-        article = _community_article(G, cid, nodes, label, labels, cohesion.get(cid))
-        slug = _unique_slug(_safe_filename(label))
+        article = _community_article(G, cid, nodes, label, labels, cohesion.get(cid), slug_map)
+        slug = community_slugs[cid]
         (out / f"{slug}.md").write_text(article, encoding="utf-8")
         count += 1
 
@@ -233,14 +265,15 @@ def to_wiki(
     for node_data in god_nodes_data:
         nid = node_data.get("id")
         if nid and nid in G:
-            article = _god_node_article(G, nid, labels)
-            slug = _unique_slug(_safe_filename(node_data['label']))
+            article = _god_node_article(G, nid, labels, slug_map)
+            slug = god_node_slugs[nid]
             (out / f"{slug}.md").write_text(article, encoding="utf-8")
             count += 1
 
     # Index
     (out / "index.md").write_text(
-        _index_md(communities, labels, god_nodes_data, G.number_of_nodes(), G.number_of_edges()),
+        _index_md(communities, labels, god_nodes_data,
+                  G.number_of_nodes(), G.number_of_edges(), slug_map),
         encoding="utf-8",
     )
 

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -137,3 +137,79 @@ def test_community_article_truncation_notice(tmp_path):
     to_wiki(G, communities, tmp_path, community_labels={0: "Big Community"})
     article = (tmp_path / "Big_Community.md").read_text()
     assert "and 5 more nodes" in article
+
+
+# -- #228: mixed [[label]](filename.md) wikilinks for non-Obsidian agents -----
+
+def test_index_uses_mixed_wikilink_for_communities(tmp_path):
+    """Communities in index.md must point at real filenames so non-Obsidian
+    agents can follow the link by reading the markdown directly (#228)."""
+    G = _make_graph()
+    to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS)
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "[[Parsing Layer]](Parsing_Layer.md)" in index
+    assert "[[Rendering Layer]](Rendering_Layer.md)" in index
+
+
+def test_index_uses_mixed_wikilink_for_god_nodes(tmp_path):
+    """God nodes in index.md must also point at their article filenames (#228)."""
+    G = _make_graph()
+    to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS,
+            god_nodes_data=GOD_NODES)
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    assert "[[parse]](parse.md)" in index
+
+
+def test_community_article_cross_links_use_mixed_format(tmp_path):
+    """Cross-community links inside an article must follow the mixed format
+    so they're navigable from a plain markdown viewer (#228)."""
+    G = _make_graph()
+    to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS, cohesion=COHESION)
+    parsing = (tmp_path / "Parsing_Layer.md").read_text(encoding="utf-8")
+    # Parsing community connects to Rendering community via n1 -> n3
+    assert "[[Rendering Layer]](Rendering_Layer.md)" in parsing
+
+
+def test_god_node_article_community_link_is_mixed(tmp_path):
+    """The 'Community: ...' line at the top of a god-node article must point
+    to the community article on disk (#228)."""
+    G = _make_graph()
+    to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS,
+            god_nodes_data=GOD_NODES)
+    parse_article = (tmp_path / "parse.md").read_text(encoding="utf-8")
+    assert "Community:** [[Parsing Layer]](Parsing_Layer.md)" in parse_article
+
+
+def test_neighbor_without_article_keeps_bare_wikilink(tmp_path):
+    """Neighbors that don't have their own .md article must stay as plain
+    [[label]] wikilinks - emitting a path to a non-existent file would
+    break agent navigation worse than the bare wikilink does."""
+    G = _make_graph()
+    to_wiki(G, COMMUNITIES, tmp_path, community_labels=LABELS,
+            god_nodes_data=GOD_NODES)
+    parse_article = (tmp_path / "parse.md").read_text(encoding="utf-8")
+    # n2 (validate) is a regular node, not a god node, so it has no article.
+    # Its link from the parse god-node article must stay bare.
+    assert "[[validate]]" in parse_article
+    assert "[[validate]](validate.md)" not in parse_article
+
+
+def test_filenames_unique_under_collisions(tmp_path):
+    """If two community labels would map to the same _safe_filename, the
+    resulting links must point at the disambiguated slugs that actually exist."""
+    G = nx.Graph()
+    G.add_node("a", label="alpha", file_type="code", source_file="a.py", community=0)
+    G.add_node("b", label="beta",  file_type="code", source_file="b.py", community=1)
+    G.add_edge("a", "b", relation="calls", confidence="EXTRACTED", weight=1.0)
+    communities = {0: ["a"], 1: ["b"]}
+    # Two different labels that both collapse to the same _safe_filename:
+    labels = {0: "Foo: Bar", 1: "Foo: Bar"}  # same string -> same slug, second gets _2
+    to_wiki(G, communities, tmp_path, community_labels=labels)
+
+    # Every filename referenced from index.md must actually exist on disk.
+    index = (tmp_path / "index.md").read_text(encoding="utf-8")
+    import re
+    referenced = re.findall(r"\]\(([^)]+\.md)\)", index)
+    assert referenced  # the test would be vacuous otherwise
+    for fname in referenced:
+        assert (tmp_path / fname).exists(), f"index.md links to missing {fname!r}"


### PR DESCRIPTION
## Summary

Issue #228 reports that the wiki's `--wiki` output is described as "agent-crawlable", but the wikilinks emitted in `index.md` and inside articles use bare Obsidian syntax:

```markdown
- [[API: Auth & Session Layer]] — 38 nodes
```

The actual file on disk is `API-_Auth_&_Session_Layer.md` (via `_safe_filename` substitutions). Any agent not running inside Obsidian — an LLM reading files from a git clone, a plain markdown renderer, GitHub's web view, etc. — sees the wikilink and cannot resolve it to a file path.

This PR switches every wiki-internal reference to a **known article** to the mixed form:

```markdown
- [[API: Auth & Session Layer]](API-_Auth_&_Session_Layer.md) — 38 nodes
```

Obsidian still parses the `[[…]]` portion as a wikilink (so internal navigation in Obsidian is unchanged); standard markdown viewers and agents follow the explicit relative path. References to nodes that don't have their own article (regular neighbors of a god node) keep the bare `[[label]]` form — emitting a path to a non-existent file would break agent navigation worse than the bare wikilink.

### Touch points

- `index.md` community list
- `index.md` god-node list
- Cross-community links inside community articles
- "Community: …" link at the top of god-node articles

### Implementation

- New `_wikilink(label, slug_map)` helper picks between the two forms based on whether the label maps to a real filename.
- `to_wiki()` pre-computes the full `slug_map` before any article is written so cross-references resolve correctly regardless of generation order.
- Slug map is threaded through `_index_md` / `_community_article` / `_god_node_article` (each gains a `slug_map` kwarg, defaulting to `None` for backward compatibility).

Closes #228

## Test plan

6 new tests in `tests/test_wiki.py` (all 21 wiki tests pass):

- `test_index_uses_mixed_wikilink_for_communities`
- `test_index_uses_mixed_wikilink_for_god_nodes`
- `test_community_article_cross_links_use_mixed_format`
- `test_god_node_article_community_link_is_mixed`
- `test_neighbor_without_article_keeps_bare_wikilink` — guards the non-article fallback
- `test_filenames_unique_under_collisions` — every link in index.md must resolve to an existing file even when `_safe_filename` collides

All existing wiki tests still pass; backward-compatible with Obsidian parsers.