### PR TITLE
Make default VS Code Copilot graphify instructions stricter so agents stop bypassing GRAPH_REPORT.md

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -368,11 +368,25 @@ def gemini_uninstall(project_dir: Path | None = None) -> None:
 
 _VSCODE_INSTRUCTIONS_MARKER = "## graphify"
 _VSCODE_INSTRUCTIONS_SECTION = """\
-## graphify
+## graphify (MANDATORY FIRST STEP)
 
-Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` if it exists.
-If `graphify-out/wiki/index.md` exists, navigate it for deep questions.
-Type `/graphify` in Copilot Chat to build or update the knowledge graph.
+For ANY question about this repo's architecture, structure, components, conventions,
+or how to add/modify/find code, your **first tool call MUST be** to read
+`graphify-out/GRAPH_REPORT.md` (if it exists). No exceptions — even for "simple" questions,
+even if you've read it earlier in the session.
+
+Triggers include: "how do I…", "where is…", "what does … do", "add/modify a <component>",
+"explain the <architecture|flow>", or anything that depends on how files/classes relate.
+
+After reading the report (and `graphify-out/wiki/index.md` for deep questions), answer
+from the graph. **Do NOT re-verify by opening source files** for conceptual questions —
+the graph is the grounding. Read source only when (a) modifying/debugging specific code,
+(b) the graph genuinely lacks the needed detail, or (c) the graph is missing/stale.
+
+Before each reply, self-check: did my first tool call read `GRAPH_REPORT.md`? If not, stop
+and read it now.
+
+Type `/graphify` in Copilot Chat to build or update the graph.
 """
 
 


### PR DESCRIPTION
The default `## graphify` section that `graphify vscode install` writes to `.github/copilot-instructions.md` is too soft. In practice, Copilot agents (both VS Code Copilot Chat and the GitHub Copilot CLI) frequently bypass it — they answer architecture / how-to / where-is questions straight from memory or by grepping source, instead of reading `graphify-out/GRAPH_REPORT.md` first. That defeats the whole point of having the graph.

### What this PR changes

Replaces `_VSCODE_INSTRUCTIONS_SECTION` in `graphify/__main__.py` with a more prescriptive version:

- **Mandatory first tool call**: for any architecture/codebase question, the agent's first tool call must be reading `graphify-out/GRAPH_REPORT.md`.
- **Explicit trigger list**: `how do I…`, `where is…`, `add a handler`, `explain the architecture`, etc.
- **Trust the graph**: explicit instruction *not* to re-verify by opening source files after the graph for conceptual questions.
- **Narrow allowlist**: source reads are still allowed for actual code modification / debugging / when the graph is genuinely missing detail or is stale.
- **Self-check**: the agent is told to verify before each reply that its first tool call read the report.

### Why

Tested locally with the Copilot CLI on a Java REST API repo:

- With the soft wording, the agent answered `what's needed to add a new endpoint?` without ever reading `GRAPH_REPORT.md`.
- With the stricter wording, the agent consistently reads `GRAPH_REPORT.md` first and grounds its answer in god nodes / communities.

### Scope

- Only touches `_VSCODE_INSTRUCTIONS_SECTION` (the VS Code / Copilot install path).
- Does not touch the Antigravity, Kiro, Aider, Claude, Codex, etc. templates — those can be aligned in a follow-up if this approach is accepted.
- Does not change install/uninstall logic; the marker (`## graphify`) is still detected so re-runs and `vscode uninstall` keep working. Note: existing repos that already have the soft section won't be auto-upgraded (the install is a no-op when the marker is present), same behaviour as today.

### Test

`vscode install` / `vscode uninstall` still work end-to-end on a fresh repo and on a repo that already has the new section.
