### PR TITLE
add .luau extension support (Roblox Luau)

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -18,7 +18,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4087,6 +4087,7 @@ _DISPATCH: dict[str, Any] = {
     ".php": extract_php,
     ".swift": extract_swift,
     ".lua": extract_lua,
+    ".luau": extract_lua,
     ".toc": extract_lua,
     ".zig": extract_zig,
     ".ps1": extract_powershell,

--- a/tests/fixtures/sample.luau
+++ b/tests/fixtures/sample.luau
@@ -1,0 +1,35 @@
+-- Luau sample (Roblox): typed Lua superset.
+-- tree-sitter-lua doesn't parse the type annotations, but extracts
+-- function declarations and call edges fine.
+
+local Server = {}
+Server.__index = Server
+
+type ServerConfig = {
+	port: number,
+	name: string?,
+}
+
+function Server.new(config: ServerConfig): Server
+	local self = setmetatable({}, Server)
+	self.port = config.port
+	self.name = config.name or "default"
+	return self
+end
+
+function Server:start(): ()
+	print(string.format("listening on :%d", self.port))
+end
+
+function Server:stop(): ()
+	print("stopped")
+end
+
+local function main()
+	local s = Server.new({ port = 8080 })
+	s:start()
+end
+
+main()
+
+return Server

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -61,7 +61,7 @@ def test_collect_files_from_dir():
     supported = {".py", ".js", ".ts", ".tsx", ".go", ".rs",
                  ".java", ".c", ".cpp", ".cc", ".cxx", ".rb",
                  ".cs", ".kt", ".kts", ".scala", ".php", ".h", ".hpp",
-                 ".swift", ".lua", ".toc", ".zig", ".ps1", ".ex", ".exs",
+                 ".swift", ".lua", ".luau", ".toc", ".zig", ".ps1", ".ex", ".exs",
                  ".m", ".mm"}
     assert all(f.suffix in supported for f in files)
     assert len(files) > 0


### PR DESCRIPTION
## Problem

Graphify recognizes `.lua` but not `.luau`. Roblox first-party code is written in Luau (a Lua superset with type annotations) using the `.luau` extension. On a real 479-file Roblox codebase, graphify silently skipped all 379 first-party `.luau` files and produced a graph dominated by vendored `.lua` dependencies (Roact's `Packages/_Index/`), giving a misleading picture of the codebase.

## Repro

```bash
git clone <any Roblox/Wally project> repo && cd repo
graphify update .
# manifest.json contains zero .luau entries
# the resulting graph reflects vendored Lua deps, not first-party Luau code
```

## Fix

Two-line change plus test coverage:

- `graphify/detect.py` — add `.luau` to `CODE_EXTENSIONS`
- `graphify/extract.py` — map `.luau` to `extract_lua` in `_DISPATCH`
- `tests/test_extract.py` — add `.luau` to the `supported` set in `test_collect_files_from_dir`
- `tests/fixtures/sample.luau` — minimal Luau source exercising type annotations + functions + calls

`tree-sitter-lua` doesn't parse Luau-specific type annotations cleanly, but it successfully extracts function declarations and call edges from Luau source (errors recover gracefully and skipped tokens don't abort the parse).

## Verification

**Smoke test on the included fixture:**
```
extracted nodes: 5
extracted edges: 5
first 3 nodes: ['sample.luau', 'Server.new()', 'Server:start()']
```

**Real-world: same codebase, before vs. after**

|  | before patch | after patch |
|---|---:|---:|
| Files processed | 100 (vendored `.lua` only) | 379 (first-party `.luau` + `.lua`) |
| Nodes | 344 | 1,265 |
| Edges | 340 | 1,471 |
| Communities | 87 | 236 |
| Top god node | `createElement()` (Roact internals) | `Clock.makeMock()` (game code) |

**Tests:** `pytest tests/test_detect.py tests/test_extract.py` → 51 passed.

## Notes

- A dedicated `tree-sitter-luau` grammar exists and would be a richer long-term option, but reusing `tree-sitter-lua` is the minimal change to make Luau projects functional today.
- For projects mixing `.lua` and `.luau` (common in Roblox), this also lets `.graphifyignore` cleanly exclude vendored `Packages/` while keeping first-party Luau in scope.