### PR TITLE
refactor(__main__): strengthen agent instructions with forceful graph-first directives

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -224,13 +224,13 @@ def _print_install_usage() -> None:
 _CLAUDE_MD_SECTION = """\
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 """
 
 _CLAUDE_MD_MARKER = "## graphify"
@@ -240,13 +240,13 @@ _CLAUDE_MD_MARKER = "## graphify"
 _AGENTS_MD_SECTION = """\
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 """
 
 _AGENTS_MD_MARKER = "## graphify"
@@ -254,13 +254,13 @@ _AGENTS_MD_MARKER = "## graphify"
 _GEMINI_MD_SECTION = """\
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 """
 
 _GEMINI_MD_MARKER = "## graphify"


### PR DESCRIPTION
## Summary

The three agent instruction templates injected by `graphify install` for Claude Code (CLAUDE.md), Codex/OpenCode/OpenClaw (AGENTS.md), and Gemini CLI (GEMINI.md) currently use soft advisory language ("Before answering... read...") that agents seem to routinely ignore.

Changed to forceful `ALWAYS`/`NEVER` directives that leave no ambiguity.

## Changes

- `graphify/__main__.py`
  - `_CLAUDE_MD_SECTION` updated
  - `_AGENTS_MD_SECTION` updated
  - `_GEMINI_MD_SECTION` updated

Each now states:

- "ALWAYS read the graph report before file ops"
- "For cross-module questions, use graphify query/path/explain" (already present)
- "After modifying code, run `graphify update .`" (already present)

## Verification

- `python3 -m py_compile graphify/__main__.py` compiles clean