### PR TITLE
Handle positional install platform names

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -206,6 +206,12 @@ def install(platform: str = "claude") -> None:
     print()
 
 
+def _print_install_usage() -> None:
+    platforms = ", ".join([*_PLATFORM_CONFIG, "gemini", "cursor"])
+    print("Usage: graphify install [--platform P|P]")
+    print(f"Platforms: {platforms}")
+
+
 _CLAUDE_MD_SECTION = """\
 ## graphify
 
@@ -1150,18 +1156,41 @@ def main() -> None:
     if cmd == "install":
         # Default to windows platform on Windows, claude elsewhere
         default_platform = "windows" if platform.system() == "Windows" else "claude"
-        chosen_platform = default_platform
+        selected_platform: str | None = None
         args = sys.argv[2:]
         i = 0
         while i < len(args):
-            if args[i].startswith("--platform="):
-                chosen_platform = args[i].split("=", 1)[1]
+            arg = args[i]
+            if arg in ("-h", "--help"):
+                _print_install_usage()
+                return
+            if arg.startswith("--platform="):
+                candidate = arg.split("=", 1)[1]
+                if selected_platform and selected_platform != candidate:
+                    print("error: specify install platform only once", file=sys.stderr)
+                    sys.exit(1)
+                selected_platform = candidate
                 i += 1
-            elif args[i] == "--platform" and i + 1 < len(args):
-                chosen_platform = args[i + 1]
+            elif arg == "--platform":
+                if i + 1 >= len(args):
+                    print("error: --platform requires a value", file=sys.stderr)
+                    sys.exit(1)
+                candidate = args[i + 1]
+                if selected_platform and selected_platform != candidate:
+                    print("error: specify install platform only once", file=sys.stderr)
+                    sys.exit(1)
+                selected_platform = candidate
                 i += 2
+            elif arg.startswith("-"):
+                print(f"error: unknown install option '{arg}'", file=sys.stderr)
+                sys.exit(1)
             else:
+                if selected_platform and selected_platform != arg:
+                    print("error: specify install platform only once", file=sys.stderr)
+                    sys.exit(1)
+                selected_platform = arg
                 i += 1
+        chosen_platform = selected_platform or default_platform
         install(platform=chosen_platform)
     elif cmd == "claude":
         subcmd = sys.argv[2] if len(sys.argv) > 2 else ""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,7 @@
 """Tests for graphify install --platform routing."""
+import os
 from pathlib import Path
+import sys
 from unittest.mock import patch
 import pytest
 
@@ -18,8 +20,13 @@ PLATFORMS = {
 
 def _install(tmp_path, platform):
     from graphify.__main__ import install
-    with patch("graphify.__main__.Path.home", return_value=tmp_path):
-        install(platform=platform)
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        with patch("graphify.__main__.Path.home", return_value=tmp_path):
+            install(platform=platform)
+    finally:
+        os.chdir(old_cwd)
 
 
 def test_install_default_claude(tmp_path):
@@ -35,6 +42,29 @@ def test_install_codex(tmp_path):
 def test_install_opencode(tmp_path):
     _install(tmp_path, "opencode")
     assert (tmp_path / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_positional_platform_opencode(tmp_path, monkeypatch):
+    from graphify.__main__ import main
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["graphify", "install", "opencode"])
+    with patch("graphify.__main__.Path.home", return_value=tmp_path):
+        main()
+    assert (tmp_path / ".config" / "opencode" / "skills" / "graphify" / "SKILL.md").exists()
+    assert not (tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md").exists()
+
+
+def test_install_help_does_not_install_default(tmp_path, monkeypatch, capsys):
+    from graphify.__main__ import main
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["graphify", "install", "opencode", "--help"])
+    with patch("graphify.__main__.Path.home", return_value=tmp_path):
+        main()
+    out = capsys.readouterr().out
+    assert "Usage: graphify install" in out
+    assert "opencode" in out
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".config").exists()
 
 
 def test_install_claw(tmp_path):


### PR DESCRIPTION
Fixes #755.

`graphify install --platform opencode` works today, but `graphify install opencode` silently drops the positional platform and installs the default platform instead. That is especially confusing when someone runs `graphify install opencode --help`: it can write Claude files while looking like an OpenCode command.

This makes the install parser treat one positional argument as the platform name, shows install-specific help for `-h`/`--help`, and errors on conflicting platform selections instead of quietly guessing.

I also tightened the install tests so the OpenCode install case runs from the temp directory and does not leave a repo-local `.opencode/` artifact behind.

Tests:
- `python3 -m py_compile graphify/__main__.py tests/test_install.py`
- `uv run --with pytest pytest tests/test_install.py -q`
- `git diff --check`