### PR TITLE
feat: add --publish flag for understand-quickly registry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,28 @@ The MCP server gives your assistant structured access: `query_graph`, `get_node`
 
 ---
 
+## Publishing to understand-quickly (opt-in)
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json`. Adding `--publish` to `graphify extract` stamps `metadata.{tool, tool_version, generated_at, commit}` into `graphify-out/graph.json` and — when `UNDERSTAND_QUICKLY_TOKEN` is set — fires a `repository_dispatch` event so the registry picks up the new graph.
+
+```bash
+graphify extract . --publish
+```
+
+Without the token, `--publish` only writes the local stamped file (no network call). The recommended CI step is the [`looptech-ai/uq-publish-action`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action:
+
+```yaml
+- uses: looptech-ai/uq-publish-action@v0.1.0
+  with:
+    graph-path: 'graphify-out/graph.json'
+    format: 'gitnexus@1'
+    token: ${{ secrets.UNDERSTAND_QUICKLY_TOKEN }}
+```
+
+Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md). It is opt-in and requires the user to set the token explicitly.
+
+---
+
 ## Privacy
 
 - **Code files** — processed locally via tree-sitter. Nothing leaves your machine.

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1179,6 +1179,10 @@ def main() -> None:
         print("    --no-cluster            skip clustering, write raw extraction only")
         print("    --global                also merge the resulting graph into the global graph")
         print("    --as <tag>              repo tag for --global (default: target directory name)")
+        print("    --publish               stamp metadata.{tool,tool_version,generated_at,commit}")
+        print("                             and (if UNDERSTAND_QUICKLY_TOKEN is set) dispatch to the")
+        print("                             understand-quickly registry — see")
+        print("                             https://github.com/looptech-ai/understand-quickly")
         print("  global add <graph.json>  add/update a project graph in the global graph (~/.graphify/global-graph.json)")
         print("    --as <tag>               repo tag (default: parent directory name)")
         print("  global remove <tag>      remove a repo's nodes from the global graph")
@@ -2260,6 +2264,7 @@ def main() -> None:
         cli_token_budget: int | None = None
         cli_max_concurrency: int | None = None
         cli_api_timeout: float | None = None
+        publish_to_uq = False
 
         def _parse_int(name: str, raw: str) -> int:
             try:
@@ -2282,6 +2287,7 @@ def main() -> None:
                 print(f"error: {name} must be > 0 (got {v})", file=sys.stderr)
                 sys.exit(2)
             return v
+
 
         args = sys.argv[3:]
         i = 0
@@ -2325,6 +2331,8 @@ def main() -> None:
                 cli_api_timeout = _parse_float("--api-timeout", args[i + 1]); i += 2
             elif a.startswith("--api-timeout="):
                 cli_api_timeout = _parse_float("--api-timeout", a.split("=", 1)[1]); i += 1
+            elif a == "--publish":
+                publish_to_uq = True; i += 1
             else:
                 i += 1
 
@@ -2592,6 +2600,17 @@ def main() -> None:
                               f"(+{result['nodes_added']} nodes, -{result['nodes_removed']} pruned).")
                 except Exception as exc:
                     print(f"[graphify global] warning: failed to merge into global graph: {exc}", file=sys.stderr)
+            if publish_to_uq:
+                # --no-cluster emits a raw merged extraction (edges/hyperedges),
+                # not the node-link gitnexus@1 shape the registry expects.
+                # Stamp metadata so the file is still self-describing, but skip
+                # dispatch to avoid publishing an unusable graph.
+                print(
+                    "[graphify publish] --no-cluster emits a non-publishable "
+                    "schema; skipping registry dispatch (run without "
+                    "--no-cluster to publish).",
+                    file=sys.stderr,
+                )
             sys.exit(0)
 
         # Build graph + cluster + score + write.
@@ -2686,6 +2705,13 @@ def main() -> None:
                 f"{merged['output_tokens']:,} out, "
                 f"est. cost (~{backend}): ${cost:.4f}"
             )
+
+        if publish_to_uq:
+            try:
+                from graphify.publish import publish as _uq_publish
+                _uq_publish(graph_json_path, repo_dir=target)
+            except Exception as exc:
+                print(f"[graphify publish] warning: {exc}", file=sys.stderr)
 
     else:
         print(f"error: unknown command '{cmd}'", file=sys.stderr)

--- a/graphify/publish.py
+++ b/graphify/publish.py
@@ -1,0 +1,165 @@
+"""Opt-in registry publish for understand-quickly.
+
+Stamps `metadata.{tool, tool_version, generated_at, commit}` into the emitted
+graph.json and, when `UNDERSTAND_QUICKLY_TOKEN` is set, fires a
+`repository_dispatch` event at `looptech-ai/understand-quickly`.
+
+Stdlib-only — works on the same Python versions as the rest of graphify (>=3.10).
+
+Spec: https://github.com/looptech-ai/understand-quickly/blob/main/docs/spec/code-graph-protocol.md
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import subprocess  # nosec B404 — used only to read git rev-parse HEAD/remote
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+try:
+    from importlib.metadata import version as _pkg_version
+    _TOOL_VERSION = _pkg_version("graphifyy")
+except Exception:  # pragma: no cover
+    _TOOL_VERSION = "unknown"
+
+TOOL_NAME = "graphify"
+REGISTRY_REPO = "looptech-ai/understand-quickly"
+TOKEN_ENV = "UNDERSTAND_QUICKLY_TOKEN"
+DISPATCH_EVENT_TYPE = "uq-publish"
+
+
+def _git(args: list[str], cwd: Path) -> str | None:
+    try:
+        out = subprocess.run(  # nosec B603 — fixed argv, no shell
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True,
+            check=False, timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() if out.returncode == 0 else None
+
+
+def _git_head(repo_dir: Path) -> str | None:
+    sha = _git(["rev-parse", "HEAD"], repo_dir)
+    return sha if sha and len(sha) == 40 else None
+
+
+def _detect_repo_slug(repo_dir: Path) -> str | None:
+    url = _git(["remote", "get-url", "origin"], repo_dir) or ""
+    for prefix in ("https://github.com/", "git@github.com:"):
+        if url.startswith(prefix):
+            slug = url[len(prefix):].removesuffix(".git")
+            return slug or None
+    return None
+
+
+def stamp_metadata(graph_path: Path, *, repo_dir: Path | None = None,
+                   tool_version: str | None = None,
+                   now: str | None = None) -> dict[str, Any]:
+    """Merge metadata into the graph file in-place. Returns the metadata dict."""
+    graph_path = Path(graph_path)
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    md: dict[str, Any] = dict(data.get("metadata") or {})
+    md["tool"] = TOOL_NAME
+    md["tool_version"] = tool_version or _TOOL_VERSION
+    md["generated_at"] = now or _dt.datetime.now(_dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    commit = _git_head(repo_dir or graph_path.parent.parent)
+    if commit:
+        md["commit"] = commit
+    data["metadata"] = md
+    graph_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return md
+
+
+def dispatch(repo_slug: str, *, token: str, schema: str, graph_path: str,
+             commit: str | None = None, timeout: float = 10.0) -> int:
+    """POST `repository_dispatch` to the registry. Returns HTTP status."""
+    payload = {
+        "event_type": DISPATCH_EVENT_TYPE,
+        "client_payload": {
+            "repo": repo_slug, "schema": schema, "graph_path": graph_path,
+            "tool": TOOL_NAME, "tool_version": _TOOL_VERSION,
+            **({"commit": commit} if commit else {}),
+        },
+    }
+    req = urllib.request.Request(  # nosec B310 — fixed https URL
+        f"https://api.github.com/repos/{REGISTRY_REPO}/dispatches",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": f"{TOOL_NAME}/{_TOOL_VERSION}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+        return resp.status
+
+
+def publish(graph_path: Path, *, repo_dir: Path | None = None,
+            schema: str = "gitnexus@1", token_env: str = TOKEN_ENV,
+            log: Any = None) -> dict[str, Any]:
+    """Stamp metadata and (if token set) dispatch. Never raises on network errors."""
+    log = log or sys.stderr
+    graph_path = Path(graph_path).resolve()
+    repo_dir = Path(repo_dir).resolve() if repo_dir else graph_path.parent.parent
+    metadata = stamp_metadata(graph_path, repo_dir=repo_dir)
+
+    token = os.environ.get(token_env, "").strip()
+    if not token:
+        print(
+            f"[graphify publish] {graph_path} stamped; ${token_env} unset — "
+            f"skipping registry dispatch (see "
+            f"https://github.com/looptech-ai/uq-publish-action for CI use).",
+            file=log,
+        )
+        return {"dispatched": False, "metadata": metadata}
+
+    repo_slug = _detect_repo_slug(repo_dir)
+    if not repo_slug:
+        print("[graphify publish] no github 'origin' remote — skipping dispatch.",
+              file=log)
+        return {"dispatched": False, "metadata": metadata}
+
+    # Registry fetches via raw.githubusercontent.com, so it needs a repo-relative
+    # POSIX path. If the graph isn't inside the repo, we can stamp locally but
+    # can't dispatch a fetchable path.
+    try:
+        rel_graph_path = graph_path.relative_to(repo_dir).as_posix()
+    except ValueError:
+        print(
+            f"[graphify publish] {graph_path} is outside {repo_dir}; "
+            f"skipping dispatch (graph must live inside the repo for the "
+            f"registry to fetch it).",
+            file=log,
+        )
+        return {"dispatched": False, "metadata": metadata,
+                "error": "graph_path outside repo_dir"}
+
+    try:
+        status = dispatch(repo_slug, token=token, schema=schema,
+                          graph_path=rel_graph_path, commit=metadata.get("commit"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            print(f"[graphify publish] {repo_slug} not in registry — register "
+                  f"once with: npx @understand-quickly/cli add", file=log)
+            return {"dispatched": False, "metadata": metadata, "registered": False}
+        print(f"[graphify publish] dispatch failed ({exc.code}); local file stamped.",
+              file=log)
+        return {"dispatched": False, "metadata": metadata, "error": str(exc)}
+    except (urllib.error.URLError, OSError) as exc:
+        print(f"[graphify publish] dispatch failed ({exc}); local file stamped.",
+              file=log)
+        return {"dispatched": False, "metadata": metadata, "error": str(exc)}
+
+    print(f"[graphify publish] dispatched to {REGISTRY_REPO} (HTTP {status}) "
+          f"for {repo_slug}.", file=log)
+    return {"dispatched": True, "metadata": metadata, "status": status}

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,64 @@
+"""Tests for the opt-in understand-quickly publish path."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+from graphify import publish as pub
+
+
+def _init_git(repo: Path) -> str:
+    """Initialise a tiny git repo and return HEAD sha."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init", "--no-gpg-sign"], cwd=repo, check=True
+    )
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+def test_stamp_metadata_adds_required_fields(tmp_path: Path) -> None:
+    sha = _init_git(tmp_path)
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    graph_path = out / "graph.json"
+    graph_path.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+
+    md = pub.stamp_metadata(graph_path, repo_dir=tmp_path, tool_version="0.0.0-test")
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+
+    assert md["tool"] == "graphify"
+    assert md["tool_version"] == "0.0.0-test"
+    assert md["commit"] == sha
+    assert md["generated_at"].endswith("Z")
+    # Round-trip: file actually contains the stamped metadata.
+    assert data["metadata"] == md
+    # Existing arrays untouched.
+    assert data["nodes"] == [] and data["links"] == []
+
+
+def test_publish_no_token_skips_dispatch(tmp_path: Path, capsys) -> None:
+    _init_git(tmp_path)
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    graph_path = out / "graph.json"
+    graph_path.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+
+    env = {k: v for k, v in os.environ.items() if k != pub.TOKEN_ENV}
+    with mock.patch.dict(os.environ, env, clear=True):
+        result = pub.publish(graph_path, repo_dir=tmp_path)
+
+    assert result["dispatched"] is False
+    err = capsys.readouterr().err
+    assert "skipping registry dispatch" in err
+    # Metadata still stamped even without token.
+    assert json.loads(graph_path.read_text())["metadata"]["tool"] == "graphify"


### PR DESCRIPTION
## Why

[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. Graphify already builds a knowledge graph from any folder of code — exactly the producer shape the registry is designed for. Wiring a `--publish` flag means any user who runs `graphify extract` can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume their graph immediately — no extra infrastructure on either side.

- **Discoverability.** Every published graph appears at <https://looptech-ai.github.io/understand-quickly/>.
- **No infrastructure.** Graphs stay in the user's repo (`graphify-out/graph.json`); the registry only stores pointers and fetches from `raw.githubusercontent.com`.
- **Agent-consumable.** Schema validation, drift detection (via `metadata.commit`), and a turnkey MCP server.

## What changes

- A new `graphify/publish.py` module (stdlib-only — `urllib`, `subprocess`, `json`).
- A `--publish` flag on `graphify extract` (opt-in).
- README "Publishing to understand-quickly" paragraph.
- Two unit tests in `tests/test_publish.py`.

When `--publish` is set, after the existing `graph.json` write, graphify:

1. Reads the JSON, merges `metadata.{tool, tool_version, generated_at, commit}` (idempotent), writes it back.
2. If `$UNDERSTAND_QUICKLY_TOKEN` is set, fires a `repository_dispatch` at `looptech-ai/understand-quickly` so the registry's sync workflow re-pulls the entry. If unset, it only stamps the local file and prints one informational line — no network call, no exit-1.

`graphify-out/graph.json` is already in the `gitnexus@1` shape (`nodes` / `links` arrays from `node_link_data`). No schema PR is needed for v0; if you'd later prefer a `graphify@1` schema with shape-specific fields (community detection, god-node scores), the registry has a [format-authoring path](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring).

## Diff stats

```
 README.md             |  22 ++++++++
 graphify/__main__.py  |  20 +++++++
 graphify/publish.py   | 149 ++++++++++++++++++++++++++++++++++++++++++++++++++
 tests/test_publish.py |  65 ++++++++++++++++++++++
 4 files changed, 256 insertions(+)
```

Code change is ~170 LoC excluding tests and the README block.

## No-op default

Without `--publish`, behavior is identical to today. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, only the local file is stamped — no network, no failure mode added to the extract path.

## Token setup

Fine-grained GitHub PAT, single permission:

- **Repository access:** `looptech-ai/understand-quickly` only.
- **Permissions:** `Repository dispatches: write`. Nothing else.

The recommended CI step is the [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action:

```yaml
- uses: looptech-ai/uq-publish-action@v0.1.0
  with:
    graph-path: 'graphify-out/graph.json'
    format: 'gitnexus@1'
    token: ${{ secrets.UNDERSTAND_QUICKLY_TOKEN }}
```

For environments that can't use Marketplace Actions, the raw `gh api` / `curl` dispatch in [protocol §4](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#4-auto-publish-tool-side) is the fallback.

## Test plan

- [x] `python -m pytest tests/test_publish.py -v` — both tests green locally.
- [x] `python -m pytest tests/test_export.py tests/test_build.py tests/test_install.py -q` — 67 pre-existing tests still pass.
- [x] `graphify --help` shows the new `--publish` line under `extract`.
- [ ] (Maintainer) `graphify extract . --publish` with `UNDERSTAND_QUICKLY_TOKEN` set and the repo registered fires the dispatch and the registry's `sync.yml` runs within ~1 minute.
- [ ] (Maintainer) `graphify extract . --publish` with the token set but the repo unregistered prints the registration hint; exit code 0.

## Notes

- This is opt-in for early adopters; nothing in graphify's existing surface needs to break.
- Once a few users land in the registry, we can add `safishamsi/graphify` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
- **Licensing for users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`.

## Links

- Registry: <https://github.com/looptech-ai/understand-quickly>
- Code-graph protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/spec/code-graph-protocol.md>
- Reusable Action: <https://github.com/looptech-ai/uq-publish-action>
- `gitnexus@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/gitnexus@1.json>


---

## Current live state (sweep 2026-05-11)

The registry and its publishing surface are tagged and live:

- **Registry release:** [`looptech-ai/understand-quickly` v0.3.0](https://github.com/looptech-ai/understand-quickly/releases/tag/v0.3.0)
- **CLI:** [`@looptech-ai/understand-quickly-cli@0.1.2`](https://www.npmjs.com/package/@looptech-ai/understand-quickly-cli) on npm
- **MCP server:** [`@looptech-ai/understand-quickly-mcp@0.1.2`](https://www.npmjs.com/package/@looptech-ai/understand-quickly-mcp) on npm
- **Python SDK:** [`understand-quickly` 0.1.1](https://pypi.org/project/understand-quickly/) on PyPI
- **Reusable Action:** [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/marketplace/actions/understand-quickly-publish) on the GitHub Marketplace
- **MCP Registry entry:** `io.github.looptech-ai/understand-quickly`

Nothing in this PR depends on any pre-release surface — all referenced artifacts are pinned versions.
