### PR TITLE
fix: use project-relative paths in manifest.json and GRAPH_REPORT.md

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1606,7 +1606,7 @@ def main() -> None:
         _commit = _gh()
         report = generate(G, communities, cohesion, labels, gods, surprises,
                           {"warning": "cluster-only mode — file stats not available"},
-                          tokens, str(watch_path), suggested_questions=questions,
+                          tokens, watch_path.name or str(watch_path), suggested_questions=questions,
                           min_community_size=min_community_size, built_at_commit=_commit)
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         to_json(G, communities, str(out / "graph.json"))
@@ -2325,7 +2325,7 @@ def main() -> None:
                     f"est. cost: ${cost:.4f}"
                 )
             try:
-                _save_manifest(files_by_type, manifest_path=str(manifest_path))
+                _save_manifest(files_by_type, manifest_path=str(manifest_path), root=target)
             except Exception as exc:
                 print(f"[graphify extract] warning: could not write manifest: {exc}", file=sys.stderr)
             if global_merge:
@@ -2407,7 +2407,7 @@ def main() -> None:
         }
         analysis_path.write_text(json.dumps(analysis, indent=2), encoding="utf-8")
         try:
-            _save_manifest(files_by_type, manifest_path=str(manifest_path))
+            _save_manifest(files_by_type, manifest_path=str(manifest_path), root=target)
         except Exception as exc:
             print(f"[graphify extract] warning: could not write manifest: {exc}", file=sys.stderr)
 

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -790,16 +790,22 @@ def load_manifest(manifest_path: str = _MANIFEST_PATH) -> dict:
         return {}
 
 
-def save_manifest(files: dict[str, list[str]], manifest_path: str = _MANIFEST_PATH) -> None:
+def save_manifest(files: dict[str, list[str]], manifest_path: str = _MANIFEST_PATH, *, root: Path | None = None) -> None:
     """Save current file mtimes + content hashes for change detection on --update."""
+    if root is None:
+        mp = Path(manifest_path).parent
+        root = mp.parent if mp.name == "graphify-out" else mp
+    root = root.resolve()
     manifest: dict[str, dict] = {}
     for file_list in files.values():
         for f in file_list:
             try:
                 p = Path(f)
-                manifest[f] = {"mtime": p.stat().st_mtime, "hash": _md5_file(p)}
-            except OSError:
-                pass  # file deleted between detect() and manifest write - skip it
+                rp = p.resolve() if p.is_absolute() else p
+                key = str(rp.relative_to(root)) if p.is_absolute() else f
+                manifest[key] = {"mtime": p.stat().st_mtime, "hash": _md5_file(p)}
+            except (OSError, ValueError):
+                pass  # file deleted or outside root - skip it
     Path(manifest_path).parent.mkdir(parents=True, exist_ok=True)
     Path(manifest_path).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
@@ -825,6 +831,7 @@ def detect_incremental(
     incremental runs.
     """
     full = detect(root, follow_symlinks=follow_symlinks, google_workspace=google_workspace)
+    root = root.resolve()
     manifest = load_manifest(manifest_path)
 
     if not manifest:
@@ -840,9 +847,12 @@ def detect_incremental(
 
     for ftype, file_list in full["files"].items():
         for f in file_list:
-            stored = manifest.get(f)
+            fp = Path(f)
+            rfp = fp.resolve() if fp.is_absolute() else fp
+            rel_key = str(rfp.relative_to(root)) if fp.is_absolute() else f
+            stored = manifest.get(f) or manifest.get(rel_key)
             try:
-                current_mtime = Path(f).stat().st_mtime
+                current_mtime = fp.stat().st_mtime
             except Exception:
                 current_mtime = 0
 
@@ -866,7 +876,17 @@ def detect_incremental(
 
     # Files in manifest that no longer exist - their cached nodes are now ghost nodes
     current_files = {f for flist in full["files"].values() for f in flist}
-    deleted_files = [f for f in manifest if f not in current_files]
+    current_rel = set()
+    for f in current_files:
+        fp = Path(f)
+        if fp.is_absolute():
+            try:
+                current_rel.add(str(fp.resolve().relative_to(root)))
+            except ValueError:
+                pass
+        else:
+            current_rel.add(f)
+    deleted_files = [f for f in manifest if f not in current_files and f not in current_rel]
 
     new_total = sum(len(v) for v in new_files.values())
     full["incremental"] = True


### PR DESCRIPTION
## Summary

- `manifest.json` keys now store project-relative paths instead of absolute paths (e.g. `src/main.py` instead of `/Users/foo/project/src/main.py`)
- `GRAPH_REPORT.md` title uses the directory name instead of the full absolute path
- `detect_incremental` is backwards-compatible: matches both legacy absolute keys and new relative keys

## Motivation

Absolute paths in output files leak local filesystem structure and break portability — the same graph output produces different content on different machines, making it impossible to commit `graphify-out/` to version control or share across environments.

## Test plan

- [x] `tests/test_detect.py` — all 33 tests pass (including incremental + symlink tests)
- [x] `tests/test_report.py`, `tests/test_build.py`, `tests/test_ingest.py` — all pass
- [x] No new ruff lint errors introduced
- [x] Backwards compatible: existing manifests with absolute keys still work via fallback lookup