### PR TITLE
fix(svelte): stamp dynamic-import stub source_file to target, not importer (#712)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1758,6 +1758,11 @@ def extract_svelte(path: Path) -> dict:
             raw = m.group(1)
             if not raw:
                 continue
+            # target_source_file: where the IMPORTED file actually lives.
+            # Used as the stub node's source_file so build_from_json's
+            # last-write-wins merge agrees with the real file's extraction.
+            # Empty for bare/scoped externals where we don't know the path (#712).
+            target_source_file = ""
             if raw.startswith("."):
                 # Relative import - resolve to full path so IDs match file node IDs.
                 resolved = Path(os.path.normpath(path.parent / raw))
@@ -1767,6 +1772,7 @@ def extract_svelte(path: Path) -> dict:
                 elif resolved.suffix == ".jsx":
                     resolved = resolved.with_suffix(".tsx")
                 node_id = _make_id(str(resolved))
+                target_source_file = str(resolved)
             else:
                 # Check tsconfig.json path aliases (e.g. "$lib/" -> "src/lib/", "@/" -> "src/")
                 # before treating as external. Mirrors _import_js logic so SvelteKit alias
@@ -1779,6 +1785,7 @@ def extract_svelte(path: Path) -> dict:
                         break
                 if resolved_alias is not None:
                     node_id = _make_id(str(resolved_alias))
+                    target_source_file = str(resolved_alias)
                 else:
                     # Bare/scoped import (node_modules) - use last segment;
                     # build_from_json drops as external if no matching node exists.
@@ -1786,6 +1793,9 @@ def extract_svelte(path: Path) -> dict:
                     if not module_name:
                         continue
                     node_id = _make_id(module_name)
+                    # target_source_file stays "" — we genuinely don't know
+                    # where externals live, and stamping the importer's path
+                    # would corrupt the node's metadata (#712).
             if node_id in existing_ids:
                 # Edge target already a real node - just add the edge, don't add a node.
                 result.setdefault("edges", []).append({
@@ -1796,7 +1806,7 @@ def extract_svelte(path: Path) -> dict:
                 continue
             result.setdefault("nodes", []).append({
                 "id": node_id, "label": raw,
-                "file_type": "code", "source_file": str(path),
+                "file_type": "code", "source_file": target_source_file,
                 "confidence": "EXTRACTED",
             })
             result.setdefault("edges", []).append({

--- a/tests/test_svelte_dynamic_import_stub.py
+++ b/tests/test_svelte_dynamic_import_stub.py
@@ -1,0 +1,227 @@
+"""Tests for #712 — extract_svelte()'s regex pass for `import('...')` must
+stamp the stub node's source_file to the *imported* file's path, never to
+the *importer's* path.
+
+build_from_json does last-write-wins on node attributes when two extractors
+produce nodes with the same ID. Before #712, the importer-stamped stub
+could clobber the correct source_file from the target file's own extraction
+depending on file-iteration order, causing downstream tools to attribute
+the file to whichever component first imports it.
+"""
+
+from pathlib import Path
+
+from graphify.extract import _make_id, extract_svelte
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _node_by_id(result: dict, node_id: str) -> dict | None:
+    for n in result["nodes"]:
+        if n.get("id") == node_id:
+            return n
+    return None
+
+
+# ── Relative dynamic imports ──────────────────────────────────────────────────
+
+
+def test_relative_dynamic_import_stub_points_to_target(tmp_path):
+    target = _write(tmp_path / "Modal.svelte", "<div></div>")
+    importer = _write(tmp_path / "page.svelte", """\
+<script>
+  let show = false
+</script>
+{#if show}
+  {#await import('./Modal.svelte') then Mod}<Mod.default/>{/await}
+{/if}
+""")
+    result = extract_svelte(importer)
+    target_node = _node_by_id(result, _make_id(str(target)))
+    assert target_node is not None, (
+        f"Expected stub node for Modal.svelte; nodes={[n['id'] for n in result['nodes']]}"
+    )
+    assert target_node["source_file"] == str(target), (
+        f"Stub source_file must point at the IMPORTED file (#712);\n"
+        f"  expected: {target}\n"
+        f"  got:      {target_node['source_file']}"
+    )
+
+
+def test_relative_dynamic_import_stub_does_not_carry_importer_path(tmp_path):
+    """The specific bug: source_file pointed to the importer."""
+    target = _write(tmp_path / "Modal.svelte", "<div></div>")
+    importer = _write(tmp_path / "page.svelte", """\
+<script>
+  const lazy = () => import('./Modal.svelte')
+</script>
+""")
+    result = extract_svelte(importer)
+    target_node = _node_by_id(result, _make_id(str(target)))
+    assert target_node is not None
+    assert target_node["source_file"] != str(importer), (
+        f"Stub source_file must NOT be the importer's path (#712 regression)"
+    )
+
+
+# ── Aliased dynamic imports ($lib/...) ───────────────────────────────────────
+
+
+def test_alias_dynamic_import_stub_points_to_resolved_path(tmp_path):
+    """$lib/X.svelte alias imports were the original repro for #712."""
+    src_dir = tmp_path / "src"
+    lib_dir = src_dir / "lib" / "components" / "library"
+    lib_dir.mkdir(parents=True)
+    target = _write(lib_dir / "popover.svelte", "<div></div>")
+
+    # Minimal tsconfig.json with $lib alias
+    _write(tmp_path / "tsconfig.json", """\
+{
+  "compilerOptions": {
+    "paths": { "$lib": ["./src/lib"], "$lib/*": ["./src/lib/*"] }
+  }
+}
+""")
+    importer_dir = src_dir / "partials" / "Card"
+    importer_dir.mkdir(parents=True)
+    importer = _write(importer_dir / "card.svelte", """\
+<script>
+  const lazy = () => import('$lib/components/library/popover.svelte')
+</script>
+""")
+
+    result = extract_svelte(importer)
+    expected_id = _make_id(str(target))
+    target_node = _node_by_id(result, expected_id)
+    assert target_node is not None, (
+        f"Expected resolved alias to produce node id={expected_id}; "
+        f"got nodes={[n['id'] for n in result['nodes']]}"
+    )
+    # The stamped source_file may use a different path normalization
+    # (resolve symlinks, /private prefix on macOS, etc) but it must NOT
+    # be the importer's path.
+    assert target_node["source_file"] != str(importer), (
+        f"Stub source_file must not be importer's path; got {target_node['source_file']}"
+    )
+    # And it should point to something that IS the target (basename match
+    # is enough — paths can differ in normalization).
+    assert Path(target_node["source_file"]).name == "popover.svelte", (
+        f"Stub source_file basename should be the target file's basename; "
+        f"got {target_node['source_file']}"
+    )
+
+
+# ── Last-write-wins merge consistency ─────────────────────────────────────────
+
+
+def test_two_importers_agree_on_target_source_file(tmp_path):
+    """If A.svelte and B.svelte both dynamically import C.svelte, the stub
+    nodes they create must agree on C.svelte's source_file. Otherwise
+    build_from_json's last-write-wins merge depends on file-iteration order."""
+    target = _write(tmp_path / "C.svelte", "<div></div>")
+    importer_a = _write(tmp_path / "A.svelte", """\
+<script>
+  const lazy = () => import('./C.svelte')
+</script>
+""")
+    importer_b = _write(tmp_path / "B.svelte", """\
+<script>
+  {#await import('./C.svelte') then C}<C.default/>{/await}
+</script>
+""")
+    result_a = extract_svelte(importer_a)
+    result_b = extract_svelte(importer_b)
+    target_id = _make_id(str(target))
+    node_a = _node_by_id(result_a, target_id)
+    node_b = _node_by_id(result_b, target_id)
+    assert node_a is not None and node_b is not None
+    assert node_a["source_file"] == node_b["source_file"], (
+        f"Two importers of the same target produced inconsistent source_file:\n"
+        f"  from A: {node_a['source_file']}\n"
+        f"  from B: {node_b['source_file']}\n"
+        f"  Last-write-wins merge becomes order-dependent (#712)."
+    )
+    assert node_a["source_file"] == str(target), (
+        f"Both stubs should point to the actual target file"
+    )
+
+
+def test_target_extraction_does_not_clobber_correct_source_file(tmp_path):
+    """End-to-end: when the same .svelte file is extracted twice — once as
+    a dynamic-import stub from another file, once as itself — the canonical
+    source_file (its own path) must survive the merge regardless of order."""
+    target = _write(tmp_path / "Modal.svelte", """\
+<script>
+  let open = false
+</script>
+""")
+    importer = _write(tmp_path / "page.svelte", """\
+<script>
+  const lazy = () => import('./Modal.svelte')
+</script>
+""")
+    # Stub from importer
+    stub_node = _node_by_id(extract_svelte(importer), _make_id(str(target)))
+    # Real node from target's own extraction
+    real_node = _node_by_id(extract_svelte(target), _make_id(str(target)))
+    assert stub_node is not None and real_node is not None
+    # Both must report the same source_file. Otherwise either side losing
+    # the merge corrupts downstream queries that read source_file.
+    assert stub_node["source_file"] == real_node["source_file"], (
+        f"Stub and real node must agree on source_file so the merge order "
+        f"doesn't matter:\n  stub: {stub_node['source_file']}\n  "
+        f"real: {real_node['source_file']}"
+    )
+
+
+# ── External / bare imports ──────────────────────────────────────────────────
+
+
+def test_bare_module_dynamic_import_does_not_corrupt_source_file(tmp_path):
+    """Dynamic imports of node_modules (e.g. `import('lodash')`) shouldn't
+    be stamped with the importer's path either — better to leave empty
+    than to lie."""
+    importer = _write(tmp_path / "page.svelte", """\
+<script>
+  const load = () => import('lodash-es')
+</script>
+""")
+    result = extract_svelte(importer)
+    # Look for any node whose label is the bare module name
+    bare_nodes = [n for n in result["nodes"]
+                  if (n.get("label") or "") == "lodash-es"]
+    if bare_nodes:
+        # If a stub was created for an external, its source_file must NOT
+        # claim to be the importer.
+        assert bare_nodes[0]["source_file"] != str(importer), (
+            f"Bare-module stub source_file must not claim to be the importer "
+            f"(#712); got {bare_nodes[0]['source_file']}"
+        )
+
+
+# ── Edge source_file (separate concern, regression guard) ────────────────────
+
+
+def test_dynamic_import_edge_source_file_is_importer(tmp_path):
+    """The EDGE's source_file is the importer (correct — that's where the
+    import statement lives). Only the NODE stub had the bug. Guard against
+    accidentally over-correcting and changing the edge's source_file too."""
+    target = _write(tmp_path / "Modal.svelte", "<div></div>")
+    importer = _write(tmp_path / "page.svelte", """\
+<script>
+  const lazy = () => import('./Modal.svelte')
+</script>
+""")
+    result = extract_svelte(importer)
+    dyn_edges = [e for e in result["edges"]
+                 if e.get("relation") == "dynamic_import"]
+    assert dyn_edges
+    for e in dyn_edges:
+        assert e["source_file"] == str(importer), (
+            f"Edge source_file should remain the importer (where the import "
+            f"statement is located); got {e['source_file']}"
+        )


### PR DESCRIPTION
> Code written by Claude Code, but reviewed by me (I'm not super familiar with Python, but SWE with +20 years experience).

Fixes #712. Independent of #714 — branched off `v7`, applies cleanly with or without #714 merged first.

## Problem

`extract_svelte()`'s regex pass for `import('...')` resolved a target path (relative or via tsconfig alias) and created a stub node for it — but stamped the stub's `source_file` to `str(path)`, which is the **importer's** path, not the target's.

`build_from_json` does last-write-wins on node attributes (`G.add_node` overwrites). When the target file is later extracted by `_extract_generic` on its own, both nodes share the same id (`_make_id(str(target))`) and merge. Whether the stub's wrong `source_file` or the real correct one wins depends purely on file-iteration order — non-deterministic.

**Effect:** downstream tools that read `source_file` off file nodes (display, *"where is X defined"*, blast-radius queries, community summaries) see the file as living inside whichever component first imported it. On a real 1,873-file SvelteKit codebase, 16 `.svelte` file nodes were corrupted this way — every dynamically-imported component sampled.

## Fix

Thread the resolved target path through to `source_file`:
- **relative imports** → `str(resolved)`
- **alias imports** (`$lib/...`) → `str(resolved_alias)`
- **bare/scoped externals** → leave `source_file` empty (we genuinely don't know where `node_modules` live, and stamping the importer would lie)

The stub **edge**'s `source_file` is unchanged — that legitimately is the importer (where the import statement lives). Edge vs node distinction is preserved.

## Tests

7 new tests in `tests/test_svelte_dynamic_import_stub.py`:

| Test | What it guards |
|---|---|
| `test_relative_dynamic_import_stub_points_to_target` | Stub source_file == target's path |
| `test_relative_dynamic_import_stub_does_not_carry_importer_path` | The literal #712 bug |
| `test_alias_dynamic_import_stub_points_to_resolved_path` | `$lib/...` aliases resolve correctly |
| `test_two_importers_agree_on_target_source_file` | Two stubs of same target are consistent → merge-order independent |
| `test_target_extraction_does_not_clobber_correct_source_file` | End-to-end: stub's source_file matches real extraction's source_file |
| `test_bare_module_dynamic_import_does_not_corrupt_source_file` | External modules don't get importer-path stamped |
| `test_dynamic_import_edge_source_file_is_importer` | Edge source_file unchanged (over-correction guard) |

**6 of 7 fail against unpatched v7** — confirming they're real regression guards. The 7th is the over-correction check that intentionally documents what should NOT change (edge source_file remains the importer).

## Test plan

- [x] `pytest tests/test_svelte_dynamic_import_stub.py` — 7/7 pass
- [x] Confirmed 6/7 fail against unpatched v7
- [x] `pytest tests/` — 556 pass, 7 pre-existing failures unrelated to this change