### PR TITLE
docs(skill): clarify that no provider API key is read for semantic extraction

### DIFF
--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -207,6 +207,8 @@ This step has two parts: **structural extraction** (deterministic, free) and **s
 
 Print it once, then continue. If `GEMINI_API_KEY` or `GOOGLE_API_KEY` IS set, use `graphify.llm.extract_corpus_parallel(files, backend="gemini")` for semantic extraction instead of dispatching Claude subagents. The default Gemini model is `gemini-3-flash-preview`; set `GRAPHIFY_GEMINI_MODEL` or pass `--model` in headless CLI flows to override it.
 
+> **No other API keys are read.** If `GEMINI_API_KEY`/`GOOGLE_API_KEY` are unset, fall straight through to Claude Code subagent dispatch (Part B below) — the host session itself is the LLM. graphify does **not** read `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or any other provider key from the environment. If a host agent prompts the user for `ANTHROPIC_API_KEY` to run extraction, that prompt is a misread of this skill — ignore it and dispatch subagents as written.
+
 **Run Part A (AST) and Part B (semantic) in parallel. Dispatch all semantic subagents AND start AST extraction in the same message. Both can run simultaneously since they operate on different file types. Merge results in Part C as before.**
 
 Note: Parallelizing AST + semantic saves 5-15s on large corpora. AST is deterministic and fast; start it while subagents are processing docs/papers.


### PR DESCRIPTION
## Summary

- Adds one explicit callout under Step 3 that graphify never reads `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or any non-Gemini provider key from the environment.
- Names `ANTHROPIC_API_KEY` specifically because that is the misread we hit in the wild — Claude Code sessions, on seeing the existing "Tip: set `GEMINI_API_KEY`..." line, generalize and prompt the user for `ANTHROPIC_API_KEY`, then halt the skill when none is present.
- Pure docs. No behavior change. Existing Gemini-backend tip and default subagent dispatch are untouched.

## Why

Hit by a teammate today on a clean install. Their Claude Code session saw "semantic extraction (LLM, costs tokens)" plus the Gemini tip, decided it needed *some* key, checked the env for the most obvious one (`ANTHROPIC_API_KEY`), and prompted the user. The skill actually wants to fall through to subagent dispatch in that case — but the wording doesn't make the negative-space explicit, so the host agent invented a requirement.

## Test plan

- [x] Render the skill locally and re-read Step 3 with fresh eyes; the new line resolves the ambiguity.
- [x] No code paths touched, so no functional tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)