### PR TITLE
feat: add .qmd file extension support

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -19,7 +19,7 @@ class FileType(str, Enum):
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
 CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08'}
-DOC_EXTENSIONS = {'.md', '.mdx', '.txt', '.rst', '.html', '.yaml', '.yml'}
+DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
 OFFICE_EXTENSIONS = {'.docx', '.xlsx'}

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -646,7 +646,7 @@ def to_obsidian(
     def safe_name(label: str) -> str:
         cleaned = re.sub(r'[\\/*?:"<>|#^[\]]', "", label.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")).strip()
         # Strip trailing .md/.mdx/.markdown so "CLAUDE.md" doesn't become "CLAUDE.md.md"
-        cleaned = re.sub(r"\.(md|mdx|markdown)$", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\.(md|mdx|qmd|markdown)$", "", cleaned, flags=re.IGNORECASE)
         return cleaned or "unnamed"
 
     node_filename: dict[str, str] = {}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4426,6 +4426,7 @@ _DISPATCH: dict[str, Any] = {
     ".sql": extract_sql,
     ".md": extract_markdown,
     ".mdx": extract_markdown,
+    ".qmd": extract_markdown,
 }
 
 

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -70,7 +70,7 @@ def _rebuild_code(watch_path: Path, *, follow_symlinks: bool = False, force: boo
         detected = detect(watch_path, follow_symlinks=follow_symlinks)
         code_files = [Path(f) for f in detected['files']['code']]
 
-        # Include document files that have AST extractors (e.g. .md, .mdx)
+        # Include document files that have AST extractors (e.g. .md, .mdx, .qmd)
         from graphify.extract import _get_extractor
         for doc_file in detected['files'].get('document', []):
             p = Path(doc_file)


### PR DESCRIPTION
This PR adds support for [Quarto](https://quarto.org) markdown (`.qmd`) files by routing them through the existing `extract_markdown` pipeline.

Since `.qmd` files are largely compatible with standard Markdown, this change only adds `.qmd` support at the detection and dispatch layers.

Changes included in this PR:

* Add `.qmd` to document file extension detection
* Update export logic to properly sanitize `.qmd` filenames
* Add `.qmd` extractor dispatch using the existing markdown extractor
* Update watch comments to include `.qmd` files

Quarto supports executable fenced code blocks using language labels wrapped in curly braces:

````markdown
```{python}
# some code
```
````

The only notable difference is that Quarto executable code blocks use labels like `{python}`, so `extract_markdown` produces `"code: {python}"` instead of `"code: python"`. I believe this should be fine since the label is only used for display and the code block itself is still extracted correctly.