### PR TITLE
fix: harden assistant hooks and AST worker fallback

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -5,7 +5,9 @@ import os
 import platform
 import re
 import shutil
+import shlex
 import sys
+import sysconfig
 from pathlib import Path
 
 try:
@@ -270,23 +272,30 @@ def gemini_install(project_dir: Path | None = None) -> None:
         skill_dst = Path.home() / ".agents" / "skills" / "graphify" / "SKILL.md"
     else:
         skill_dst = Path.home() / ".gemini" / "skills" / "graphify" / "SKILL.md"
-    skill_dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy(skill_src, skill_dst)
-    (skill_dst.parent / ".graphify_version").write_text(__version__, encoding="utf-8")
-    print(f"  skill installed  ->  {skill_dst}")
+    try:
+        skill_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(skill_src, skill_dst)
+        (skill_dst.parent / ".graphify_version").write_text(__version__, encoding="utf-8")
+        print(f"  skill installed  ->  {skill_dst}")
+    except OSError as exc:
+        print(f"  warning: could not install Gemini skill at {skill_dst} ({exc})")
+        print("  Project GEMINI.md and hook configuration will still be updated.")
 
     target = (project_dir or Path(".")) / "GEMINI.md"
 
-    if target.exists():
-        content = target.read_text(encoding="utf-8")
-        if _GEMINI_MD_MARKER in content:
-            print("graphify already configured in GEMINI.md")
+    try:
+        if target.exists():
+            content = target.read_text(encoding="utf-8")
+            if _GEMINI_MD_MARKER in content:
+                print("graphify already configured in GEMINI.md")
+            else:
+                target.write_text(content.rstrip() + "\n\n" + _GEMINI_MD_SECTION, encoding="utf-8")
+                print(f"graphify section written to {target.resolve()}")
         else:
-            target.write_text(content.rstrip() + "\n\n" + _GEMINI_MD_SECTION, encoding="utf-8")
+            target.write_text(_GEMINI_MD_SECTION, encoding="utf-8")
             print(f"graphify section written to {target.resolve()}")
-    else:
-        target.write_text(_GEMINI_MD_SECTION, encoding="utf-8")
-        print(f"graphify section written to {target.resolve()}")
+    except OSError as exc:
+        print(f"  warning: could not update GEMINI.md at {target} ({exc})")
 
     _install_gemini_hook(project_dir or Path("."))
     print()
@@ -296,15 +305,26 @@ def gemini_install(project_dir: Path | None = None) -> None:
 
 def _install_gemini_hook(project_dir: Path) -> None:
     settings_path = project_dir / ".gemini" / "settings.json"
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"  warning: could not create Gemini hook directory at {settings_path.parent} ({exc})")
+        return
     try:
         settings = json.loads(settings_path.read_text(encoding="utf-8")) if settings_path.exists() else {}
     except json.JSONDecodeError:
         settings = {}
+    except OSError as exc:
+        print(f"  warning: could not read Gemini hook config at {settings_path} ({exc})")
+        return
     before_tool = settings.setdefault("hooks", {}).setdefault("BeforeTool", [])
     settings["hooks"]["BeforeTool"] = [h for h in before_tool if "graphify" not in str(h)]
     settings["hooks"]["BeforeTool"].append(_GEMINI_HOOK)
-    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    try:
+        settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    except OSError as exc:
+        print(f"  warning: could not write Gemini hook config at {settings_path} ({exc})")
+        return
     print("  .gemini/settings.json  ->  BeforeTool hook registered")
 
 
@@ -333,11 +353,17 @@ def gemini_uninstall(project_dir: Path | None = None) -> None:
     else:
         skill_dst = Path.home() / ".gemini" / "skills" / "graphify" / "SKILL.md"
     if skill_dst.exists():
-        skill_dst.unlink()
-        print(f"  skill removed    ->  {skill_dst}")
+        try:
+            skill_dst.unlink()
+            print(f"  skill removed    ->  {skill_dst}")
+        except OSError as exc:
+            print(f"  warning: could not remove Gemini skill at {skill_dst} ({exc})")
     version_file = skill_dst.parent / ".graphify_version"
     if version_file.exists():
-        version_file.unlink()
+        try:
+            version_file.unlink()
+        except OSError as exc:
+            print(f"  warning: could not remove Gemini version stamp at {version_file} ({exc})")
     for d in (skill_dst.parent, skill_dst.parent.parent):
         try:
             d.rmdir()
@@ -715,67 +741,54 @@ def _uninstall_opencode_plugin(project_dir: Path) -> None:
         print(f"  {_OPENCODE_CONFIG_PATH}  ->  plugin deregistered")
 
 
-_CODEX_HOOK = {
-    "hooks": {
-        "PreToolUse": [
-            {
-                "matcher": "Bash",
-                "hooks": [
-                    {
-                        "type": "command",
-                        # Use the graphify CLI itself so the hook is shell-agnostic:
-                        # no [ -f ] bash syntax, no python3 vs python Conda issue,
-                        # no JSON escaping inside PowerShell strings. Works on
-                        # Windows (PowerShell/cmd.exe), macOS, and Linux.
-                        "command": "graphify hook-check",
-                    }
-                ],
-            }
-        ]
-    }
-}
+def _resolve_graphify_hook_command() -> str:
+    """Return the command Codex should run for graphify hook-check.
 
-
-def _resolve_graphify_exe() -> str:
-    """Return the absolute path to the graphify executable.
-
-    Falls back to bare 'graphify' if resolution fails. Using an absolute path
-    ensures the hook works in environments where the venv Scripts/ directory is
-    not on PATH (e.g. VS Code Codex extension on Windows).
+    Prefer the entry point from the current interpreter environment over PATH so
+    installs cannot register an older global graphify executable, while avoiding
+    `python -m graphify` cwd shadowing in target repositories.
     """
-    import shutil
-    found = shutil.which("graphify")
-    if found:
-        return found
-    # Derive from sys.executable: same Scripts/ (Windows) or bin/ (Unix) dir
-    scripts_dir = Path(sys.executable).parent
-    for name in ("graphify.exe", "graphify"):
-        candidate = scripts_dir / name
+    scripts_dir = Path(sysconfig.get_path("scripts") or Path(sys.executable).parent)
+    candidates = [scripts_dir / "graphify.exe", scripts_dir / "graphify"]
+    for candidate in candidates:
         if candidate.exists():
-            return str(candidate)
-    return "graphify"
+            args = [str(candidate), "hook-check"]
+            break
+    else:
+        args = [sys.executable, str(Path(__file__).resolve()), "hook-check"]
+    if platform.system() == "Windows":
+        return "& " + " ".join("'" + arg.replace("'", "''") + "'" for arg in args)
+    return shlex.join(args)
 
 
 def _install_codex_hook(project_dir: Path) -> None:
     """Add graphify PreToolUse hook to .codex/hooks.json."""
     hooks_path = project_dir / ".codex" / "hooks.json"
-    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"  warning: could not create .codex hook directory ({exc})")
+        return
 
     if hooks_path.exists():
         try:
             existing = json.loads(hooks_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             existing = {}
+        except OSError as exc:
+            print(f"  warning: could not read .codex/hooks.json ({exc})")
+            print("  AGENTS.md was updated; rerun `graphify codex install` outside the sandbox to register the PreToolUse hook.")
+            return
     else:
         existing = {}
 
-    graphify_exe = _resolve_graphify_exe()
+    hook_command = _resolve_graphify_hook_command()
     hook_entry = {
         "hooks": {
             "PreToolUse": [
                 {
                     "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": f"{graphify_exe} hook-check"}],
+                    "hooks": [{"type": "command", "command": hook_command}],
                 }
             ]
         }
@@ -784,8 +797,13 @@ def _install_codex_hook(project_dir: Path) -> None:
     pre_tool = existing.setdefault("hooks", {}).setdefault("PreToolUse", [])
     existing["hooks"]["PreToolUse"] = [h for h in pre_tool if "graphify" not in str(h)]
     existing["hooks"]["PreToolUse"].extend(hook_entry["hooks"]["PreToolUse"])
-    hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
-    print(f"  .codex/hooks.json  ->  PreToolUse hook registered ({graphify_exe} hook-check)")
+    try:
+        hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    except OSError as exc:
+        print(f"  warning: could not write .codex/hooks.json ({exc})")
+        print("  AGENTS.md was updated; rerun `graphify codex install` outside the sandbox to register the PreToolUse hook.")
+        return
+    print(f"  .codex/hooks.json  ->  PreToolUse hook registered ({hook_command})")
 
 
 def _uninstall_codex_hook(project_dir: Path) -> None:
@@ -797,10 +815,19 @@ def _uninstall_codex_hook(project_dir: Path) -> None:
         existing = json.loads(hooks_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return
+    except OSError as exc:
+        print(f"  warning: could not read .codex/hooks.json ({exc})")
+        print("  Rerun `graphify codex uninstall` outside the sandbox to remove the PreToolUse hook.")
+        return
     pre_tool = existing.get("hooks", {}).get("PreToolUse", [])
     filtered = [h for h in pre_tool if "graphify" not in str(h)]
     existing["hooks"]["PreToolUse"] = filtered
-    hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    try:
+        hooks_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    except OSError as exc:
+        print(f"  warning: could not write .codex/hooks.json ({exc})")
+        print("  Rerun `graphify codex uninstall` outside the sandbox to remove the PreToolUse hook.")
+        return
     print(f"  .codex/hooks.json  ->  PreToolUse hook removed")
 
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import sys
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Any
@@ -3868,9 +3869,16 @@ def extract(
     # Phase 2: extract uncached files (parallel or sequential)
     if uncached_work:
         if parallel and len(uncached_work) >= _PARALLEL_THRESHOLD:
-            _extract_parallel(
-                uncached_work, per_file, effective_root, max_workers, total
-            )
+            try:
+                _extract_parallel(
+                    uncached_work, per_file, effective_root, max_workers, total
+                )
+            except (OSError, BrokenProcessPool) as exc:
+                print(
+                    f"  AST extraction: parallel worker startup failed ({exc}); falling back to sequential extraction",
+                    flush=True,
+                )
+                _extract_sequential(uncached_work, per_file, effective_root, total)
         else:
             _extract_sequential(uncached_work, per_file, effective_root, total)
 

--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -161,35 +161,61 @@ def _hooks_dir(root: Path) -> Path:
                 p = Path(custom).expanduser()
                 if not p.is_absolute():
                     p = root / p
-                p.mkdir(parents=True, exist_ok=True)
+                try:
+                    p.mkdir(parents=True, exist_ok=True)
+                except OSError:
+                    pass
                 return p
     except (OSError, FileNotFoundError):
         pass
     d = root / ".git" / "hooks"
-    d.mkdir(exist_ok=True)
+    try:
+        d.mkdir(exist_ok=True)
+    except OSError:
+        pass
     return d
 
 
 def _install_hook(hooks_dir: Path, name: str, script: str, marker: str) -> str:
     """Install a single git hook, appending if an existing hook is present."""
     hook_path = hooks_dir / name
-    if hook_path.exists():
-        content = hook_path.read_text(encoding="utf-8")
+    try:
+        exists = hook_path.exists()
+    except OSError as exc:
+        return f"permission denied accessing {hook_path}: {exc}"
+    if exists:
+        try:
+            content = hook_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return f"permission denied reading {hook_path}: {exc}"
         if marker in content:
             return f"already installed at {hook_path}"
-        hook_path.write_text(content.rstrip() + "\n\n" + script, encoding="utf-8", newline="\n")
+        try:
+            hook_path.write_text(content.rstrip() + "\n\n" + script, encoding="utf-8", newline="\n")
+        except OSError as exc:
+            return f"permission denied writing {hook_path}: {exc}"
         return f"appended to existing {name} hook at {hook_path}"
-    hook_path.write_text("#!/bin/sh\n" + script, encoding="utf-8", newline="\n")
-    hook_path.chmod(0o755)
+    try:
+        hook_path.write_text("#!/bin/sh\n" + script, encoding="utf-8", newline="\n")
+        hook_path.chmod(0o755)
+    except OSError as exc:
+        return f"permission denied writing {hook_path}: {exc}"
     return f"installed at {hook_path}"
 
 
 def _uninstall_hook(hooks_dir: Path, name: str, marker: str, marker_end: str) -> str:
     """Remove graphify section from a git hook using start/end markers."""
     hook_path = hooks_dir / name
-    if not hook_path.exists():
+    try:
+        exists = hook_path.exists()
+    except OSError as exc:
+        return f"permission denied accessing {hook_path}: {exc}"
+    if not exists:
         return f"no {name} hook found - nothing to remove."
-    content = hook_path.read_text(encoding="utf-8")
+    try:
+        content = hook_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return f"permission denied reading {hook_path}: {exc}"
     if marker not in content:
         return f"graphify hook not found in {name} - nothing to remove."
     new_content = re.sub(
@@ -199,9 +225,15 @@ def _uninstall_hook(hooks_dir: Path, name: str, marker: str, marker_end: str) ->
         flags=re.DOTALL,
     ).strip()
     if not new_content or new_content in ("#!/bin/bash", "#!/bin/sh"):
-        hook_path.unlink()
+        try:
+            hook_path.unlink()
+        except OSError as exc:
+            return f"permission denied removing {hook_path}: {exc}"
         return f"removed {name} hook at {hook_path}"
-    hook_path.write_text(new_content + "\n", encoding="utf-8", newline="\n")
+    try:
+        hook_path.write_text(new_content + "\n", encoding="utf-8", newline="\n")
+    except OSError as exc:
+        return f"permission denied writing {hook_path}: {exc}"
     return f"graphify removed from {name} at {hook_path} (other hook content preserved)"
 
 
@@ -241,9 +273,17 @@ def status(path: Path = Path(".")) -> str:
 
     def _check(name: str, marker: str) -> str:
         p = hooks_dir / name
-        if not p.exists():
+        try:
+            exists = p.exists()
+        except OSError as exc:
+            return f"permission denied accessing hook: {exc}"
+        if not exists:
             return "not installed"
-        return "installed" if marker in p.read_text(encoding="utf-8") else "not installed (hook exists but graphify not found)"
+        try:
+            content = p.read_text(encoding="utf-8")
+        except OSError as exc:
+            return f"permission denied reading hook: {exc}"
+        return "installed" if marker in content else "not installed (hook exists but graphify not found)"
 
     commit = _check("post-commit", _HOOK_MARKER)
     checkout = _check("post-checkout", _CHECKOUT_MARKER)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -56,6 +56,49 @@ def test_extract_merges_multiple_files():
     assert result["input_tokens"] == 0
 
 
+def test_extract_falls_back_when_parallel_startup_fails(tmp_path, monkeypatch, capsys):
+    from concurrent.futures.process import BrokenProcessPool
+    import graphify.extract as extract_mod
+
+    paths = []
+    for i in range(20):
+        path = tmp_path / f"mod_{i}.py"
+        path.write_text(f"def func_{i}():\n    return {i}\n", encoding="utf-8")
+        paths.append(path)
+
+    called_sequential = False
+    original_sequential = extract_mod._extract_sequential
+
+    def fail_parallel(*args, **kwargs):
+        raise OSError("sandbox denied semaphores")
+
+    def track_sequential(*args, **kwargs):
+        nonlocal called_sequential
+        called_sequential = True
+        return original_sequential(*args, **kwargs)
+
+    monkeypatch.setattr(extract_mod, "_extract_parallel", fail_parallel)
+    monkeypatch.setattr(extract_mod, "_extract_sequential", track_sequential)
+
+    result = extract_mod.extract(paths, cache_root=tmp_path / "cache", parallel=True)
+
+    assert called_sequential
+    assert len(result["nodes"]) > 0
+    assert "falling back to sequential extraction" in capsys.readouterr().out
+
+    called_sequential = False
+
+    def fail_broken_pool(*args, **kwargs):
+        raise BrokenProcessPool("worker died")
+
+    monkeypatch.setattr(extract_mod, "_extract_parallel", fail_broken_pool)
+
+    result = extract_mod.extract(paths, cache_root=tmp_path / "cache2", parallel=True)
+
+    assert called_sequential
+    assert len(result["nodes"]) > 0
+
+
 def test_collect_files_from_dir():
     files = collect_files(FIXTURES)
     supported = {".py", ".js", ".ts", ".tsx", ".go", ".rs",

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -119,6 +119,61 @@ def test_status_shows_both_hooks(tmp_path):
     assert result.count("installed") >= 2
 
 
+def test_install_reports_permission_denied(tmp_path, monkeypatch):
+    """Protected hook dirs should not crash hook install."""
+    repo = _make_git_repo(tmp_path)
+    original = Path.write_text
+
+    def deny_post_commit(self, *args, **kwargs):
+        if self.name == "post-commit":
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", deny_post_commit)
+    result = install(repo)
+
+    assert "post-commit: permission denied" in result
+    assert "post-checkout: installed" in result
+
+
+def test_install_reports_permission_denied_reading_existing_hook(tmp_path, monkeypatch):
+    """Unreadable existing hooks should be reported without crashing."""
+    repo = _make_git_repo(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text("#!/bin/sh\necho existing\n", encoding="utf-8")
+    original = Path.read_text
+
+    def deny_post_commit(self, *args, **kwargs):
+        if self == hook:
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_post_commit)
+    result = install(repo)
+
+    assert "post-commit: permission denied reading" in result
+    assert "post-checkout: installed" in result
+
+
+def test_status_reports_permission_denied_reading_existing_hook(tmp_path, monkeypatch):
+    """Protected hook files should not crash hook status."""
+    repo = _make_git_repo(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text("#!/bin/sh\necho existing\n", encoding="utf-8")
+    original = Path.read_text
+
+    def deny_post_commit(self, *args, **kwargs):
+        if self == hook:
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_post_commit)
+    result = status(repo)
+
+    assert "post-commit: permission denied reading hook" in result
+    assert "post-checkout: not installed" in result
+
+
 def test_hook_skips_head_on_exe():
     """Hook script must skip shebang extraction for .exe binaries (Windows)."""
     from graphify.hooks import _PYTHON_DETECT

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -16,55 +16,58 @@ PLATFORMS = {
 }
 
 
-def _install(tmp_path, platform):
+def _install(tmp_path, platform, monkeypatch=None):
     from graphify.__main__ import install
+    if monkeypatch is not None:
+        monkeypatch.chdir(tmp_path)
     with patch("graphify.__main__.Path.home", return_value=tmp_path):
         install(platform=platform)
 
 
-def test_install_default_claude(tmp_path):
-    _install(tmp_path, "claude")
+def test_install_default_claude(tmp_path, monkeypatch):
+    _install(tmp_path, "claude", monkeypatch)
     assert (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_codex(tmp_path):
-    _install(tmp_path, "codex")
+def test_install_codex(tmp_path, monkeypatch):
+    _install(tmp_path, "codex", monkeypatch)
     assert (tmp_path / ".agents" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_opencode(tmp_path):
-    _install(tmp_path, "opencode")
+def test_install_opencode(tmp_path, monkeypatch):
+    _install(tmp_path, "opencode", monkeypatch)
     assert (tmp_path / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md").exists()
+    assert (tmp_path / ".opencode" / "plugins" / "graphify.js").exists()
 
 
-def test_install_claw(tmp_path):
-    _install(tmp_path, "claw")
+def test_install_claw(tmp_path, monkeypatch):
+    _install(tmp_path, "claw", monkeypatch)
     assert (tmp_path / ".openclaw" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_droid(tmp_path):
-    _install(tmp_path, "droid")
+def test_install_droid(tmp_path, monkeypatch):
+    _install(tmp_path, "droid", monkeypatch)
     assert (tmp_path / ".factory" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_trae(tmp_path):
-    _install(tmp_path, "trae")
+def test_install_trae(tmp_path, monkeypatch):
+    _install(tmp_path, "trae", monkeypatch)
     assert (tmp_path / ".trae" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_trae_cn(tmp_path):
-    _install(tmp_path, "trae-cn")
+def test_install_trae_cn(tmp_path, monkeypatch):
+    _install(tmp_path, "trae-cn", monkeypatch)
     assert (tmp_path / ".trae-cn" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_windows(tmp_path):
-    _install(tmp_path, "windows")
+def test_install_windows(tmp_path, monkeypatch):
+    _install(tmp_path, "windows", monkeypatch)
     assert (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
 
 
-def test_install_unknown_platform_exits(tmp_path):
+def test_install_unknown_platform_exits(tmp_path, monkeypatch):
     with pytest.raises(SystemExit):
-        _install(tmp_path, "unknown")
+        _install(tmp_path, "unknown", monkeypatch)
 
 
 def test_codex_skill_contains_spawn_agent():
@@ -98,14 +101,14 @@ def test_all_skill_files_exist_in_package():
         assert (pkg / name).exists(), f"Missing: {name}"
 
 
-def test_claude_install_registers_claude_md(tmp_path):
+def test_claude_install_registers_claude_md(tmp_path, monkeypatch):
     """Claude platform install writes CLAUDE.md; others do not."""
-    _install(tmp_path, "claude")
+    _install(tmp_path, "claude", monkeypatch)
     assert (tmp_path / ".claude" / "CLAUDE.md").exists()
 
 
-def test_codex_install_does_not_write_claude_md(tmp_path):
-    _install(tmp_path, "codex")
+def test_codex_install_does_not_write_claude_md(tmp_path, monkeypatch):
+    _install(tmp_path, "codex", monkeypatch)
     assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
 
 
@@ -127,6 +130,106 @@ def test_codex_agents_install_writes_agents_md(tmp_path):
     assert agents_md.exists()
     assert "graphify" in agents_md.read_text()
     assert "GRAPH_REPORT.md" in agents_md.read_text()
+
+
+def test_codex_hook_uses_current_interpreter(tmp_path, monkeypatch):
+    """Codex hook must not point at a stale graphify binary from PATH."""
+    import json as _json
+    import shlex
+    import graphify.__main__ as main
+
+    scripts = tmp_path / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    graphify_bin = scripts / "graphify"
+    graphify_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(main.sysconfig, "get_path", lambda name: str(scripts) if name == "scripts" else "")
+    monkeypatch.setattr(main.platform, "system", lambda: "Darwin")
+    _agents_install(tmp_path, "codex")
+    hooks = _json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert command == shlex.join([str(graphify_bin), "hook-check"])
+    assert "-m graphify" not in command
+
+
+@pytest.mark.parametrize("shadow_kind", ["module", "package"])
+def test_codex_hook_command_avoids_target_repo_graphify_shadowing(tmp_path, shadow_kind):
+    """Hook command should run installed graphify even if cwd has graphify/."""
+    import json as _json
+    import subprocess
+
+    _agents_install(tmp_path, "codex")
+    hooks = _json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    target = tmp_path / "target"
+    target.mkdir()
+    if shadow_kind == "module":
+        (target / "graphify.py").write_text(
+            'raise RuntimeError("shadow graphify module imported")\n',
+            encoding="utf-8",
+        )
+    else:
+        shadow_pkg = target / "graphify"
+        shadow_pkg.mkdir()
+        (shadow_pkg / "__init__.py").write_text(
+            'raise RuntimeError("shadow graphify package imported")\n',
+            encoding="utf-8",
+        )
+
+    result = subprocess.run(command, cwd=target, shell=True, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_codex_hook_command_posix_quotes_shell_metacharacters(monkeypatch):
+    """POSIX hooks should not expose interpreter paths to shell expansion."""
+    import shlex
+    import graphify.__main__ as main
+
+    exe = '/tmp/a$b`c" d/bin/python'
+    scripts = Path('/tmp/a$b`c" d/bin')
+    monkeypatch.setattr(main.sys, "executable", exe)
+    monkeypatch.setattr(main.sysconfig, "get_path", lambda name: str(scripts) if name == "scripts" else "")
+    monkeypatch.setattr(Path, "exists", lambda self: self == scripts / "graphify")
+    monkeypatch.setattr(main.platform, "system", lambda: "Darwin")
+
+    assert main._resolve_graphify_hook_command() == shlex.join(
+        [str(scripts / "graphify"), "hook-check"]
+    )
+
+
+def test_codex_hook_command_falls_back_to_absolute_main(monkeypatch):
+    """Fallback should not use cwd-sensitive `python -m graphify`."""
+    import shlex
+    import sys
+    import graphify.__main__ as main
+
+    monkeypatch.setattr(main.sysconfig, "get_path", lambda name: "" if name == "scripts" else "")
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    monkeypatch.setattr(main.platform, "system", lambda: "Darwin")
+
+    command = main._resolve_graphify_hook_command()
+
+    assert command == shlex.join([sys.executable, str(Path(main.__file__).resolve()), "hook-check"])
+    assert "-m graphify" not in command
+
+
+def test_codex_hook_command_windows_uses_powershell_call_operator(monkeypatch):
+    """Windows Codex hooks run under PowerShell and need explicit invocation."""
+    import graphify.__main__ as main
+
+    exe = r"C:\Users\O'Brien\AppData\Local\Programs\Python\python.exe"
+    scripts = Path(r"C:\Users\O'Brien\AppData\Local\Programs\Python\Scripts")
+    monkeypatch.setattr(main.sys, "executable", exe)
+    monkeypatch.setattr(main.sysconfig, "get_path", lambda name: str(scripts) if name == "scripts" else "")
+    monkeypatch.setattr(Path, "exists", lambda self: self == scripts / "graphify.exe")
+    monkeypatch.setattr(main.platform, "system", lambda: "Windows")
+
+    assert main._resolve_graphify_hook_command() == (
+        r"& 'C:\Users\O''Brien\AppData\Local\Programs\Python\Scripts/graphify.exe' 'hook-check'"
+    )
 
 
 def test_opencode_agents_install_writes_agents_md(tmp_path):
@@ -155,6 +258,41 @@ def test_agents_install_appends_to_existing(tmp_path):
     content = agents_md.read_text()
     assert "Do not break things." in content
     assert "## graphify" in content
+
+
+def test_codex_agents_install_warns_when_hook_write_denied(tmp_path, monkeypatch, capsys):
+    """Codex install should still write AGENTS.md if .codex is protected."""
+    original = Path.write_text
+
+    def deny_hooks_json(self, *args, **kwargs):
+        if self.name == "hooks.json":
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", deny_hooks_json)
+    _agents_install(tmp_path, "codex")
+
+    assert (tmp_path / "AGENTS.md").exists()
+    assert "could not write .codex/hooks.json" in capsys.readouterr().out
+
+
+def test_codex_agents_install_warns_when_hook_read_denied(tmp_path, monkeypatch, capsys):
+    """Unreadable existing Codex hook config should not crash install."""
+    hooks = tmp_path / ".codex" / "hooks.json"
+    hooks.parent.mkdir()
+    hooks.write_text("{}", encoding="utf-8")
+    original = Path.read_text
+
+    def deny_hooks_json(self, *args, **kwargs):
+        if self == hooks:
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_hooks_json)
+    _agents_install(tmp_path, "codex")
+
+    assert (tmp_path / "AGENTS.md").exists()
+    assert "could not read .codex/hooks.json" in capsys.readouterr().out
 
 
 def test_agents_uninstall_removes_section(tmp_path):
@@ -274,6 +412,43 @@ def test_gemini_install_writes_gemini_md(tmp_path):
     md = tmp_path / "GEMINI.md"
     assert md.exists()
     assert "graphify-out/GRAPH_REPORT.md" in md.read_text()
+
+def test_gemini_install_continues_when_global_skill_denied(tmp_path, monkeypatch, capsys):
+    from graphify.__main__ import gemini_install
+    original_mkdir = Path.mkdir
+
+    def deny_skill_dir(self, *args, **kwargs):
+        if "skills" in self.parts:
+            raise PermissionError("sandbox denied")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(Path, "mkdir", deny_skill_dir)
+    gemini_install(tmp_path)
+
+    assert (tmp_path / "GEMINI.md").exists()
+    out = capsys.readouterr().out
+    assert "could not install Gemini skill" in out
+    assert "BeforeTool hook registered" in out
+
+
+def test_gemini_install_warns_when_hook_write_denied(tmp_path, monkeypatch, capsys):
+    from graphify.__main__ import gemini_install
+    original = Path.write_text
+
+    def deny_settings_json(self, *args, **kwargs):
+        if self.name == "settings.json":
+            raise PermissionError("sandbox denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(Path, "write_text", deny_settings_json)
+    gemini_install(tmp_path)
+
+    out = capsys.readouterr().out
+    assert (tmp_path / "GEMINI.md").exists()
+    assert "could not write Gemini hook config" in out
+
 
 def test_gemini_install_writes_hook(tmp_path):
     import json as _json


### PR DESCRIPTION
## Summary
- run the Codex `hook-check` command through the current Python environment's entry point instead of a possibly stale `graphify` binary from `PATH`
- quote the Codex hook command for POSIX shells and Windows PowerShell
- avoid target-repo `graphify.py` / `graphify/` shadowing when Codex runs the hook from a project cwd
- report hook install/read/write/status failures instead of crashing where filesystem access is denied
- fall back to sequential AST extraction when process workers cannot start or the process pool breaks

## Why
This makes Graphify more reliable in venv, uv/pipx, PowerShell, sandboxed, and protected-directory environments without changing the Codex hook payload behavior. `hook-check` remains a silent no-op and graph guidance still comes from `AGENTS.md` / installed skills.

## Tests
- `.venv/bin/python -m pytest tests/test_install.py tests/test_hooks.py tests/test_extract.py -q --tb=short`
- `.venv/bin/python -m pip install tree-sitter-sql`
- `.venv/bin/python -m pytest tests/ -q --tb=short`
- `git diff --check`
- `.venv/bin/python -m compileall -q graphify`
- `.venv/bin/python -m graphify update .`
- `.venv/bin/python -m graphify hook-check`

## Links
- Helps #522
- Refs #328
- Follow-up to #663
