### PR TITLE
feat(llm): add `--backend claude-cli` (routes through Claude Code CLI, no ANTHROPIC_API_KEY needed)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2422,6 +2422,18 @@ def main() -> None:
                     host in ("localhost", "127.0.0.1", "::1")
                     or host.startswith("127.")
                 )
+            if backend == "claude-cli":
+                # Routes through the locally-installed Claude Code CLI which
+                # authenticates via its own subscription session — no API key.
+                import shutil as _shutil_check
+                allow_no_key = _shutil_check.which("claude") is not None
+                if not allow_no_key:
+                    print(
+                        "error: backend 'claude-cli' requires the `claude` CLI on $PATH "
+                        "(install Claude Code and run `claude` once to authenticate).",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
             if not allow_no_key:
                 print(
                     f"error: backend '{backend}' requires {_format_backend_env_keys(backend)} to be set.",

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -53,6 +53,20 @@ BACKENDS: dict[str, dict] = {
         "temperature": 0,
         "max_tokens": 16384,
     },
+    "claude-cli": {
+        # Routes through the locally-installed `claude` CLI (Claude Code) using
+        # `-p --output-format json`. Authenticates via the user's existing
+        # Pro/Max subscription instead of a separate ANTHROPIC_API_KEY — costs
+        # are billed to the plan, not pay-as-you-go API credit, so pricing
+        # below is zero for graphify's cost-estimator. Model selection is
+        # whatever the active Claude Code session is using; the `default_model`
+        # value is only for cost-tracking labels.
+        "default_model": "claude-code-plan",
+        "env_key": None,
+        "pricing": {"input": 0.0, "output": 0.0},
+        "temperature": 0,
+        "max_tokens": 16384,
+    },
     "kimi": {
         "base_url": "https://api.moonshot.ai/v1",
         "default_model": "kimi-k2.6",
@@ -397,6 +411,77 @@ def _call_claude(api_key: str, model: str, user_message: str, max_tokens: int = 
     return result
 
 
+def _call_claude_cli(user_message: str, max_tokens: int = 8192) -> dict:
+    """Call Claude via the locally-installed Claude Code CLI (`claude -p`).
+
+    Routes through the user's Claude Code subscription auth instead of a separate
+    ANTHROPIC_API_KEY. Useful for users on Pro/Max plans who don't want to
+    provision a pay-as-you-go API key just to run graphify's semantic pass.
+
+    Requires the `claude` binary to be on $PATH and the user to have already
+    authenticated via `claude` interactively at least once.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("claude") is None:
+        raise RuntimeError(
+            "Claude Code CLI not found on $PATH. Install from "
+            "https://docs.claude.com/en/docs/agents-and-tools/claude-code and "
+            "run `claude` once interactively to authenticate."
+        )
+
+    proc = subprocess.run(
+        [
+            "claude", "-p",
+            "--output-format", "json",
+            "--append-system-prompt", _EXTRACTION_SYSTEM,
+        ],
+        input=user_message,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}"
+        )
+
+    try:
+        envelope = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"claude -p produced unparseable JSON envelope: {exc}; "
+            f"first 500 chars of stdout: {proc.stdout[:500]!r}"
+        ) from exc
+
+    raw_content = envelope.get("result", "")
+    result = _parse_llm_json(raw_content or "{}")
+    usage = envelope.get("usage") or {}
+    # Total input includes fresh input + cache reads + cache creation — all of
+    # those represent tokens the model processed for this call.
+    result["input_tokens"] = (
+        int(usage.get("input_tokens", 0) or 0)
+        + int(usage.get("cache_read_input_tokens", 0) or 0)
+        + int(usage.get("cache_creation_input_tokens", 0) or 0)
+    )
+    result["output_tokens"] = int(usage.get("output_tokens", 0) or 0)
+    # `modelUsage` keys look like "claude-opus-4-7[1m]" — first key is the active session model.
+    model_usage = envelope.get("modelUsage") or {}
+    result["model"] = next(iter(model_usage), "claude-code-plan")
+    stop_reason = envelope.get("stop_reason", "")
+    result["finish_reason"] = "length" if stop_reason == "max_tokens" else "stop"
+    if _response_is_hollow(raw_content, result) and result["finish_reason"] != "length":
+        print(
+            "[graphify] claude-cli returned a hollow response; treating as "
+            "truncation so adaptive retry can bisect the chunk.",
+            file=sys.stderr,
+        )
+        result["finish_reason"] = "length"
+    return result
+
+
 def _call_bedrock(model: str, user_message: str, max_tokens: int = 8192) -> dict:
     """Call AWS Bedrock via boto3 Converse API using the standard AWS credential chain."""
     try:
@@ -471,7 +556,7 @@ def extract_files_direct(
             file=sys.stderr,
         )
         key = "ollama"
-    if not key and backend != "bedrock":
+    if not key and backend != "bedrock" and backend != "claude-cli":
         raise ValueError(
             f"No API key for backend '{backend}'. "
             f"Set {_format_backend_env_keys(backend)} or pass api_key=."
@@ -482,6 +567,8 @@ def extract_files_direct(
 
     if backend == "claude":
         return _call_claude(key, mdl, user_msg, max_tokens=max_out)
+    if backend == "claude-cli":
+        return _call_claude_cli(user_msg, max_tokens=max_out)
     if backend == "bedrock":
         return _call_bedrock(mdl, user_msg, max_tokens=max_out)
     return _call_openai_compat(
@@ -852,7 +939,7 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
         ollama_url = os.environ.get("OLLAMA_BASE_URL", cfg.get("base_url", ""))
         _validate_ollama_base_url(ollama_url)
         key = "ollama"
-    if not key and backend != "bedrock":
+    if not key and backend != "bedrock" and backend != "claude-cli":
         raise ValueError(
             f"No API key for backend '{backend}'. Set {_format_backend_env_keys(backend)}."
         )
@@ -870,6 +957,28 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
             messages=[{"role": "user", "content": prompt}],
         )
         return resp.content[0].text if resp.content else ""
+
+    if backend == "claude-cli":
+        # Plain-text completion path (no JSON-extraction system prompt). Used
+        # by dedup tiebreaker etc.
+        import shutil, subprocess
+        if shutil.which("claude") is None:
+            raise RuntimeError("Claude Code CLI not found on $PATH")
+        proc = subprocess.run(
+            ["claude", "-p", "--output-format", "json"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}")
+        try:
+            envelope = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"claude -p produced unparseable JSON envelope: {exc}") from exc
+        return envelope.get("result", "")
 
     if backend == "bedrock":
         try:

--- a/tests/test_claude_cli_backend.py
+++ b/tests/test_claude_cli_backend.py
@@ -1,0 +1,126 @@
+"""Tests for the `claude-cli` backend.
+
+This backend shells out to the locally-installed Claude Code CLI (`claude -p`)
+so Pro/Max subscribers can run graphify's semantic pass without provisioning
+a separate ANTHROPIC_API_KEY. Tests here mock subprocess.run so they do not
+require the `claude` binary or a live network call.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from graphify import llm
+
+
+CLAUDE_ENVELOPE = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "result": json.dumps({
+        "nodes": [
+            {"id": "foo_module", "label": "Foo module", "file_type": "document",
+             "source_file": "foo.md"},
+            {"id": "foo_greet", "label": "greet", "file_type": "code",
+             "source_file": "foo.md"},
+        ],
+        "edges": [
+            {"source": "foo_module", "target": "foo_greet",
+             "relation": "references", "confidence": "EXTRACTED"},
+        ],
+    }),
+    "stop_reason": "end_turn",
+    "usage": {
+        "input_tokens": 6,
+        "output_tokens": 11,
+        "cache_read_input_tokens": 17837,
+        "cache_creation_input_tokens": 30800,
+    },
+    "modelUsage": {
+        "claude-opus-4-7[1m]": {
+            "inputTokens": 6, "outputTokens": 11,
+            "costUSD": 0.2017235,
+        }
+    },
+}
+
+
+@pytest.fixture
+def fake_claude(monkeypatch):
+    """Patch shutil.which + subprocess.run so the backend looks like it has a real CLI."""
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = json.dumps(CLAUDE_ENVELOPE)
+    completed.stderr = ""
+    monkeypatch.setattr(llm, "_response_is_hollow", lambda raw, parsed: False)
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed) as run:
+        yield run
+
+
+def test_call_claude_cli_returns_parsed_result(fake_claude):
+    result = llm._call_claude_cli("dummy user message", max_tokens=8192)
+    assert len(result["nodes"]) == 2
+    assert len(result["edges"]) == 1
+    # Total input tokens = fresh + cache_read + cache_creation (the model processed all of it).
+    assert result["input_tokens"] == 6 + 17837 + 30800
+    assert result["output_tokens"] == 11
+    assert result["model"] == "claude-opus-4-7[1m]"
+    assert result["finish_reason"] == "stop"
+
+
+def test_call_claude_cli_finish_reason_length_on_max_tokens(monkeypatch):
+    envelope = dict(CLAUDE_ENVELOPE, stop_reason="max_tokens")
+    completed = MagicMock(returncode=0, stdout=json.dumps(envelope), stderr="")
+    monkeypatch.setattr(llm, "_response_is_hollow", lambda raw, parsed: False)
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        result = llm._call_claude_cli("dummy", max_tokens=8192)
+    assert result["finish_reason"] == "length"
+
+
+def test_call_claude_cli_raises_when_cli_missing():
+    with patch("shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="Claude Code CLI not found"):
+            llm._call_claude_cli("dummy", max_tokens=8192)
+
+
+def test_call_claude_cli_raises_on_nonzero_exit(monkeypatch):
+    completed = MagicMock(returncode=2, stdout="", stderr="auth failed")
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="exited 2"):
+            llm._call_claude_cli("dummy", max_tokens=8192)
+
+
+def test_call_claude_cli_raises_on_garbage_envelope(monkeypatch):
+    completed = MagicMock(returncode=0, stdout="not json", stderr="")
+    with patch("shutil.which", return_value="/fake/bin/claude"), \
+         patch("subprocess.run", return_value=completed):
+        with pytest.raises(RuntimeError, match="unparseable JSON envelope"):
+            llm._call_claude_cli("dummy", max_tokens=8192)
+
+
+def test_extract_files_direct_dispatches_to_claude_cli(tmp_path, fake_claude):
+    """End-to-end through the public extract_files_direct entrypoint — backend dispatch
+    must route to `_call_claude_cli` without requiring an ANTHROPIC_API_KEY."""
+    f = tmp_path / "foo.md"
+    f.write_text("# Foo module\n\nThe greet() helper formats a name.\n")
+    result = llm.extract_files_direct(
+        files=[f], backend="claude-cli", root=tmp_path,
+    )
+    assert fake_claude.called
+    assert len(result["nodes"]) == 2
+
+
+def test_claude_cli_backend_registered_with_zero_cost():
+    """Pricing must be zero for cost estimation — calls bill against the user's plan,
+    not an API key, so the per-call cost is zero from graphify's perspective."""
+    assert "claude-cli" in llm.BACKENDS
+    pricing = llm.BACKENDS["claude-cli"]["pricing"]
+    assert pricing["input"] == 0.0
+    assert pricing["output"] == 0.0
+    assert llm.estimate_cost("claude-cli", 1_000_000, 1_000_000) == 0.0


### PR DESCRIPTION
Closes #855.

## Summary

Adds a `claude-cli` backend that shells out to the locally-installed `claude` CLI (Claude Code) via `claude -p --output-format json` instead of calling the Anthropic API directly. Lets Pro/Max subscribers run graphify's semantic pass against their plan instead of provisioning a separate `ANTHROPIC_API_KEY`.

Verified end-to-end on a real codebase: full semantic extract (167k in / 8k out tokens, Opus 4.7 1M context), billed against the user's Max plan, $0 marginal cost.

## Changes

- `graphify/llm.py`:
  - New `BACKENDS["claude-cli"]` entry — `env_key: None`, zero pricing (calls bill against the subscription, not API credit, so estimator should treat this as $0).
  - New `_call_claude_cli(user_message, max_tokens)`:
    - Verifies `shutil.which("claude")` finds the CLI.
    - Subprocess-calls `claude -p --output-format json --append-system-prompt <_EXTRACTION_SYSTEM>` with the user message piped on stdin.
    - Parses the JSON envelope (`result` → model output; `usage` → token counts; `stop_reason` → `finish_reason`; `modelUsage` → model id).
    - Reports total input tokens as `usage.input_tokens + cache_read_input_tokens + cache_creation_input_tokens` so accounting reflects what the model actually processed (the CLI's default system prompt is cached aggressively, so subsequent calls within a session see high cache_read counts).
  - New dispatch arm in `extract_files_direct` plus the lower `_call_llm` helper used by the dedup tiebreaker.
  - New env-key skip for `claude-cli` (mirrors the existing `bedrock` skip in the validation).

- `graphify/__main__.py`:
  - New env-key carve-out in the extract command's backend validation: when `backend == "claude-cli"`, check `shutil.which("claude")` instead of an env var. Same shape as the existing ollama local-loopback carve-out, with a helpful error message if the CLI isn't installed.

- `tests/test_claude_cli_backend.py`:
  - 7 tests, all mocking `subprocess.run` + `shutil.which` so the suite runs on CI without the `claude` binary or network.
  - Coverage: success path (parsed result + usage sums + model id), `stop_reason == "max_tokens"` → `finish_reason == "length"`, missing CLI raises, non-zero exit raises, unparseable JSON envelope raises, end-to-end through `extract_files_direct`, and pricing-is-zero contract.

## Why not `--bare` mode?

The CLI's `--bare` flag strips the default Claude Code system prompt but requires `ANTHROPIC_API_KEY` to authenticate — defeating the purpose. So this backend uses `--append-system-prompt` instead. The default Claude Code prompt gets appended to `_EXTRACTION_SYSTEM`, but the extraction prompt is strict enough that Claude produces valid JSON anyway. Empirically verified: ran the full graphify extract pipeline through this backend on a 1,083-node graph and got valid extraction output.

One side effect: `usage.input_tokens` for the first call in a session is large (the CLI's system prompt is part of the model input). Subsequent calls hit `cache_read_input_tokens` for that prefix and the fresh-input count drops to just the user message. This is normal Anthropic prompt caching behavior; the test fixture uses a realistic envelope showing this pattern.

## Test plan

- [x] Seven new tests pass locally.
- [x] Full suite: 742 passed, same 11 baseline failures (SQL needs optional `tree-sitter-sql`; one Fortran preprocessed test; two Ollama env-var tests) — zero new failures.
- [x] Manual end-to-end: `graphify extract . --backend claude-cli` on a real 336-code-file / 32-doc corpus completed in a single chunk, produced 1,083 graph nodes and 2,140 edges, $0 marginal cost on the user's Max plan.

## Notes for the reviewer

- I considered adding a `detect_backend()` arm that auto-selects `claude-cli` when the binary is present and no API keys are set. Skipped for this PR to keep behavior change minimal — `--backend claude-cli` must be explicit. Happy to add auto-detection in a follow-up if you'd prefer.
- The pricing dict is `{"input": 0.0, "output": 0.0}` because cost is plan-based, not per-token. If you'd rather track plan token *usage* (without dollarizing it) the estimator could grow a `plan_tokens` field — also a follow-up.
