### PR TITLE
sql extractor: extract ALTER TABLE foreign keys + schema-qualified names

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2505,9 +2505,7 @@ def extract_sql(path: Path) -> dict:
     def _obj_name(n) -> str | None:
         for c in n.children:
             if c.type == "object_reference":
-                for cc in c.children:
-                    if cc.type == "identifier":
-                        return _read(cc)
+                return _read(c)
         return None
 
     def _add_node(nid: str, label: str, line: int) -> None:
@@ -2546,9 +2544,7 @@ def extract_sql(path: Path) -> dict:
                                 if cc.type == "keyword_references":
                                     found_ref = True
                                 elif found_ref and cc.type == "object_reference":
-                                    for ccc in cc.children:
-                                        if ccc.type == "identifier":
-                                            ref_name = _read(ccc)
+                                    ref_name = _read(cc)
                                     break
                             if ref_name:
                                 ref_nid = _make_id(stem, ref_name)
@@ -2577,6 +2573,33 @@ def extract_sql(path: Path) -> dict:
                 _add_node(nid, f"{name}()", line)
                 _walk_from_refs(node, nid, line)
 
+        elif t == "alter_table":
+            name = _obj_name(node)
+            if name:
+                src_nid = table_nids.get(name.lower())
+                if not src_nid:
+                    src_nid = _make_id(stem, name)
+                    _add_node(src_nid, name, line)
+                    table_nids[name.lower()] = src_nid
+                for child in node.children:
+                    if child.type == "add_constraint":
+                        for cc in child.children:
+                            if cc.type != "constraint":
+                                continue
+                            found_ref = False
+                            ref_name: str | None = None
+                            for ccc in cc.children:
+                                if ccc.type == "keyword_references":
+                                    found_ref = True
+                                elif found_ref and ccc.type == "object_reference":
+                                    ref_name = _read(ccc)
+                                    break
+                            if ref_name:
+                                ref_nid = table_nids.get(ref_name.lower())
+                                if not ref_nid:
+                                    ref_nid = _make_id(stem, ref_name)
+                                _add_edge(src_nid, ref_nid, "references", line)
+
         for child in node.children:
             walk(child)
 
@@ -2587,12 +2610,10 @@ def extract_sql(path: Path) -> dict:
                 if c.type == "relation":
                     for cc in c.children:
                         if cc.type == "object_reference":
-                            for ccc in cc.children:
-                                if ccc.type == "identifier":
-                                    tbl = _read(ccc)
-                                    tbl_nid = _make_id(stem, tbl)
-                                    _add_edge(caller_nid, tbl_nid, "reads_from",
-                                              c.start_point[0] + 1)
+                            tbl = _read(cc)
+                            tbl_nid = _make_id(stem, tbl)
+                            _add_edge(caller_nid, tbl_nid, "reads_from",
+                                      c.start_point[0] + 1)
         for child in node.children:
             _walk_from_refs(child, caller_nid, line)
 

--- a/tests/fixtures/sample_alter_fk.sql
+++ b/tests/fixtures/sample_alter_fk.sql
@@ -1,0 +1,12 @@
+CREATE TABLE customers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE orders (
+  id SERIAL PRIMARY KEY,
+  customer_id INT,
+  total NUMERIC
+);
+
+ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id);

--- a/tests/fixtures/sample_schema_qualified.sql
+++ b/tests/fixtures/sample_schema_qualified.sql
@@ -1,0 +1,11 @@
+CREATE TABLE Sales.Customer (
+  CustomerID SERIAL PRIMARY KEY,
+  Name TEXT NOT NULL
+);
+
+CREATE TABLE Sales.SalesOrder (
+  OrderID SERIAL PRIMARY KEY,
+  CustomerID INT REFERENCES Sales.Customer(CustomerID)
+);
+
+ALTER TABLE Sales.SalesOrder ADD CONSTRAINT fk_cust FOREIGN KEY (CustomerID) REFERENCES Sales.Customer(CustomerID);

--- a/tests/test_multilang.py
+++ b/tests/test_multilang.py
@@ -252,3 +252,30 @@ def test_sql_no_dangling_edges():
     node_ids = {n["id"] for n in r["nodes"]}
     for e in r["edges"]:
         assert e["source"] in node_ids, f"dangling source: {e['source']}"
+
+def test_sql_alter_table_fk_edge():
+    """ALTER TABLE ... FOREIGN KEY ... REFERENCES produces a references edge."""
+    r = extract_sql(FIXTURES / "sample_alter_fk.sql")
+    fk_edges = [e for e in r["edges"] if e["relation"] == "references"]
+    assert len(fk_edges) >= 1
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in fk_edges:
+        assert e["source"] in node_ids, f"dangling source: {e['source']}"
+        assert e["target"] in node_ids, f"dangling target: {e['target']}"
+
+def test_sql_schema_qualified_names():
+    """Schema-qualified table names (Schema.Table) are preserved."""
+    r = extract_sql(FIXTURES / "sample_schema_qualified.sql")
+    labels = [n["label"] for n in r["nodes"]]
+    assert any("Sales.Customer" in l for l in labels)
+    assert any("Sales.SalesOrder" in l for l in labels)
+
+def test_sql_schema_qualified_alter_fk():
+    """ALTER TABLE with schema-qualified names produces correct edges."""
+    r = extract_sql(FIXTURES / "sample_schema_qualified.sql")
+    fk_edges = [e for e in r["edges"] if e["relation"] == "references"]
+    assert len(fk_edges) >= 1
+    node_ids = {n["id"] for n in r["nodes"]}
+    for e in fk_edges:
+        assert e["source"] in node_ids, f"dangling source: {e['source']}"
+        assert e["target"] in node_ids, f"dangling target: {e['target']}"


### PR DESCRIPTION
## Problem

`extract_sql()` misses foreign key relationships defined via `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES` — it only extracts inline `REFERENCES` within `CREATE TABLE` column definitions.

Many real-world schemas (pg_dump output, enterprise databases) define FK constraints separately. For example, [AdventureWorks](https://github.com/lorint/AdventureWorks-for-Postgres) (68 tables, 5 schemas) defines all 89 FK relationships via ALTER TABLE — graphify currently finds **zero** of them.

Additionally, `_obj_name()` only reads the first `identifier` child of `object_reference` nodes, so schema-qualified names like `Sales.Customer` are truncated to just `Sales`.

## Goal

Make graphify's SQL parser reliable enough that downstream tools can consume `graph.json` as the single source of truth for database schema relationships — instead of re-parsing SQL with regex.

## Changes

**`graphify/extract.py`:**
- **`_obj_name()`**: Read the full `object_reference` text instead of just the first `identifier` child. This preserves schema-qualified names (`Sales.Customer`) while keeping bare names (`users`) unchanged.
- **`walk()` — new `alter_table` handler**: Extract FK edges from `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES`. Reuses existing `table_nids` lookup to connect to previously-seen CREATE TABLE nodes.
- **Inline FK + `_walk_from_refs()`**: Same fix — read full `object_reference` text for schema-qualified references.

**Tests:**
- `test_sql_alter_table_fk_edge` — ALTER TABLE FK produces a `references` edge with no dangling nodes
- `test_sql_schema_qualified_names` — `Sales.Customer` label is preserved (not truncated to `Sales`)
- `test_sql_schema_qualified_alter_fk` — ALTER TABLE with schema-qualified names produces correct edges

All 6 existing SQL tests continue to pass.

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| AdventureWorks FK edges | 0 | 89 |
| Schema-qualified name `Sales.Customer` | Parsed as `Sales` | Parsed as `Sales.Customer` |

## Downstream use case

I uses graphify's `graph.json` to auto-generate per-table schema documentation for AI database agents. Without ALTER TABLE FK extraction, it had to re-implement SQL parsing with regex — this PR eliminates that need.