### PR TITLE
Add Solidity AST extraction (.sol) via tree-sitter-solidity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ scripts/run_k2_*.py
 scripts/llm.py
 scripts/benchmark_kimi*.json
 scripts/benchmark_kimi*.py
+
+# Local planning notes
+SOLIDITY_PLAN.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Feat: Solidity support -- `.sol` files extracted via `tree-sitter-solidity`. Covers contracts/interfaces/libraries, free functions, modifiers, events, errors, structs, enums, state variables, constructors, and fallback/receive. Edges include `inherits`, `imports`, `imports_from` (named imports + `using ... for ...`), `applies_modifier`, `emits`, and `calls` (low-confidence 0.5 for member calls, 1.0 for direct). A pre-pass collects file-wide name maps so inheritance, modifier invocations, and emit statements resolve to in-file definitions instead of dangling bare-name targets. Builtins (`require`/`assert`/`keccak256`/type conversions) are filtered from `calls`, and `revert_statement` subtrees are skipped so error construction is not misclassified as a function call. Available via `pip install graphifyy[solidity]`. Validated against OpenZeppelin contracts (349 `.sol` files, 0 errors, ~0.8 ms/file).
+
 ## 0.7.15 (2026-05-11)
 
 - Fix: `-h`/`--help`/`-?` in any position now stops execution — previously `graphify cursor install --help` silently installed into Cursor; `graphify benchmark --help` crashed with FileNotFoundError (#821)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To remove graphify from all platforms at once: `graphify uninstall` (add `--purg
 
 | Type | Extensions |
 |------|-----------|
-| Code (29 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .groovy .gradle .dart .v .sv .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk` |
+| Code (30 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .groovy .gradle .dart .v .sv .sql .sol .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk` |
 | Docs | `.md .mdx .qmd .html .txt .rst .yaml .yml` |
 | Office | `.docx .xlsx` (requires `pip install graphifyy[office]`) |
 | Google Workspace | `.gdoc .gsheet .gslides` (opt-in; requires `gws` auth and `--google-workspace`; Sheets need `pip install graphifyy[google]`) |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -24,7 +24,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.sol', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4547,6 +4547,353 @@ def extract_markdown(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges, "input_tokens": 0, "output_tokens": 0}
 
 
+# Solidity built-in functions/types that parse as call_expression but aren't real calls.
+_SOL_BUILTINS: frozenset[str] = frozenset({
+    "require", "assert", "revert",
+    "keccak256", "sha256", "sha3", "ripemd160", "ecrecover",
+    "addmod", "mulmod", "blockhash", "gasleft", "selfdestruct",
+    "type", "address", "payable", "string", "bytes",
+    "uint", "uint8", "uint16", "uint32", "uint64", "uint128", "uint256",
+    "int", "int8", "int16", "int32", "int64", "int128", "int256",
+    "bool",
+})
+
+
+def extract_solidity(path: Path) -> dict:
+    """Extract contracts, interfaces, libraries, functions, modifiers, events, errors,
+    structs, enums, state variables, plus inheritance/imports/calls/emits/modifiers
+    from a .sol file via tree-sitter.
+
+    Two-pass: pre-pass collects file-wide declaration name→nid maps so that
+    inheritance, modifier invocations, and emit statements resolve to in-file
+    definitions when present (instead of producing dangling bare-name targets).
+    """
+    try:
+        import tree_sitter_solidity as tssol
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return {"nodes": [], "edges": [], "error": "tree_sitter_solidity not installed. Run: pip install tree-sitter-solidity"}
+
+    try:
+        language = Language(tssol.language())
+        parser = Parser(language)
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        root = tree.root_node
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    stem = _file_stem(path)
+    str_path = str(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+
+    def add_node(nid: str, label: str, line: int) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": "code",
+                          "source_file": str_path, "source_location": f"L{line}",
+                          "confidence_score": 1.0})
+
+    def add_edge(src: str, tgt: str, relation: str, line: int,
+                 confidence: str = "EXTRACTED", score: float = 1.0,
+                 context: str | None = None) -> None:
+        edge = {"source": src, "target": tgt, "relation": relation,
+                "confidence": confidence, "confidence_score": score,
+                "source_file": str_path, "source_location": f"L{line}", "weight": 1.0}
+        if context:
+            edge["context"] = context
+        edges.append(edge)
+
+    file_nid = _make_id(str(path))
+    add_node(file_nid, path.name, 1)
+
+    def _name_text(node) -> str | None:
+        n = node.child_by_field_name("name")
+        if n:
+            return _read_text(n, source)
+        return None
+
+    # ── Pass 1: collect file-wide name maps for target resolution ────────────
+    decl_map: dict[str, str] = {}      # contract/interface/library name → nid
+    modifier_map: dict[str, str] = {}  # modifier name → nid (flat; collisions: last wins)
+    event_map: dict[str, str] = {}     # event name → nid
+
+    for top_child in root.children:
+        if top_child.type not in ("contract_declaration", "interface_declaration", "library_declaration"):
+            continue
+        decl_name = _name_text(top_child)
+        if not decl_name:
+            continue
+        decl_nid = _make_id(stem, decl_name)
+        decl_map[decl_name] = decl_nid
+
+        body = top_child.child_by_field_name("body")
+        if not body:
+            continue
+        for member in body.children:
+            mt = member.type
+            mname = _name_text(member)
+            if not mname:
+                continue
+            if mt == "modifier_definition":
+                modifier_map[mname] = _make_id(decl_nid, mname)
+            elif mt == "event_definition":
+                event_map[mname] = _make_id(decl_nid, "event", mname)
+
+    def _resolve_decl(name: str) -> str:
+        return decl_map.get(name) or _make_id(name)
+
+    def _resolve_modifier(name: str) -> str:
+        return modifier_map.get(name) or _make_id(name)
+
+    def _resolve_event(name: str) -> str:
+        return event_map.get(name) or _make_id(name)
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
+    def _emit_event_name(emit_node) -> str | None:
+        # emit_statement.name field wraps an identifier or member_expression. Read
+        # only the name field (not full subtree) to avoid picking up identifiers
+        # from event arguments.
+        name_field = emit_node.child_by_field_name("name")
+        if not name_field:
+            return None
+        inner = name_field
+        # Unwrap `expression` wrapper if present
+        while inner.type == "expression" and inner.children:
+            inner = inner.children[0]
+        if inner.type == "identifier":
+            return _read_text(inner, source)
+        if inner.type == "member_expression":
+            prop = inner.child_by_field_name("property")
+            if prop:
+                return _read_text(prop, source)
+        # Fallback: first identifier child of name field
+        for c in name_field.children:
+            if c.type == "identifier":
+                return _read_text(c, source)
+        return None
+
+    def _walk_calls(body_node, caller_nid: str) -> None:
+        # Walk function body; emit `calls`/`emits` edges. Skip revert_statement
+        # subtrees (NotOwner(...) inside revert is error construction, not a call).
+        stack = [body_node]
+        while stack:
+            n = stack.pop()
+            t = n.type
+
+            if t == "revert_statement":
+                # Don't descend: revert_arguments contains a call_expression-like
+                # invocation of the error type, which isn't a function call.
+                continue
+
+            if t == "call_expression":
+                fn = n.child_by_field_name("function") or (n.children[0] if n.children else None)
+                if fn is not None:
+                    line = n.start_point[0] + 1
+                    if fn.type == "expression" and fn.children:
+                        fn = fn.children[0]
+                    if fn.type == "identifier":
+                        callee = _read_text(fn, source)
+                        if callee not in _SOL_BUILTINS:
+                            tgt = _make_id(callee)
+                            add_node(tgt, f"{callee}()", line)
+                            add_edge(caller_nid, tgt, "calls", line)
+                    elif fn.type == "member_expression":
+                        prop = fn.child_by_field_name("property")
+                        if prop:
+                            method = _read_text(prop, source)
+                            if method not in _SOL_BUILTINS:
+                                tgt = _make_id(method)
+                                add_node(tgt, f"{method}()", line)
+                                add_edge(caller_nid, tgt, "calls", line,
+                                         confidence="INFERRED", score=0.5,
+                                         context="member_call")
+                    elif fn.type == "primitive_type":
+                        # `address(this)`, `uint256(x)` etc — type conversion, not a call
+                        pass
+
+            elif t == "emit_statement":
+                event = _emit_event_name(n)
+                if event:
+                    line = n.start_point[0] + 1
+                    tgt = _resolve_event(event)
+                    add_node(tgt, event, line)
+                    add_edge(caller_nid, tgt, "emits", line)
+
+            for child in n.children:
+                stack.append(child)
+
+    def _walk_function(fn_node, parent_nid: str, parent_relation: str = "contains") -> None:
+        # Handles function_definition, modifier_definition, constructor_definition, fallback_receive_definition.
+        # parent_relation: "contains" for contract members, "defines" for file-scoped free functions.
+        t = fn_node.type
+        line = fn_node.start_point[0] + 1
+
+        if t == "constructor_definition":
+            fn_label = "constructor()"
+            fn_id_part = "constructor"
+        elif t == "fallback_receive_definition":
+            kind = "fallback"
+            for c in fn_node.children:
+                if c.type in ("receive", "fallback"):
+                    kind = c.type
+                    break
+            fn_label = f"{kind}()"
+            fn_id_part = kind
+        elif t == "modifier_definition":
+            name = _name_text(fn_node)
+            if not name:
+                return
+            fn_label = f"{name}()"
+            fn_id_part = name
+        else:
+            name = _name_text(fn_node)
+            if not name:
+                return
+            fn_label = f"{name}()"
+            fn_id_part = name
+
+        fn_nid = _make_id(parent_nid, fn_id_part)
+        add_node(fn_nid, fn_label, line)
+        add_edge(parent_nid, fn_nid, parent_relation, line)
+
+        # Modifier invocations on function header (skip on modifier definitions themselves)
+        if t != "modifier_definition":
+            for c in fn_node.children:
+                if c.type == "modifier_invocation":
+                    for grand in c.children:
+                        if grand.type == "identifier":
+                            mod_name = _read_text(grand, source)
+                            mod_line = c.start_point[0] + 1
+                            mod_tgt = _resolve_modifier(mod_name)
+                            add_node(mod_tgt, mod_name, mod_line)
+                            add_edge(fn_nid, mod_tgt, "applies_modifier", mod_line)
+                            break
+
+        body = fn_node.child_by_field_name("body")
+        if body:
+            _walk_calls(body, fn_nid)
+
+    def _walk_contract_body(body_node, contract_nid: str) -> None:
+        for child in body_node.children:
+            t = child.type
+            line = child.start_point[0] + 1
+
+            if t in ("function_definition", "modifier_definition",
+                     "constructor_definition", "fallback_receive_definition"):
+                _walk_function(child, contract_nid)
+
+            elif t == "event_definition":
+                name = _name_text(child)
+                if name:
+                    nid = _make_id(contract_nid, "event", name)
+                    add_node(nid, name, line)
+                    add_edge(contract_nid, nid, "contains", line)
+
+            elif t == "error_declaration":
+                name = _name_text(child)
+                if name:
+                    nid = _make_id(contract_nid, "error", name)
+                    add_node(nid, name, line)
+                    add_edge(contract_nid, nid, "contains", line)
+
+            elif t == "struct_declaration":
+                name = _name_text(child)
+                if name:
+                    nid = _make_id(contract_nid, "struct", name)
+                    add_node(nid, name, line)
+                    add_edge(contract_nid, nid, "contains", line)
+
+            elif t == "enum_declaration":
+                name = _name_text(child)
+                if name:
+                    nid = _make_id(contract_nid, "enum", name)
+                    add_node(nid, name, line)
+                    add_edge(contract_nid, nid, "contains", line)
+
+            elif t == "state_variable_declaration":
+                name = _name_text(child)
+                if name:
+                    nid = _make_id(contract_nid, "var", name)
+                    add_node(nid, name, line)
+                    add_edge(contract_nid, nid, "contains", line)
+
+            elif t == "using_directive":
+                # `using Lib for Type;` — emit imports_from edge from contract to library
+                lib_name = None
+                for c in child.children:
+                    if c.type == "type_alias":
+                        for g in c.children:
+                            if g.type == "identifier":
+                                lib_name = _read_text(g, source)
+                                break
+                        break
+                if lib_name:
+                    tgt = _resolve_decl(lib_name)
+                    add_node(tgt, lib_name, line)
+                    add_edge(contract_nid, tgt, "imports_from", line, context="using_for")
+
+    def _walk_top(node) -> None:
+        for child in node.children:
+            t = child.type
+            line = child.start_point[0] + 1
+
+            if t == "import_directive":
+                source_node = child.child_by_field_name("source")
+                import_name = child.child_by_field_name("import_name")
+                alias_node = child.child_by_field_name("alias")
+                if source_node:
+                    src_text = _read_text(source_node, source).strip('"\'')
+                    src_tgt = _make_id(src_text)
+                    add_node(src_tgt, src_text, line)
+                    if import_name:
+                        sym = _read_text(import_name, source)
+                        sym_tgt = _make_id(sym)
+                        add_node(sym_tgt, sym, line)
+                        add_edge(file_nid, sym_tgt, "imports_from", line, context=src_text)
+                    else:
+                        add_edge(file_nid, src_tgt, "imports", line)
+                    if alias_node:
+                        alias = _read_text(alias_node, source)
+                        alias_tgt = _make_id(alias)
+                        add_node(alias_tgt, alias, line)
+                        add_edge(file_nid, alias_tgt, "imports", line, context=f"alias_for:{src_text}")
+
+            elif t in ("contract_declaration", "interface_declaration", "library_declaration"):
+                name = _name_text(child)
+                if not name:
+                    continue
+                contract_nid = _make_id(stem, name)
+                add_node(contract_nid, name, line)
+                add_edge(file_nid, contract_nid, "defines", line)
+
+                for c in child.children:
+                    if c.type == "inheritance_specifier":
+                        anc = c.child_by_field_name("ancestor")
+                        if anc:
+                            for g in anc.children:
+                                if g.type == "identifier":
+                                    anc_name = _read_text(g, source)
+                                    anc_line = c.start_point[0] + 1
+                                    anc_tgt = _resolve_decl(anc_name)
+                                    add_node(anc_tgt, anc_name, anc_line)
+                                    add_edge(contract_nid, anc_tgt, "inherits", anc_line)
+                                    break
+
+                body = child.child_by_field_name("body")
+                if body:
+                    _walk_contract_body(body, contract_nid)
+
+            elif t == "function_definition":
+                _walk_function(child, file_nid, parent_relation="defines")
+
+    _walk_top(root)
+    return {"nodes": nodes, "edges": edges}
+
+
 # ── Pascal / Delphi extractor ─────────────────────────────────────────────────
 
 _pascal_unit_cache: dict[str, dict[str, str]] = {}
@@ -5506,6 +5853,7 @@ _DISPATCH: dict[str, Any] = {
     ".dfm": extract_delphi_form,
     ".lfm": extract_lazarus_form,
     ".lpk": extract_lazarus_package,
+    ".sol": extract_solidity,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ bedrock = ["boto3"]
 gemini = ["openai", "tiktoken"]
 openai = ["openai", "tiktoken"]
 sql = ["tree-sitter-sql"]
-all = ["mcp", "neo4j", "pypdf", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper", "yt-dlp", "matplotlib", "openai", "tiktoken", "boto3", "tree-sitter-sql"]
+solidity = ["tree-sitter-solidity>=1.2.13,<2"]
+all = ["mcp", "neo4j", "pypdf", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper", "yt-dlp", "matplotlib", "openai", "tiktoken", "boto3", "tree-sitter-sql", "tree-sitter-solidity>=1.2.13,<2"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/fixtures/sample.sol
+++ b/tests/fixtures/sample.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IERC20.sol";
+import {Ownable} from "./Ownable.sol";
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+library MathLib {
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+}
+
+abstract contract Ownable {
+    address public owner;
+    error NotOwner(address caller);
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner(msg.sender);
+        _;
+    }
+}
+
+contract Token is IERC20, Ownable {
+    using MathLib for uint256;
+
+    enum Status { Active, Paused }
+    struct Account { uint256 balance; bool frozen; }
+
+    mapping(address => uint256) public balances;
+    Status public status;
+    uint256 constant MAX_SUPPLY = 1e27;
+
+    event Minted(address indexed to, uint256 amount);
+    error InsufficientBalance(uint256 requested, uint256 available);
+
+    constructor(uint256 initial) {
+        owner = msg.sender;
+        balances[msg.sender] = initial;
+    }
+
+    receive() external payable {}
+    fallback() external payable {}
+
+    function transfer(address to, uint256 amount) external override onlyOwner returns (bool) {
+        if (balances[msg.sender] < amount) revert InsufficientBalance(amount, balances[msg.sender]);
+        balances[msg.sender] = balances[msg.sender].add(amount);
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+}
+
+function freeFunction(uint256 x) pure returns (uint256) {
+    return x * 2;
+}

--- a/tests/fixtures/solidity/Ownable.sol
+++ b/tests/fixtures/solidity/Ownable.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+abstract contract Ownable {
+    address public owner;
+    error NotOwner(address caller);
+    event OwnershipTransferred(address indexed previous, address indexed next);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner(msg.sender);
+        _;
+    }
+
+    function transferOwnership(address next) external onlyOwner {
+        emit OwnershipTransferred(owner, next);
+        owner = next;
+    }
+}

--- a/tests/fixtures/solidity/Token.sol
+++ b/tests/fixtures/solidity/Token.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address holder) external view returns (uint256);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+library SafeMath {
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+}
+
+contract Token is IERC20 {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) private _balances;
+
+    function balanceOf(address holder) external view returns (uint256) {
+        return _balances[holder];
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _balances[msg.sender] = _balances[msg.sender].add(amount);
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+}

--- a/tests/fixtures/solidity/Vault.sol
+++ b/tests/fixtures/solidity/Vault.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "./Ownable.sol";
+import "./Token.sol";
+
+contract Vault is Ownable {
+    Token public token;
+
+    event Deposited(address indexed from, uint256 amount);
+
+    constructor(Token _token) {
+        owner = msg.sender;
+        token = _token;
+    }
+
+    function deposit(uint256 amount) external onlyOwner {
+        token.transfer(address(this), amount);
+        emit Deposited(msg.sender, amount);
+    }
+}

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -1,9 +1,9 @@
-"""Tests for multi-language AST extraction: JS/TS, Go, Rust, SQL."""
+"""Tests for multi-language AST extraction: JS/TS, Go, Rust, SQL, Solidity."""
 from __future__ import annotations
 import shutil
 from pathlib import Path
 import pytest
-from graphify.extract import extract_js, extract_go, extract_rust, extract, extract_sql
+from graphify.extract import extract_js, extract_go, extract_rust, extract, extract_sql, extract_solidity
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -279,3 +279,195 @@ def test_sql_schema_qualified_alter_fk():
     for e in fk_edges:
         assert e["source"] in node_ids, f"dangling source: {e['source']}"
         assert e["target"] in node_ids, f"dangling target: {e['target']}"
+
+
+# ── Solidity ──────────────────────────────────────────────────────────────────
+
+def _sol():
+    pytest.importorskip("tree_sitter_solidity")
+    return extract_solidity(FIXTURES / "sample.sol")
+
+
+def test_solidity_no_error():
+    r = _sol()
+    assert "error" not in r, r.get("error")
+
+
+def test_solidity_finds_contract_interface_library():
+    labels = [n["label"] for n in _sol()["nodes"]]
+    assert "Token" in labels
+    assert "IERC20" in labels
+    assert "MathLib" in labels
+    assert "Ownable" in labels
+
+
+def test_solidity_finds_functions_modifier_constructor():
+    labels = [n["label"] for n in _sol()["nodes"]]
+    assert "transfer()" in labels
+    assert "add()" in labels
+    assert "onlyOwner()" in labels
+    assert "constructor()" in labels
+    assert "receive()" in labels
+    assert "fallback()" in labels
+
+
+def test_solidity_finds_events_errors_struct_enum_state_var():
+    labels = [n["label"] for n in _sol()["nodes"]]
+    assert "Minted" in labels
+    assert "InsufficientBalance" in labels
+    assert "Account" in labels
+    assert "Status" in labels
+    assert "balances" in labels
+
+
+def test_solidity_finds_free_function():
+    labels = [n["label"] for n in _sol()["nodes"]]
+    assert "freeFunction()" in labels
+
+
+def test_solidity_inheritance_edges():
+    relations = {e["relation"] for e in _sol()["edges"]}
+    assert "inherits" in relations
+
+
+def test_solidity_import_edges():
+    relations = {e["relation"] for e in _sol()["edges"]}
+    assert "imports" in relations
+    assert "imports_from" in relations
+
+
+def test_solidity_emits_edge():
+    relations = {e["relation"] for e in _sol()["edges"]}
+    assert "emits" in relations
+
+
+def test_solidity_applies_modifier_edge():
+    relations = {e["relation"] for e in _sol()["edges"]}
+    assert "applies_modifier" in relations
+
+
+def test_solidity_using_for_emits_imports_from_with_context():
+    edges = [e for e in _sol()["edges"]
+             if e["relation"] == "imports_from" and e.get("context") == "using_for"]
+    assert edges, "expected `using ... for ...` to emit imports_from edge with context=using_for"
+
+
+def test_solidity_member_call_low_confidence():
+    edges = [e for e in _sol()["edges"]
+             if e["relation"] == "calls" and e.get("context") == "member_call"]
+    assert edges, "expected at least one member call (e.g. .add())"
+    assert all(e["confidence_score"] < 1.0 for e in edges)
+
+
+def test_solidity_no_dangling_sources():
+    r = _sol()
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in r["edges"]:
+        assert e["source"] in node_ids, f"dangling source: {e['source']}"
+
+
+def test_solidity_inheritance_resolves_to_in_file_def():
+    """Token is IERC20, Ownable — both ancestors are defined in the same file,
+    so inherits edges should target the in-file declaration nodes (not bare names)."""
+    r = _sol()
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    inherits = [(e["source"], e["target"]) for e in r["edges"] if e["relation"] == "inherits"]
+    # Token contract id contains "token"; ancestors should resolve to the contract-scoped ids
+    targets = {node_by_id[t] for s, t in inherits if s in node_by_id}
+    assert "IERC20" in targets
+    assert "Ownable" in targets
+
+
+def test_solidity_modifier_resolves_to_in_file_def():
+    r = _sol()
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    mods = [e for e in r["edges"] if e["relation"] == "applies_modifier"]
+    assert mods, "expected at least one applies_modifier edge"
+    # Target should be the in-file modifier definition (file-stem prefix in id)
+    for e in mods:
+        target_id = e["target"]
+        assert "_" in target_id, f"modifier target {target_id} looks like a bare unresolved name"
+
+
+def test_solidity_emit_resolves_to_in_file_event():
+    r = _sol()
+    emits = [e for e in r["edges"] if e["relation"] == "emits"]
+    assert emits, "expected at least one emits edge"
+    for e in emits:
+        # In-file event ids have the contract-stem prefix and 'event' segment
+        assert "event" in e["target"], f"emit target {e['target']} not resolved to in-file event"
+
+
+def test_solidity_revert_not_treated_as_call():
+    """`revert NotOwner(msg.sender)` constructs an error — should not produce a calls edge."""
+    r = _sol()
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    call_targets = {
+        node_by_id.get(e["target"], e["target"])
+        for e in r["edges"] if e["relation"] == "calls"
+    }
+    assert "NotOwner" not in call_targets
+    assert "InsufficientBalance" not in call_targets
+
+
+def test_solidity_builtins_filtered_from_calls():
+    """require/assert/keccak256 etc. should not show up as call targets."""
+    r = _sol()
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    call_targets = {
+        node_by_id.get(e["target"], e["target"])
+        for e in r["edges"] if e["relation"] == "calls"
+    }
+    for builtin in ("require", "assert", "revert", "keccak256", "address"):
+        assert builtin not in call_targets, f"{builtin} leaked into calls"
+
+
+# Multi-file Solidity fixture exercises cross-file imports + inheritance.
+SOL_DIR = FIXTURES / "solidity"
+
+
+def _sol_multi():
+    pytest.importorskip("tree_sitter_solidity")
+    return {
+        "Ownable": extract_solidity(SOL_DIR / "Ownable.sol"),
+        "Token": extract_solidity(SOL_DIR / "Token.sol"),
+        "Vault": extract_solidity(SOL_DIR / "Vault.sol"),
+    }
+
+
+def test_solidity_multifile_no_errors():
+    for name, r in _sol_multi().items():
+        assert "error" not in r, f"{name}: {r.get('error')}"
+
+
+def test_solidity_multifile_vault_imports_ownable_and_token():
+    r = _sol_multi()["Vault"]
+    relations = [(e["relation"], e.get("context", "")) for e in r["edges"]
+                 if e["relation"] in ("imports", "imports_from")]
+    # Named import: import {Ownable} from "./Ownable.sol"
+    assert any(rel == "imports_from" for rel, _ in relations), "expected named import edge"
+    # Bare import: import "./Token.sol"
+    assert any(rel == "imports" for rel, _ in relations), "expected bare import edge"
+
+
+def test_solidity_multifile_vault_inherits_ownable_unresolved_cross_file():
+    """Vault inherits Ownable, but Ownable lives in another file — resolution is
+    per-file, so the inherits target is the bare name (a known limitation)."""
+    r = _sol_multi()["Vault"]
+    inherits = [e for e in r["edges"] if e["relation"] == "inherits"]
+    assert inherits, "Vault should have an inherits edge"
+    # Cross-file ancestor — bare-name target is acceptable until cross-file resolution lands
+    target_labels = {n["label"] for n in r["nodes"] if n["id"] == inherits[0]["target"]}
+    assert "Ownable" in target_labels
+
+
+def test_solidity_multifile_token_using_for_resolves_in_file():
+    """SafeMath is defined in Token.sol — `using SafeMath for uint256` should
+    resolve to the in-file library nid."""
+    r = _sol_multi()["Token"]
+    node_by_id = {n["id"]: n["label"] for n in r["nodes"]}
+    using_edges = [e for e in r["edges"]
+                   if e["relation"] == "imports_from" and e.get("context") == "using_for"]
+    assert using_edges
+    for e in using_edges:
+        assert node_by_id.get(e["target"]) == "SafeMath"


### PR DESCRIPTION
## Summary

Adds Solidity to the set of languages supported by graphify's deterministic AST extraction. Mirrors the existing pattern used for SQL: optional dependency, `_DISPATCH` registration, dedicated tree-sitter extractor.

- New `extract_solidity()` in `graphify/extract.py` (~280 lines, bespoke walk).
- `tree-sitter-solidity` added as an optional `solidity` extra (pinned `>=1.2.13,<2`) and bundled into the `all` extra.
- `.sol` registered in `_DISPATCH` and `detect.CODE_EXTENSIONS`.

## Coverage

**Nodes:** contract / interface / library declarations, free functions, functions / modifiers / constructors / fallback / receive, events, errors, structs, enums, state variables.

**Edges:** `defines`, `contains`, `inherits`, `imports`, `imports_from` (named imports + `using ... for ...`), `applies_modifier`, `emits`, `calls` (low-confidence `0.5` for member calls, full `1.0` for direct).

## Resolution quality

A pre-pass collects file-wide `decl_map` / `modifier_map` / `event_map` so that `inherits`, `applies_modifier`, and `emits` edges resolve to in-file definition nids instead of producing dangling bare-name targets.

`require` / `assert` / `revert` / `keccak256` / type conversions (`address(...)`, `uintN(...)`) are filtered from `calls`. `revert_statement` subtrees are skipped entirely so `revert NotOwner(...)` is not misclassified as a function call.

## Validation

- 21 new unit tests in `tests/test_multilang.py` (single-file fixture + multi-file fixture under `tests/fixtures/solidity/`). All pass.
- 525 unrelated tests still pass.
- Benchmarked on OpenZeppelin contracts (349 `.sol` files): 0 errors, ~0.8 ms/file, 7,148 nodes / 8,535 edges. Edge distribution: `contains` 40% · `calls` 35% · `imports_from` 10% · `inherits` 6% · `defines` 5% · `emits` 2% · `applies_modifier` 2%. ERC20 god-node check confirms `ERC20` as top, with `approve` / `transfer` / `transferFrom` next — matches the expected ERC20 surface.

## Out of scope (Phase 5+ candidates)

- Cross-file name resolution (single-file resolution only, by design — bare names for cross-file ancestors).
- Type-resolved member calls (currently flagged `INFERRED` 0.5 with `context: member_call`).
- Yul / inline assembly parsing.
- Natspec extraction (`@notice`, `@dev`).
- Storage read/write tracking.
- Reentrancy / external-call ordering analysis.

## Test plan

- [ ] `pytest tests/test_multilang.py -k solidity -v` passes (21 tests).
- [ ] `pytest tests/` shows no regressions in non-Solidity tests.
- [ ] `pip install graphifyy[solidity]` then run `graphify` on a folder with `.sol` files — graph builds without errors.
- [ ] Spot-check OpenZeppelin or Uniswap V3 results for edge sanity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)