### PR TITLE
fix(detect): exempt source-code files from generic-keyword secret filter

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -29,11 +29,30 @@ CORPUS_WARN_THRESHOLD = 50_000    # words - below this, warn "you may not need a
 CORPUS_UPPER_THRESHOLD = 500_000  # words - above this, warn about token cost
 FILE_COUNT_UPPER = 200             # files - above this, warn about token cost
 
-# Files that may contain secrets - skip silently
+# Files that may contain secrets - skip silently.
+#
+# Keyword pattern is named separately so _is_sensitive() can opt source-code
+# files out of it: source files are CODE, not credential storage, so something
+# like 'password-reset.ts' or 'AuthOauthAccessToken.model.ts' should not be
+# silently dropped from the graph just because the filename mentions auth
+# concepts. Word boundaries also narrow the match so 'tokenizer' / 'secretary'
+# (substrings inside larger words) don't trip the filter even on data files.
+# The other patterns target real credential storage by extension or exact name
+# and continue to apply to ALL files regardless of code/data classification.
+# Optional `s?` after each keyword catches plurals (`secrets.json`,
+# `database-credentials.yml`) without re-introducing the substring-match
+# false positives the word boundaries are there to prevent. Trailing word
+# chars after the optional `s` ('tokenizer', 'credentialing', 'secretary',
+# 'passwordless') still fail the closing \b and pass the filter.
+_SENSITIVE_KEYWORD_PATTERN = re.compile(
+    r'\b(credential|secret|passwd|password|token|private_key)s?\b',
+    re.IGNORECASE,
+)
+
 _SENSITIVE_PATTERNS = [
     re.compile(r'(^|[\\/])\.(env|envrc)(\.|$)', re.IGNORECASE),
     re.compile(r'\.(pem|key|p12|pfx|cert|crt|der|p8)$', re.IGNORECASE),
-    re.compile(r'(credential|secret|passwd|password|token|private_key)', re.IGNORECASE),
+    _SENSITIVE_KEYWORD_PATTERN,
     re.compile(r'(id_rsa|id_dsa|id_ecdsa|id_ed25519)(\.pub)?$'),
     re.compile(r'(\.netrc|\.pgpass|\.htpasswd)$', re.IGNORECASE),
     re.compile(r'(aws_credentials|gcloud_credentials|service.account)', re.IGNORECASE),
@@ -59,9 +78,23 @@ _PAPER_SIGNAL_THRESHOLD = 3  # need at least this many signals to call it a pape
 
 
 def _is_sensitive(path: Path) -> bool:
-    """Return True if this file likely contains secrets and should be skipped."""
+    """Return True if this file likely contains secrets and should be skipped.
+
+    The generic keyword pattern (password/token/secret/...) is suppressed for
+    known source-code extensions so legitimate code files with auth-related
+    names ('password-reset.ts', 'AuthOauthAccessToken.model.ts',
+    'access-token.svelte', etc.) aren't silently dropped from the graph.
+    Specific patterns targeting real credential storage (.env, .pem, id_rsa,
+    .netrc, etc.) keep applying to all files.
+    """
     name = path.name
-    return any(p.search(name) for p in _SENSITIVE_PATTERNS)
+    is_code = path.suffix.lower() in CODE_EXTENSIONS
+    for pattern in _SENSITIVE_PATTERNS:
+        if pattern is _SENSITIVE_KEYWORD_PATTERN and is_code:
+            continue
+        if pattern.search(name):
+            return True
+    return False
 
 
 def _looks_like_paper(path: Path) -> bool:

--- a/tests/test_is_sensitive.py
+++ b/tests/test_is_sensitive.py
@@ -1,0 +1,193 @@
+"""Tests for _is_sensitive(): the file-skip heuristic that drops files
+expected to contain secrets. Two correctness properties:
+
+  1. Source-code files are never dropped by the generic keyword filter,
+     because source IS code, not credential storage. A file like
+     'password-reset.ts' is a code module — graphify should index it.
+
+  2. Specific patterns (.env, .pem, id_rsa, .netrc, etc.) keep applying
+     to all files, so a config or credential file with one of those
+     names is still flagged regardless of code/data classification.
+"""
+
+from pathlib import Path
+
+from graphify.detect import _is_sensitive
+
+
+def _f(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("placeholder", encoding="utf-8")
+    return p
+
+
+# ── Source code is never dropped by the keyword filter ──────────────────────
+
+
+def test_password_in_ts_filename_not_sensitive(tmp_path):
+    """Real reproducer: 'password-reset.ts' is a TS module that handles the
+    user-facing password-reset flow. It contains email-template code, not
+    secrets. Must not be dropped."""
+    assert not _is_sensitive(_f(tmp_path, "password-reset.ts"))
+
+
+def test_token_in_ts_model_filename_not_sensitive(tmp_path):
+    """Real reproducer: 'AuthOauthAccessToken.model.ts' is a Sequelize
+    model definition. Code, not credentials."""
+    assert not _is_sensitive(_f(tmp_path, "AuthOauthAccessToken.model.ts"))
+
+
+def test_token_in_test_helper_filename_not_sensitive(tmp_path):
+    """Real reproducer: 'test.search-tokenizer.ts' — 'tokenizer' contains
+    'token' as a substring. With word boundaries, it doesn't match anyway,
+    but the source-code exemption makes it doubly safe."""
+    assert not _is_sensitive(_f(tmp_path, "test.search-tokenizer.ts"))
+
+
+def test_credential_in_python_filename_not_sensitive(tmp_path):
+    """Common pattern: a Python module that handles credentials at the
+    application level (validation, storage, refresh) is still code."""
+    assert not _is_sensitive(_f(tmp_path, "credential_validator.py"))
+
+
+def test_secret_in_javascript_filename_not_sensitive(tmp_path):
+    """Same logic for JS: a module file is code, not raw secrets."""
+    assert not _is_sensitive(_f(tmp_path, "secret-handler.js"))
+
+
+def test_jwt_token_validator_java_not_sensitive(tmp_path):
+    """Java source — a JWT token validator is auth code, not a credential."""
+    assert not _is_sensitive(_f(tmp_path, "JwtTokenValidator.java"))
+
+
+def test_password_handling_svelte_component_not_sensitive(tmp_path):
+    """Svelte component for password-related UI is still source code."""
+    assert not _is_sensitive(_f(tmp_path, "password-input.svelte"))
+
+
+def test_keyword_in_typescript_declaration_not_sensitive(tmp_path):
+    """TypeScript declaration files (.d.ts) are interface/type definitions."""
+    assert not _is_sensitive(_f(tmp_path, "auth-token-types.d.ts"))
+
+
+# ── Specific extension/name patterns still apply to all files ───────────────
+
+
+def test_dotenv_still_flagged(tmp_path):
+    """The most important credential-storage file pattern."""
+    assert _is_sensitive(_f(tmp_path, ".env"))
+    assert _is_sensitive(_f(tmp_path, ".env.local"))
+    assert _is_sensitive(_f(tmp_path, ".env.production"))
+
+
+def test_envrc_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, ".envrc"))
+
+
+def test_pem_certificate_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, "server.pem"))
+    assert _is_sensitive(_f(tmp_path, "key.p12"))
+    assert _is_sensitive(_f(tmp_path, "site.cert"))
+
+
+def test_ssh_key_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, "id_rsa"))
+    assert _is_sensitive(_f(tmp_path, "id_ed25519.pub"))
+
+
+def test_netrc_pgpass_htpasswd_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, ".netrc"))
+    assert _is_sensitive(_f(tmp_path, ".pgpass"))
+    assert _is_sensitive(_f(tmp_path, ".htpasswd"))
+
+
+def test_cloud_credential_files_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, "aws_credentials"))
+    assert _is_sensitive(_f(tmp_path, "gcloud_credentials.json"))
+    assert _is_sensitive(_f(tmp_path, "service.account.json"))
+
+
+# ── Non-code files with keyword still flagged (data files store secrets) ────
+
+
+def test_secrets_json_still_flagged(tmp_path):
+    """A JSON file literally named 'secrets.json' is data, plausibly secret
+    storage. The generic keyword filter still applies to non-code files."""
+    assert _is_sensitive(_f(tmp_path, "secrets.json"))
+
+
+def test_credentials_yaml_still_flagged(tmp_path):
+    """YAML configs named for credentials are likely real credential storage."""
+    assert _is_sensitive(_f(tmp_path, "database-credentials.yml"))
+
+
+def test_password_txt_still_flagged(tmp_path):
+    """Plaintext 'password.txt' is the canonical bad-practice secret file."""
+    assert _is_sensitive(_f(tmp_path, "password.txt"))
+
+
+def test_token_in_data_file_still_flagged(tmp_path):
+    assert _is_sensitive(_f(tmp_path, "api-token.json"))
+
+
+# ── Word-boundary correctness on data files ─────────────────────────────────
+
+
+def test_secretary_in_data_file_not_flagged(tmp_path):
+    """'secretary' contains 'secret' but isn't a real word match. Word
+    boundaries reject it."""
+    assert not _is_sensitive(_f(tmp_path, "secretary-notes.txt"))
+
+
+def test_tokenizer_in_data_file_not_flagged(tmp_path):
+    """'tokenizer' has 'token' as a substring without a closing word boundary."""
+    assert not _is_sensitive(_f(tmp_path, "tokenizer-config.json"))
+
+
+def test_passwordless_in_data_file_not_flagged(tmp_path):
+    """'passwordless' is a real word that isn't 'password'."""
+    assert not _is_sensitive(_f(tmp_path, "passwordless-auth-rfc.md"))
+
+
+def test_credentialing_in_data_file_not_flagged(tmp_path):
+    """'credentialing' contains 'credential' without trailing boundary."""
+    assert not _is_sensitive(_f(tmp_path, "medical-credentialing-rules.txt"))
+
+
+# ── Mixed: code file with extension that ALSO matches a specific pattern ────
+
+
+def test_pem_file_extension_overrides_code_check(tmp_path):
+    """Even if someone manages to have a 'foo.ts.pem' file, the .pem
+    extension pattern triggers regardless of code-extension exemption.
+    The exemption only applies to the keyword pattern."""
+    assert _is_sensitive(_f(tmp_path, "foo.ts.pem"))
+
+
+def test_env_dotfile_still_flagged_alongside_code(tmp_path):
+    """A '.env.ts' would be unusual but the .env pattern is structural."""
+    # .suffix is .ts, but the .env pattern matches anywhere in the name
+    # via the leading dot anchor. This file IS treated as sensitive.
+    assert _is_sensitive(_f(tmp_path, ".env.ts"))
+
+
+# ── Subprojects: works regardless of where the file lives ───────────────────
+
+
+def test_keyword_in_nested_path_does_not_affect_classification(tmp_path):
+    """Nested paths shouldn't change the verdict — only the filename matters
+    after the issue 436 fix that removed full-path matching."""
+    f = tmp_path / "src" / "lib" / "server" / "auth" / "password-reset.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("export const x = 1")
+    assert not _is_sensitive(f)
+
+
+def test_directory_named_secretary_does_not_block_code_inside(tmp_path):
+    """The literal reproducer from the original directory-name bug:
+    a project under a path containing 'secret' as a substring of a real word."""
+    f = tmp_path / "AISecretary" / "Services" / "Foo.swift"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("// swift code")
+    assert not _is_sensitive(f)


### PR DESCRIPTION
> Code written by Claude Code, reviewed by me (I'm not super familiar with Python, but SWE with +20 years experience).

Fixes #718. Independent of the other open PRs (#714, #715, #717) — applies cleanly off `v7`.

## Problem

The sensitive-file heuristic in `_is_sensitive` has a generic keyword pattern that substring-matches every filename regardless of extension:

```python
re.compile(r'(credential|secret|passwd|password|token|private_key)', re.IGNORECASE),
```

This silently drops legitimate source-code files from the graph when their name mentions auth concepts:

| Filename | Real content |
|---|---|
| `password-reset.ts` | Email-template helper |
| `AuthOauthAccessToken.model.ts` | Sequelize model |
| `test.search-tokenizer.ts` | Test fixture |
| `JwtTokenValidator.java` | Auth code |
| `password_manager.py` | Manager class |
| `access-token.svelte` | UI component |

There are no actual secrets in any of these files — they're source code that happens to mention auth/token/password concepts in their filenames. They get silently dropped with no warning, exactly the failure mode that made this hard to diagnose (had to compare `collect_files()` output to the manifest to notice the gap).

## Background — relationship to #436

#436 (closed by `4738e88`) reported the same class of bug. The fix in `4738e88` removed the full-path check (`or p.search(full)`), so directory paths no longer trip the filter. The original issue's proposed word-boundary refinement to the keyword regex itself was not included, and the broader question of whether the keyword pattern should apply to source-code files at all was not addressed.

## Fix

Two complementary refinements to `graphify/detect.py`:

1. **Code-extension exemption.** The keyword pattern is now pulled into a named constant `_SENSITIVE_KEYWORD_PATTERN` and skipped when the file's extension is in `CODE_EXTENSIONS`. Source files are CODE, not credential storage. The structural patterns (`.env*`, `.pem`, `id_rsa`, `.netrc`, `aws_credentials`, etc.) continue to apply to *all* files, so a hypothetical `foo.ts.pem` is still flagged correctly.

2. **Word boundaries with optional plural.** `\b(credential|secret|...)s?\b` so substring matches inside larger words (`tokenizer`, `secretary`, `passwordless`, `credentialing`, `AccessToken`) no longer false-positive on data files. The `s?` covers plurals so canonical secret-storage filenames like `secrets.json` and `database-credentials.yml` remain flagged.

```python
_SENSITIVE_KEYWORD_PATTERN = re.compile(
    r'\b(credential|secret|passwd|password|token|private_key)s?\b',
    re.IGNORECASE,
)

def _is_sensitive(path: Path) -> bool:
    name = path.name
    is_code = path.suffix.lower() in CODE_EXTENSIONS
    for pattern in _SENSITIVE_PATTERNS:
        if pattern is _SENSITIVE_KEYWORD_PATTERN and is_code:
            continue
        if pattern.search(name):
            return True
    return False
```

## Coverage matrix

| File | Before | After |
|---|---|---|
| `password-reset.ts` (code) | dropped | indexed |
| `AuthOauthAccessToken.model.ts` (code) | dropped | indexed |
| `tokenizer.ts` (code, substring match) | dropped | indexed |
| `JwtTokenValidator.java` (code) | dropped | indexed |
| `secrets.json` (data, plural keyword) | flagged | flagged |
| `database-credentials.yml` (data, plural) | flagged | flagged |
| `password.txt` (data) | flagged | flagged |
| `secretary-notes.txt` (data, substring) | dropped (false positive) | indexed |
| `tokenizer-config.json` (data, substring) | dropped (false positive) | indexed |
| `.env`, `.env.local`, `.envrc` | flagged | flagged |
| `*.pem`, `*.key`, `*.p12`, `*.cert` | flagged | flagged |
| `id_rsa`, `id_ed25519.pub` | flagged | flagged |
| `.netrc`, `.pgpass`, `.htpasswd` | flagged | flagged |
| `aws_credentials`, `gcloud_credentials.json` | flagged | flagged |
| `foo.ts.pem` (mixed) | flagged | flagged (`.pem` is structural) |

## Tests (26 new, all passing)

`tests/test_is_sensitive.py`:

- **Source-code exemption (8):** legitimate `.ts`/`.py`/`.js`/`.java`/`.svelte`/`.d.ts` files with auth-related names pass through.
- **Specific-pattern preservation (12):** `.env`, `.env.local`, `.pem`, `.p12`, `.cert`, `id_rsa`, `id_ed25519.pub`, `.netrc`, `.pgpass`, `.htpasswd`, `aws_credentials`, `gcloud_credentials.json` still flagged.
- **Data-file keyword still flagged (4):** `secrets.json`, `database-credentials.yml`, `password.txt`, `api-token.json`.
- **Word-boundary correctness on data files (4):** substring-but-not-real-word cases pass through.
- **Mixed structural cases (2):** code-extension exemption is keyword-pattern-only and doesn't override structural patterns like `.pem` or `.env`.

13 of 26 fail on unpatched `v7` — real regression guards. The other 13 verify pre-existing flag behavior is preserved.

## Validation on a real codebase

A 1,873-file SvelteKit app:

- 3 source files previously silently dropped (`password-reset.ts`, `AuthOauthAccessToken.model.ts`, `test.search-tokenizer.ts`) are now extracted and contribute their outgoing import edges.
- Isolated `.ts` file count: 32 → 29.
- Total nodes: +6 (the new file nodes plus their per-symbol nodes).

## Test plan

- [x] All 26 new tests pass
- [x] 13 of 26 fail on unpatched `v7` (regression-guard quality)
- [x] Full test suite: 575 pass, 7 pre-existing failures unrelated
- [x] Smoke test on real 1,873-file SvelteKit project — 3 previously-dropped files now in graph