### PR TITLE
fix: add missing file_type values to VALID_FILE_TYPES (closes #840)

### DIFF
--- a/graphify/validate.py
+++ b/graphify/validate.py
@@ -1,7 +1,7 @@
 # validate extraction JSON against the graphify schema before graph assembly
 from __future__ import annotations
 
-VALID_FILE_TYPES = {"code", "document", "paper", "image", "rationale", "concept"}
+VALID_FILE_TYPES = {"code", "document", "paper", "image", "rationale", "concept", "pattern", "tech", "constraint", "markdown", "tool"}
 VALID_CONFIDENCES = {"EXTRACTED", "INFERRED", "AMBIGUOUS"}
 REQUIRED_NODE_FIELDS = {"id", "label", "file_type", "source_file"}
 REQUIRED_EDGE_FIELDS = {"source", "target", "relation", "confidence", "source_file"}


### PR DESCRIPTION
## Problem
`graphify extract` emits nodes with `file_type` values like `pattern`, 
`tech`, `constraint`, `markdown`, and `tool` that are not in 
`VALID_FILE_TYPES`. This causes a warning line on every subsequent 
`graphify update` run.

## Fix
Added the 5 missing values to `VALID_FILE_TYPES` in `graphify/validate.py`.
Same approach used previously to add `rationale` (see CHANGELOG).

## Tests
567 passed, 0 failures introduced. The 2 pre-existing failures 
(`test_fortran_capital_F_parses_preprocessed`, `test_sql_finds_tables`) 
are unrelated to this change.

Closes #840