### PR TITLE
Harden Google Workspace gws exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 - Feat: TypeScript extraction parity -- interface, enum, type alias, and module-level const nodes extracted; new_expression emits calls edges; parity with Java/C# class_types (#708)
 - Feat: Quarto (`.qmd`) file support -- routed through existing Markdown extractor; Quarto executable code blocks (` ```{python} `) extracted as code nodes (#761)
 - Feat: optional Google Workspace shortcut export for headless extraction -- `graphify extract ./docs --google-workspace` converts `.gdoc`, `.gsheet`, and `.gslides` files into Markdown sidecars with the `gws` CLI before semantic extraction; account email pseudonymized via SHA256 hash; `[google]` extra adds Sheets table rendering support (#752)
+- Fix: Google Workspace exports now run `gws` from the sidecar output directory with a relative `-o` path, matching `gws` path validation and avoiding failures when extracting a corpus outside the current working directory.
 - Feat: AWS Bedrock backend -- `graphify extract ./docs --backend bedrock`; credentials via standard AWS provider chain (AWS_PROFILE, AWS_REGION, IAM roles, SSO); model via GRAPHIFY_BEDROCK_MODEL (default anthropic.claude-3-5-sonnet-20241022-v2:0); `[bedrock]` extra adds boto3 (#757)
 
 ## 0.7.8 (2026-05-06)

--- a/graphify/google_workspace.py
+++ b/graphify/google_workspace.py
@@ -100,12 +100,17 @@ def _run_gws_export(file_id: str, mime_type: str, output: Path, resource_key: st
         )
 
     params: dict[str, str] = {"fileId": file_id, "mimeType": mime_type}
-    if resource_key:
-        params["resourceKey"] = resource_key
+    # Drive resource keys are sent via X-Goog-Drive-Resource-Keys. The current
+    # gws export command has no custom-header flag, so do not pass resourceKey
+    # as an unsupported query parameter.
+    _ = resource_key
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
     timeout = int(os.environ.get("GRAPHIFY_GOOGLE_WORKSPACE_TIMEOUT", "120"))
     result = subprocess.run(
-        [exe, "drive", "files", "export", "--params", json.dumps(params), "-o", str(output)],
+        [exe, "drive", "files", "export", "--params", json.dumps(params), "-o", output.name],
         capture_output=True,
+        cwd=output.parent,
         text=True,
         timeout=timeout,
     )

--- a/tests/test_google_workspace.py
+++ b/tests/test_google_workspace.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 import graphify.google_workspace as gw
 
@@ -71,6 +72,53 @@ def test_convert_gsheet_uses_xlsx_markdown_callback(tmp_path, monkeypatch):
 
     assert out is not None
     assert "## Sheet: Main" in out.read_text(encoding="utf-8")
+
+
+def test_run_gws_export_uses_output_directory_as_cwd(tmp_path, monkeypatch):
+    output = tmp_path / "converted" / "doc.md"
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return Result()
+
+    monkeypatch.setattr(gw.shutil, "which", lambda name: "/usr/local/bin/gws")
+    monkeypatch.setattr(gw.subprocess, "run", fake_run)
+
+    gw._run_gws_export("doc-123", "text/markdown", output)
+
+    assert output.parent.exists()
+    cmd, kwargs = calls[0]
+    assert kwargs["cwd"] == output.parent.resolve()
+    assert cmd[:4] == ["/usr/local/bin/gws", "drive", "files", "export"]
+    assert cmd[-2:] == ["-o", "doc.md"]
+
+
+def test_run_gws_export_does_not_send_resource_key_as_query_param(tmp_path, monkeypatch):
+    output = tmp_path / "converted" / "doc.md"
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return Result()
+
+    monkeypatch.setattr(gw.shutil, "which", lambda name: "/usr/local/bin/gws")
+    monkeypatch.setattr(gw.subprocess, "run", fake_run)
+
+    gw._run_gws_export("doc-123", "text/markdown", output, resource_key="rk-1")
+
+    params = json.loads(calls[0][calls[0].index("--params") + 1])
+    assert params == {"fileId": "doc-123", "mimeType": "text/markdown"}
 
 
 def test_google_workspace_enabled_env(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up hardening for the Google Workspace shortcut export added in #752. That implementation is working well in a real Google Drive-backed project, and this carries over the part of that local workflow that mattered for `gws` path validation.

- run `gws drive files export` from the sidecar output directory
- pass a relative `-o` filename instead of an absolute output path
- avoid sending Drive `resourceKey` as an unsupported `files.export` query parameter
- add tests for the subprocess contract and params shape

## Why

Current `gws` validates `--output` against its current working directory. Passing an absolute temp path can fail when Graphify extracts a corpus outside the shell cwd, even if the destination is inside the corpus output tree. Running from the sidecar directory with a relative output filename matches the pattern that has been working in a larger local Graphify workspace.

Drive resource keys are header-based (`X-Goog-Drive-Resource-Keys`), and `gws drive files export` does not currently expose a custom-header flag. This keeps the params aligned with the Drive export schema (`fileId`, `mimeType`) rather than implying resource-key support through an ignored/unsupported query parameter.

## Validation

- `python3 -m py_compile graphify/google_workspace.py graphify/detect.py graphify/__main__.py tests/test_google_workspace.py tests/test_detect.py`
- `uv run --with pytest pytest tests/test_google_workspace.py tests/test_detect.py tests/test_incremental.py tests/test_cli_export.py -q`
- local `gws drive files export --dry-run` from an output directory with relative `-o out.txt`; this passed path validation and failed only at local OAuth reauth, as expected on this machine
- `uv run graphify update .`
