### PR TITLE
build: add dev deps for Nuitka onefile binary builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,12 @@ graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-aider.md",
 
 [tool.bandit]
 skips = ["B404"]
+
+[dependency-groups]
+dev = [
+    "build>=1.5.0",
+    "nuitka>=4.1",
+    "patchelf>=0.17.2.4 ; sys_platform != 'win32'",
+    "setuptools>=82.0.1",
+    "wheel>=0.47.0",
+]


### PR DESCRIPTION
## Summary
Adds dev dependencies needed to compile a self-contained `graphify` binary via Nuitka onefile mode. No changes to runtime deps or the existing wheel-build path.

## How to build
```sh
uv sync --group dev
uv run python -m nuitka --project --mode=onefile \
    --output-dir=build --output-filename=graphify \
    --assume-yes-for-downloads
```
Produces `build/graphify` (~60 MB single-file binary, Linux x86_64 host tested). Bundles the package's skill `.md` files automatically via `[tool.setuptools.package-data]`.

## Why these deps
| dep | reason |
|---|---|
| `nuitka>=4.1` | the compiler |
| `build`, `wheel`, `setuptools` | Nuitka's `--project` flow spawns `python -m build` to extract entry points / package-data from `[project]` + `[tool.setuptools.package-data]` |
| `patchelf` (macOS/Linux-only) | required by Nuitka for standalone/onefile ELF linking |

## Why nothing was added to `[tool.nuitka]`
In `--project` mode, Nuitka's wheel-config dumper (`nuitka/distutils/DistutilsCommands.py:_dumpBuildConfiguration`) only synthesizes options from setuptools distribution metadata — it never reads `[tool.nuitka]`. So `output-dir`, `output-filename`, `assume-yes-for-downloads` etc. must be passed on the CLI. Adding a `[tool.nuitka]` block would have been misleading dead config.

## Scope / deferred
- **No CI workflow / release matrix** — host platform only for now.
- **No PyPI publishing of the binary**. The pure-Python wheel produced by `uv build` (still `setuptools.build_meta`) is unchanged.
- **Optional extras not bundled** (mcp, pdf, video, llm backends, …). To get those, users still install via `uv tool install graphifyy[all]`.

A follow-up PR can layer on a release workflow that uploads platform-tagged wheels bundling the binary (ruff/uv model) for PyPI distribution.

## Related
- #886 — commit `uv.lock` (independent prerequisite for reproducible builds).

## Test plan
- [x] `uv sync --group dev` succeeds on Linux x86_64.
- [x] Build command above produces `build/graphify`.
- [x] `./build/graphify --help` prints the CLI usage.
- [x] `./build/graphify install` copies the skill files (smoke test on a clean machine).