### PR TITLE
[codex] Add OpenAI Responses fallback for mini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ graphify antigravity install / uninstall
 graphify extract ./docs                        # headless LLM extraction for CI (no IDE needed)
 graphify extract ./docs --backend gemini       # explicit backend: gemini, kimi, claude, openai, ollama, or bedrock
 graphify extract ./docs --backend gemini --model gemini-3.1-pro-preview
+graphify extract ./docs --backend openai --model gpt-5.5-mini
+GRAPHIFY_OPENAI_FALLBACK_MODELS=gpt-5.4-mini,gpt-4.1-mini graphify extract ./docs --backend openai --model gpt-5.5-mini
 graphify extract ./docs --backend ollama       # local Ollama (set OLLAMA_BASE_URL / OLLAMA_MODEL)
 graphify extract ./docs --backend bedrock      # AWS Bedrock via IAM - no API key, uses AWS credential chain
 graphify extract ./docs --google-workspace     # export .gdoc/.gsheet/.gslides via gws before extraction

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1111,8 +1111,10 @@ def main() -> None:
         print("    --top-k-edges N         per-symbol outbound edges in inspector (default 12)")
         print("    --label NAME            project label in header")
         print("  extract <path>          headless full extraction (AST + semantic LLM) for CI/scripts")
-        print("    --backend B             gemini|kimi|claude|openai|ollama (default: whichever API key is set)")
+        print("    --backend B             gemini|kimi|claude|openai|ollama|bedrock (default: whichever API key is set)")
         print("    --model M               override backend default model")
+        print("                            OpenAI GPT-5.x/Codex models use Responses API")
+        print("                            fallback: GRAPHIFY_OPENAI_FALLBACK_MODELS=m1,m2")
         print("    --out DIR               output dir (default: <path>); writes <DIR>/graphify-out/")
         print("    --google-workspace      export .gdoc/.gsheet/.gslides shortcuts via gws before extraction")
         print("    --no-cluster            skip clustering, write raw extraction only")
@@ -2077,8 +2079,8 @@ def main() -> None:
         # has an API key set.
         if len(sys.argv) < 3:
             print(
-                "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai] "
-                "[--out DIR] [--google-workspace] [--no-cluster]",
+                "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|ollama|bedrock] "
+                "[--model MODEL] [--out DIR] [--google-workspace] [--no-cluster]",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -84,6 +84,7 @@ BACKENDS: dict[str, dict] = {
         "default_model": "gpt-4.1-mini",
         "env_key": "OPENAI_API_KEY",
         "model_env_key": "GRAPHIFY_OPENAI_MODEL",
+        "fallback_models_env_key": "GRAPHIFY_OPENAI_FALLBACK_MODELS",
         "pricing": {"input": 0.40, "output": 1.60},  # USD per 1M tokens
         "temperature": 0,
     },
@@ -208,6 +209,84 @@ def _default_model_for_backend(backend: str) -> str:
     return cfg["default_model"]
 
 
+def _split_model_list(raw: str | None) -> list[str]:
+    """Parse comma-separated model names, preserving order and removing duplicates."""
+    if not raw:
+        return []
+    models: list[str] = []
+    seen: set[str] = set()
+    for item in raw.split(","):
+        model = item.strip()
+        if model and model not in seen:
+            models.append(model)
+            seen.add(model)
+    return models
+
+
+def _model_candidates_for_backend(backend: str, model: str | None) -> list[str]:
+    """Return primary model plus opt-in fallback candidates for a backend."""
+    cfg = BACKENDS[backend]
+    candidates = [model or _default_model_for_backend(backend)]
+    fallback_env_key = cfg.get("fallback_models_env_key")
+    if fallback_env_key:
+        candidates.extend(_split_model_list(os.environ.get(fallback_env_key)))
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            deduped.append(candidate)
+            seen.add(candidate)
+    return deduped
+
+
+def _openai_model_uses_responses(model: str) -> bool:
+    """Return True for OpenAI model families that need or prefer Responses."""
+    m = model.lower()
+    return m.startswith("gpt-5") or m.startswith("codex-mini") or "-codex" in m
+
+
+def _responses_text(resp) -> str:
+    """Extract text from an OpenAI Responses API object across SDK versions."""
+    output_text = getattr(resp, "output_text", None)
+    if output_text:
+        return output_text
+
+    parts: list[str] = []
+    for item in getattr(resp, "output", []) or []:
+        content = getattr(item, "content", None)
+        if content is None and isinstance(item, dict):
+            content = item.get("content", [])
+        for part in content or []:
+            text = getattr(part, "text", None)
+            if text is None and isinstance(part, dict):
+                text = part.get("text")
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _usage_tokens(usage, *names: str) -> int:
+    """Read the first available token-count attribute/key from an API usage object."""
+    if usage is None:
+        return 0
+    for name in names:
+        value = getattr(usage, name, None)
+        if value is None and isinstance(usage, dict):
+            value = usage.get(name)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _finish_reason_from_responses(resp) -> str:
+    status = getattr(resp, "status", None)
+    incomplete = getattr(resp, "incomplete_details", None)
+    if status == "incomplete" or incomplete:
+        return "length"
+    return "stop"
+
+
 def _call_openai_compat(
     base_url: str,
     api_key: str,
@@ -262,6 +341,43 @@ def _call_openai_compat(
             "Try a larger model with --model (e.g. --model qwen2.5-coder:14b).",
             file=sys.stderr,
         )
+    return result
+
+
+def _call_openai_responses(
+    base_url: str,
+    api_key: str,
+    model: str,
+    user_message: str,
+    *,
+    max_output_tokens: int = 8192,
+    reasoning_effort: str | None = None,
+) -> dict:
+    """Call OpenAI's Responses API for GPT-5/Codex models and return parsed JSON."""
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise ImportError(
+            "OpenAI Responses extraction requires the openai package. "
+            "Run: pip install graphifyy[openai]"
+        ) from exc
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+    kwargs: dict = {
+        "model": model,
+        "instructions": _EXTRACTION_SYSTEM,
+        "input": user_message,
+        "max_output_tokens": max_output_tokens,
+    }
+    if reasoning_effort is not None:
+        kwargs["reasoning"] = {"effort": reasoning_effort}
+
+    resp = client.responses.create(**kwargs)
+    result = _parse_llm_json(_responses_text(resp) or "{}")
+    result["input_tokens"] = _usage_tokens(resp.usage, "input_tokens", "prompt_tokens")
+    result["output_tokens"] = _usage_tokens(resp.usage, "output_tokens", "completion_tokens")
+    result["model"] = model
+    result["finish_reason"] = _finish_reason_from_responses(resp)
     return result
 
 
@@ -365,7 +481,8 @@ def extract_files_direct(
             f"No API key for backend '{backend}'. "
             f"Set {_format_backend_env_keys(backend)} or pass api_key=."
         )
-    mdl = model or _default_model_for_backend(backend)
+    model_candidates = _model_candidates_for_backend(backend, model)
+    mdl = model_candidates[0]
     user_msg = _read_files(files, root)
     max_out = _resolve_max_tokens(cfg.get("max_tokens", 8192))
 
@@ -373,6 +490,41 @@ def extract_files_direct(
         return _call_claude(key, mdl, user_msg, max_tokens=max_out)
     if backend == "bedrock":
         return _call_bedrock(mdl, user_msg, max_tokens=max_out)
+    if backend == "openai":
+        last_exc: Exception | None = None
+        for idx, candidate in enumerate(model_candidates):
+            try:
+                if _openai_model_uses_responses(candidate):
+                    return _call_openai_responses(
+                        cfg["base_url"],
+                        key,
+                        candidate,
+                        user_msg,
+                        max_output_tokens=cfg.get("max_completion_tokens", max_out),
+                        reasoning_effort=cfg.get("reasoning_effort"),
+                    )
+                return _call_openai_compat(
+                    cfg["base_url"],
+                    key,
+                    candidate,
+                    user_msg,
+                    temperature=cfg.get("temperature", 0),
+                    reasoning_effort=cfg.get("reasoning_effort"),
+                    max_completion_tokens=cfg.get("max_completion_tokens", max_out),
+                    backend=backend,
+                )
+            except Exception as exc:  # noqa: BLE001 - retry explicitly configured fallback models
+                last_exc = exc
+                if idx >= len(model_candidates) - 1:
+                    break
+                next_model = model_candidates[idx + 1]
+                print(
+                    f"[graphify] openai model {candidate!r} failed: {exc}; "
+                    f"retrying with {next_model!r}.",
+                    file=sys.stderr,
+                )
+        assert last_exc is not None
+        raise last_exc
     return _call_openai_compat(
         cfg["base_url"],
         key,

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -53,6 +53,112 @@ def test_openai_backend_detected(monkeypatch):
     assert llm._get_backend_api_key("openai") == "openai-key"
 
 
+def test_openai_default_model_stays_existing_chat_model(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.delenv("GRAPHIFY_OPENAI_MODEL", raising=False)
+    monkeypatch.delenv("GRAPHIFY_OPENAI_FALLBACK_MODELS", raising=False)
+
+    assert llm._default_model_for_backend("openai") == "gpt-4.1-mini"
+    assert llm._model_candidates_for_backend("openai", None) == ["gpt-4.1-mini"]
+
+
+def test_openai_fallback_models_can_be_overridden_by_env(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("GRAPHIFY_OPENAI_MODEL", "gpt-5.5-mini")
+    monkeypatch.setenv(
+        "GRAPHIFY_OPENAI_FALLBACK_MODELS",
+        "gpt-5.4-mini, gpt-4.1-mini, gpt-5.4-mini",
+    )
+
+    assert llm._model_candidates_for_backend("openai", None) == [
+        "gpt-5.5-mini",
+        "gpt-5.4-mini",
+        "gpt-4.1-mini",
+    ]
+
+
+def test_extract_files_direct_retries_openai_model_fallback(tmp_path, monkeypatch, capsys):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("GRAPHIFY_OPENAI_FALLBACK_MODELS", "gpt-5-mini")
+    source = tmp_path / "note.md"
+    source.write_text("# Architecture\n")
+    fallback_result = {
+        "nodes": [],
+        "edges": [],
+        "hyperedges": [],
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "model": "gpt-5-mini",
+    }
+
+    with patch(
+        "graphify.llm._call_openai_responses",
+        side_effect=[RuntimeError("model unavailable"), fallback_result],
+    ) as responses_call:
+        result = llm.extract_files_direct(
+            [source],
+            backend="openai",
+            model="gpt-5.5-mini",
+            root=tmp_path,
+        )
+
+    assert result is fallback_result
+    assert [call.args[2] for call in responses_call.call_args_list] == [
+        "gpt-5.5-mini",
+        "gpt-5-mini",
+    ]
+    err = capsys.readouterr().err
+    assert "gpt-5.5-mini" in err
+    assert "gpt-5-mini" in err
+
+
+def test_openai_gpt5_mini_model_uses_responses_api(tmp_path, monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    source = tmp_path / "note.md"
+    source.write_text("# Architecture\n")
+    result = {"nodes": [], "edges": [], "hyperedges": [], "input_tokens": 1, "output_tokens": 1}
+
+    with patch("graphify.llm._call_openai_compat") as compat_call:
+        with patch("graphify.llm._call_openai_responses", return_value=result) as responses_call:
+            assert (
+                llm.extract_files_direct(
+                    [source],
+                    backend="openai",
+                    model="gpt-5.4-mini",
+                    root=tmp_path,
+                )
+                is result
+            )
+
+    compat_call.assert_not_called()
+    assert responses_call.call_args.args[2] == "gpt-5.4-mini"
+
+
+def test_openai_chat_model_still_uses_chat_completions(tmp_path, monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    source = tmp_path / "note.md"
+    source.write_text("# Architecture\n")
+    result = {"nodes": [], "edges": [], "hyperedges": [], "input_tokens": 1, "output_tokens": 1}
+
+    with patch("graphify.llm._call_openai_responses") as responses_call:
+        with patch("graphify.llm._call_openai_compat", return_value=result) as compat_call:
+            assert (
+                llm.extract_files_direct(
+                    [source],
+                    backend="openai",
+                    model="gpt-4.1-mini",
+                    root=tmp_path,
+                )
+                is result
+            )
+
+    responses_call.assert_not_called()
+    assert compat_call.call_args.args[2] == "gpt-4.1-mini"
+
+
 def test_extract_files_direct_routes_gemini_through_openai_compat(tmp_path, monkeypatch):
     _clear_backend_env(monkeypatch)
     monkeypatch.setenv("GOOGLE_API_KEY", "google-key")


### PR DESCRIPTION
## Summary

- add OpenAI Responses API routing for GPT-5.x / Codex model names when users explicitly select them with `--backend openai --model ...` or `GRAPHIFY_OPENAI_MODEL`
- add opt-in OpenAI model fallback via `GRAPHIFY_OPENAI_FALLBACK_MODELS`, preserving the existing `gpt-4.1-mini` default and Chat Completions path
- document mini-model examples such as `gpt-5.5-mini` with fallback to `gpt-5.4-mini,gpt-4.1-mini`

## Scope / duplication check

- This does not change backend detection priority or the existing OpenAI default model.
- I checked open upstream issues and PRs for `openai codex mini fallback gpt-5.5 gpt-5.4`; no matching open item came back.

## Validation

- `uv run --with pytest pytest tests/test_llm_backends.py tests/test_ollama.py -q` -> 18 passed
- `python3 -m compileall graphify/llm.py graphify/__main__.py` -> passed
- `uv run graphify --help | sed -n '/extract <path>/,+8p'` -> verified help text
- `graphify update .` -> completed code graph refresh
- `uv run --with pytest pytest -q` -> 667 passed, 6 failed in existing Fortran/SQL parser tests unrelated to this backend change (`test_fortran_capital_F_parses_preprocessed`, SQL table/view/function/edge assertions)
