### PR TITLE
Fix GRAPHIFY_OUT default for query/path/explain

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -19,6 +19,10 @@ except Exception:
 _GRAPHIFY_OUT = os.environ.get("GRAPHIFY_OUT", "graphify-out")
 
 
+def _default_graph_path() -> str:
+    return str(Path(_GRAPHIFY_OUT) / "graph.json")
+
+
 def _check_skill_version(skill_dst: Path) -> None:
     """Warn if the installed skill is from an older graphify version."""
     version_file = skill_dst.parent / ".graphify_version"
@@ -1292,7 +1296,7 @@ def main() -> None:
         question = sys.argv[2]
         use_dfs = "--dfs" in sys.argv
         budget = 2000
-        graph_path = "graphify-out/graph.json"
+        graph_path = _default_graph_path()
         context_filters: list[str] = []
         args = sys.argv[3:]
         i = 0
@@ -1377,7 +1381,7 @@ def main() -> None:
         import networkx as _nx
         source_label = sys.argv[2]
         target_label = sys.argv[3]
-        graph_path = "graphify-out/graph.json"
+        graph_path = _default_graph_path()
         args = sys.argv[4:]
         for i, a in enumerate(args):
             if a == "--graph" and i + 1 < len(args):
@@ -1425,7 +1429,7 @@ def main() -> None:
         from graphify.serve import _find_node
         from networkx.readwrite import json_graph
         label = sys.argv[2]
-        graph_path = "graphify-out/graph.json"
+        graph_path = _default_graph_path()
         args = sys.argv[3:]
         for i, a in enumerate(args):
             if a == "--graph" and i + 1 < len(args):

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -5,6 +5,7 @@ and asserts the expected output file exists and is non-empty / valid.
 """
 from __future__ import annotations
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -15,12 +16,13 @@ PYTHON = sys.executable
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+def _run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     return subprocess.run(
         [PYTHON, "-m", "graphify"] + args,
         cwd=cwd,
         capture_output=True,
         text=True,
+        env=env,
     )
 
 
@@ -165,6 +167,19 @@ def test_query_missing_graph_fails(tmp_path):
     assert r.returncode != 0
 
 
+def test_query_uses_graphify_out_env(tmp_path):
+    out = _make_graph(tmp_path)
+    custom_out = tmp_path / "custom-graph"
+    out.rename(custom_out)
+    env = os.environ.copy()
+    env["GRAPHIFY_OUT"] = custom_out.name
+
+    r = _run(["query", "test"], tmp_path, env=env)
+
+    assert r.returncode == 0, r.stderr
+    assert len(r.stdout) > 0
+
+
 # ── graphify path ────────────────────────────────────────────────────────────
 
 def test_path_runs_without_error(tmp_path):
@@ -179,6 +194,18 @@ def test_path_missing_graph_fails(tmp_path):
     assert r.returncode != 0
 
 
+def test_path_uses_graphify_out_env(tmp_path):
+    out = _make_graph(tmp_path)
+    custom_out = tmp_path / "custom-graph"
+    out.rename(custom_out)
+    env = os.environ.copy()
+    env["GRAPHIFY_OUT"] = custom_out.name
+
+    r = _run(["path", "Transformer", "LayerNorm"], tmp_path, env=env)
+
+    assert r.returncode == 0, r.stderr
+
+
 # ── graphify explain ─────────────────────────────────────────────────────────
 
 def test_explain_runs_without_error(tmp_path):
@@ -190,6 +217,18 @@ def test_explain_runs_without_error(tmp_path):
 def test_explain_missing_graph_fails(tmp_path):
     r = _run(["explain", "anything"], tmp_path)
     assert r.returncode != 0
+
+
+def test_explain_uses_graphify_out_env(tmp_path):
+    out = _make_graph(tmp_path)
+    custom_out = tmp_path / "custom-graph"
+    out.rename(custom_out)
+    env = os.environ.copy()
+    env["GRAPHIFY_OUT"] = custom_out.name
+
+    r = _run(["explain", "test"], tmp_path, env=env)
+
+    assert r.returncode == 0, r.stderr
 
 
 # ── graphify export unknown format ───────────────────────────────────────────


### PR DESCRIPTION
Fixes #756.

The three graph lookup commands already accept `--graph`, but their default path still pointed at `graphify-out/graph.json` even when `GRAPHIFY_OUT` was set. That breaks shared-output and non-default output directory setups.

This switches the default path for `query`, `path`, and `explain` to the existing `GRAPHIFY_OUT` setting, while leaving explicit `--graph` overrides alone.

Tests:
- `python3 -m py_compile graphify/__main__.py tests/test_cli_export.py`
- `uv run --with pytest pytest tests/test_cli_export.py -q`