### PR TITLE
Reduce headline-output noise in god_nodes and surprising_connections

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -65,17 +65,43 @@ def _is_file_node(G: nx.Graph, node_id: str) -> bool:
     return False
 
 
+# JSON key noise: the JSON extractor emits one node per key, so common
+# keys (start/end/name/properties/...) that recur across sibling records
+# in one file accumulate positional degree rather than architectural
+# meaning. Filter them out of god_nodes. Set is intentionally narrow.
+_JSON_NOISE_LABELS = frozenset({
+    "start", "end", "name", "id", "type", "properties", "value", "key",
+    "data", "items", "title", "description", "version",
+})
+
+
+def _is_json_key_node(G: nx.Graph, node_id: str) -> bool:
+    """True if this node is a common JSON key whose degree is positional noise."""
+    attrs = G.nodes[node_id]
+    src = (attrs.get("source_file") or "").lower()
+    if not src.endswith(".json"):
+        return False
+    label = (attrs.get("label") or "").strip().lower()
+    return label in _JSON_NOISE_LABELS
+
+
 def god_nodes(G: nx.Graph, top_n: int = 10) -> list[dict]:
     """Return the top_n most-connected real entities - the core abstractions.
 
     File-level hub nodes are excluded: they accumulate import/contains edges
     mechanically and don't represent meaningful architectural abstractions.
+
+    Common JSON keys (start, end, name, id, type, ...) extracted from .json
+    files are also excluded: their degree comes from being referenced by every
+    sibling record in the same file, not from being architecturally central.
     """
     degree = dict(G.degree())
     sorted_nodes = sorted(degree.items(), key=lambda x: x[1], reverse=True)
     result = []
     for node_id, deg in sorted_nodes:
         if _is_file_node(G, node_id) or _is_concept_node(G, node_id):
+            continue
+        if _is_json_key_node(G, node_id):
             continue
         result.append({
             "id": node_id,
@@ -182,10 +208,23 @@ def _surprise_score(
     # cross-dir + cross-community and dominate "Surprising Connections".
     # Excludes `semantically_similar_to` (LLM-emitted, explicitly cross-language
     # insight) and all AMBIGUOUS/EXTRACTED edges (not from the resolver path).
+    #
+    # Same logic applies to code <-> doc INFERRED calls/uses: a README that
+    # mentions a symbol's name produces an INFERRED `calls` or `uses` edge from
+    # the README's prose to the code symbol, which is documentation cross-
+    # reference, not a structural surprise. _cross_language() misses these
+    # because .md isn't in _LANG_FAMILY. Treat them the same way.
+    cat_u = _file_category(u_source)
+    cat_v = _file_category(v_source)
+    _code_doc_inferred = (
+        conf == "INFERRED"
+        and relation in ("calls", "uses")
+        and {cat_u, cat_v} == {"code", "doc"}
+    )
     _suppress_structural = (
         conf == "INFERRED"
         and relation in ("calls", "uses")
-        and _cross_language(u_source, v_source)
+        and (_cross_language(u_source, v_source) or _code_doc_inferred)
     )
     if _suppress_structural:
         conf_bonus = 0
@@ -194,10 +233,9 @@ def _surprise_score(
     if conf in ("AMBIGUOUS", "INFERRED"):
         reasons.append(f"{conf.lower()} connection - not explicitly stated in source")
 
-    # 2. Cross file-type bonus - code↔paper or code↔image is non-obvious
-    cat_u = _file_category(u_source)
-    cat_v = _file_category(v_source)
-    if cat_u != cat_v:
+    # 2. Cross file-type bonus - code↔paper or code↔image is non-obvious.
+    # (cat_u / cat_v already computed above for _code_doc_inferred check.)
+    if cat_u != cat_v and not _suppress_structural:
         score += 2
         reasons.append(f"crosses file types ({cat_u} ↔ {cat_v})")
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -215,6 +215,260 @@ def test_cross_language_extracted_calls_not_suppressed():
     assert score >= 1
 
 
+def _make_code_doc_graph():
+    """Helper: Go code + Markdown README referencing it (real artella-backend pattern)."""
+    G = nx.Graph()
+    G.add_node("go_proc", label="VideoProcessor",
+               source_file="libs/transcoder/worker.go", file_type="code")
+    G.add_node("md_ref", label="NewVideoProcessor",
+               source_file="services/artella-videosplitter/Readme.md", file_type="document")
+    G.add_node("go_a", label="ServiceA",
+               source_file="libs/a.go", file_type="code")
+    G.add_node("go_b", label="ServiceB",
+               source_file="libs/b.go", file_type="code")
+    return G
+
+
+def test_code_doc_inferred_calls_suppressed():
+    """A README mentioning a code symbol via INFERRED `calls` edge is a doc
+    cross-reference, not a structural surprise — should be suppressed like
+    cross-language INFERRED calls were in d14e8a7. This is the artella-backend
+    pattern: libs/transcoder/worker.go -> services/.../Readme.md."""
+    G = _make_code_doc_graph()
+    G.add_edge("go_proc", "md_ref", relation="calls", confidence="INFERRED",
+               weight=0.8, source_file="libs/transcoder/worker.go")
+    G.add_edge("go_a", "go_b", relation="calls", confidence="EXTRACTED",
+               weight=1.0, source_file="libs/a.go")
+    nc = {"go_proc": 0, "md_ref": 1, "go_a": 0, "go_b": 0}
+    score_cross, _ = _surprise_score(G, "go_proc", "md_ref",
+                                      G.edges["go_proc", "md_ref"], nc,
+                                      "libs/transcoder/worker.go",
+                                      "services/artella-videosplitter/Readme.md")
+    score_same, _ = _surprise_score(G, "go_a", "go_b",
+                                     G.edges["go_a", "go_b"], nc,
+                                     "libs/a.go", "libs/b.go")
+    assert score_cross <= score_same, (
+        f"code<->doc INFERRED calls should be suppressed, got cross={score_cross}, same={score_same}"
+    )
+
+
+def test_code_doc_inferred_uses_suppressed():
+    """Same as above for `uses` relation — covers the resolver-pollution case
+    where a README's prose creates an INFERRED `uses` edge against a code symbol."""
+    G = _make_code_doc_graph()
+    G.add_edge("go_proc", "md_ref", relation="uses", confidence="INFERRED",
+               weight=0.8, source_file="libs/transcoder/worker.go")
+    G.add_edge("go_a", "go_b", relation="calls", confidence="EXTRACTED",
+               weight=1.0, source_file="libs/a.go")
+    nc = {"go_proc": 0, "md_ref": 1, "go_a": 0, "go_b": 0}
+    score_cross, _ = _surprise_score(G, "go_proc", "md_ref",
+                                      G.edges["go_proc", "md_ref"], nc,
+                                      "libs/transcoder/worker.go",
+                                      "services/artella-videosplitter/Readme.md")
+    score_same, _ = _surprise_score(G, "go_a", "go_b",
+                                     G.edges["go_a", "go_b"], nc,
+                                     "libs/a.go", "libs/b.go")
+    assert score_cross <= score_same
+
+
+def test_code_doc_extracted_not_suppressed():
+    """EXTRACTED code<->doc edges are explicit references (e.g. doc literally
+    contains a code-pattern match) — these are real structural facts and must
+    not be suppressed."""
+    G = _make_code_doc_graph()
+    G.add_edge("go_proc", "md_ref", relation="references",
+               confidence="EXTRACTED", weight=1.0,
+               source_file="services/artella-videosplitter/Readme.md")
+    nc = {"go_proc": 0, "md_ref": 1}
+    score, _ = _surprise_score(G, "go_proc", "md_ref",
+                                G.edges["go_proc", "md_ref"], nc,
+                                "libs/transcoder/worker.go",
+                                "services/artella-videosplitter/Readme.md")
+    # Should still get conf_bonus (1) plus cross-file-type bonus (2) plus
+    # other applicable bonuses — at minimum >= 3.
+    assert score >= 3, f"EXTRACTED code<->doc must keep its bonuses, got {score}"
+
+
+def test_code_doc_inferred_semantically_similar_not_suppressed():
+    """The `semantically_similar_to` relation is preserved by d14e8a7 doctrine —
+    a code↔doc INFERRED similarity edge represents an explicit LLM insight
+    (the doc and the code share a concept) and must NOT be suppressed even
+    though it crosses categories. Protects the relation gate."""
+    G = _make_code_doc_graph()
+    G.add_edge("go_proc", "md_ref", relation="semantically_similar_to",
+               confidence="INFERRED", weight=0.8,
+               source_file="libs/transcoder/worker.go")
+    G.add_edge("go_a", "go_b", relation="calls", confidence="EXTRACTED",
+               weight=1.0, source_file="libs/a.go")
+    nc = {"go_proc": 0, "md_ref": 1, "go_a": 0, "go_b": 0}
+    score_sem, _ = _surprise_score(G, "go_proc", "md_ref",
+                                    G.edges["go_proc", "md_ref"], nc,
+                                    "libs/transcoder/worker.go",
+                                    "services/artella-videosplitter/Readme.md")
+    score_same, _ = _surprise_score(G, "go_a", "go_b",
+                                     G.edges["go_a", "go_b"], nc,
+                                     "libs/a.go", "libs/b.go")
+    assert score_sem > score_same, (
+        f"semantically_similar_to across code<->doc must NOT be suppressed, "
+        f"got sem={score_sem}, same={score_same}"
+    )
+
+
+def test_code_unknown_extension_inferred_calls_suppressed():
+    """Document the `_file_category` fallback: any unknown file extension is
+    classified as "doc" (the function returns "doc" when not code/paper/image).
+    This means INFERRED calls/uses between code and an unknown-extension file
+    are also suppressed by the doc-category gate. Intentional — these edges
+    are almost always resolver pollution of the same shape as code↔README."""
+    assert _file_category("notes/random.xyz") == "doc"  # confirms fallback
+    G = nx.Graph()
+    G.add_node("go_a", label="Handler", source_file="libs/a.go", file_type="code")
+    G.add_node("unk", label="Handler", source_file="vendor/unknown.xyz", file_type="document")
+    G.add_node("c", label="C", source_file="libs/c.go", file_type="code")
+    G.add_node("d", label="D", source_file="libs/d.go", file_type="code")
+    G.add_edge("go_a", "unk", relation="calls", confidence="INFERRED",
+               weight=0.8, source_file="libs/a.go")
+    G.add_edge("c", "d", relation="calls", confidence="EXTRACTED",
+               weight=1.0, source_file="libs/c.go")
+    nc = {"go_a": 0, "unk": 1, "c": 0, "d": 0}
+    score_unknown, _ = _surprise_score(G, "go_a", "unk",
+                                        G.edges["go_a", "unk"], nc,
+                                        "libs/a.go", "vendor/unknown.xyz")
+    score_same, _ = _surprise_score(G, "c", "d",
+                                     G.edges["c", "d"], nc,
+                                     "libs/c.go", "libs/d.go")
+    assert score_unknown <= score_same, (
+        f"code<->unknown-extension INFERRED calls fall under the doc-category "
+        f"suppression by design, got unknown={score_unknown}, same={score_same}"
+    )
+
+
+def test_code_paper_inferred_calls_not_suppressed():
+    """code<->paper INFERRED edges (.go <-> .pdf) are NOT the README-mention case
+    and remain genuinely surprising — must not be caught by the code<->doc rule.
+    Verifies the suppression is narrowly scoped to file_category=='doc'."""
+    G = nx.Graph()
+    G.add_node("go_attn", label="Attention", source_file="libs/ml/attention.go", file_type="code")
+    G.add_node("pdf_attn", label="Attention", source_file="papers/attention-is-all-you-need.pdf", file_type="paper")
+    G.add_node("go_a", label="A", source_file="libs/a.go", file_type="code")
+    G.add_node("go_b", label="B", source_file="libs/b.go", file_type="code")
+    G.add_edge("go_attn", "pdf_attn", relation="calls", confidence="INFERRED",
+               weight=0.8, source_file="libs/ml/attention.go")
+    G.add_edge("go_a", "go_b", relation="calls", confidence="EXTRACTED",
+               weight=1.0, source_file="libs/a.go")
+    nc = {"go_attn": 0, "pdf_attn": 1, "go_a": 0, "go_b": 0}
+    score_paper, _ = _surprise_score(G, "go_attn", "pdf_attn",
+                                      G.edges["go_attn", "pdf_attn"], nc,
+                                      "libs/ml/attention.go",
+                                      "papers/attention-is-all-you-need.pdf")
+    score_same, _ = _surprise_score(G, "go_a", "go_b",
+                                     G.edges["go_a", "go_b"], nc,
+                                     "libs/a.go", "libs/b.go")
+    assert score_paper > score_same, (
+        f"code<->paper INFERRED is a real cross-format surprise, "
+        f"got paper={score_paper}, same={score_same}"
+    )
+
+
+def test_god_nodes_filters_json_noise_keys():
+    """Common JSON keys (start/end/name/properties/id/...) appearing in .json
+    sources should be excluded from god_nodes — their degree is positional,
+    not architectural. Real Go method abstractions must outrank them even
+    when the JSON-key degree is higher."""
+    G = nx.Graph()
+    # Single legitimate code abstraction with modest degree.
+    G.add_node("db_conn", label="DB()",
+               source_file="database/connection.go", file_type="code")
+    for i in range(20):
+        n = f"caller_{i}"
+        G.add_node(n, label=f"Caller{i}", source_file=f"libs/caller_{i}.go",
+                   file_type="code")
+        G.add_edge(n, "db_conn", relation="calls", confidence="EXTRACTED")
+    # Massive-degree JSON-key noise that should be filtered.
+    G.add_node("dates_start", label="start",
+               source_file="testhelpers/dates.json", file_type="code")
+    for i in range(50):
+        n = f"term_{i}"
+        G.add_node(n, label=f"T{i}", source_file="testhelpers/dates.json",
+                   file_type="code")
+        G.add_edge(n, "dates_start", relation="references",
+                   confidence="EXTRACTED")
+    gods = god_nodes(G, top_n=3)
+    labels = [g["label"] for g in gods]
+    assert "start" not in labels, (
+        f"common JSON-key 'start' should be filtered out, got {labels}"
+    )
+    assert "DB()" in labels, (
+        f"real code abstraction 'DB()' must surface, got {labels}"
+    )
+
+
+def test_god_nodes_keeps_noise_label_when_source_is_code():
+    """`start` is only filtered when its source is .json — a real function or
+    variable named `start` defined in a .go/.ts file must NOT be filtered."""
+    G = nx.Graph()
+    G.add_node("go_start", label="start",
+               source_file="libs/scheduler/runner.go", file_type="code")
+    G.add_node("low_deg", label="OtherThing",
+               source_file="libs/other.go", file_type="code")
+    for i in range(5):
+        n = f"caller_{i}"
+        G.add_node(n, label=f"C{i}", source_file=f"libs/c_{i}.go",
+                   file_type="code")
+        G.add_edge(n, "go_start", relation="calls", confidence="EXTRACTED")
+    G.add_edge("low_deg", "caller_0", relation="calls", confidence="EXTRACTED")
+    gods = god_nodes(G, top_n=2)
+    labels = [g["label"] for g in gods]
+    assert "start" in labels, (
+        f"`start` defined in Go source must NOT be filtered, got {labels}"
+    )
+
+
+def test_god_nodes_keeps_real_label_in_json_source():
+    """A JSON-sourced node with a non-common label (e.g. domain entity name)
+    should NOT be filtered — only the small set of generic JSON keys are
+    excluded."""
+    G = nx.Graph()
+    G.add_node("config_node", label="ProductionEsConfig",
+               source_file="config/elasticsearch.json", file_type="code")
+    for i in range(10):
+        n = f"ref_{i}"
+        G.add_node(n, label=f"R{i}", source_file=f"libs/r_{i}.go",
+                   file_type="code")
+        G.add_edge(n, "config_node", relation="references",
+                   confidence="EXTRACTED")
+    gods = god_nodes(G, top_n=1)
+    labels = [g["label"] for g in gods]
+    assert "ProductionEsConfig" in labels, (
+        f"domain entity in JSON source must NOT be filtered, got {labels}"
+    )
+
+
+def test_god_nodes_filter_is_case_insensitive():
+    """JSON-key filter must match regardless of label casing — `Start`, `START`,
+    and `start` should all be treated as the same generic key."""
+    G = nx.Graph()
+    G.add_node("real", label="RealAbstraction",
+               source_file="libs/real.go", file_type="code")
+    G.add_edge("real", "real", relation="self")  # nominal edge so it exists
+    for variant in ("Start", "START", "Name", "ID"):
+        nid = f"json_{variant.lower()}"
+        G.add_node(nid, label=variant,
+                   source_file="testhelpers/data.json", file_type="code")
+        # Give each high degree to make them outrank `real` if not filtered.
+        for i in range(15):
+            target = f"{nid}_ref_{i}"
+            G.add_node(target, label=f"X{i}",
+                       source_file="testhelpers/data.json", file_type="code")
+            G.add_edge(target, nid, relation="references")
+    gods = god_nodes(G, top_n=5)
+    labels = [g["label"] for g in gods]
+    for variant in ("Start", "START", "Name", "ID"):
+        assert variant not in labels, (
+            f"`{variant}` (case variant of JSON-noise key) must be filtered, got {labels}"
+        )
+
+
 def test_surprising_connections_have_why_field():
     G = make_graph()
     communities = cluster(G)


### PR DESCRIPTION
Two ranking-policy changes after running graphify on a Go monorepo with both READMEs and JSON fixtures. Both reduce noise in the headline-output sections; both are conservative.

### 1. Extend cross-language INFERRED suppression to code ↔ doc

d14e8a7 added a suppression for INFERRED `calls`/`uses` edges between source files in different language families. `_cross_language()` consults `_LANG_FAMILY`, which only contains programming-language extensions, so the gate doesn't fire when one endpoint is a `.md` / `.txt` / `.rst` doc.

On a Go monorepo with READMEs, the top "Surprising Connections" came out like:

```
HandleVideoProcessing() --[calls]--> NewVideoProcessor    [INFERRED]
libs/transcoder/worker.go -> services/.../Readme.md
```

The LLM saw the symbol name in the README's prose and emitted a `calls` edge. Cross-dir (+2) and cross-community (+1) bonuses promoted these into the top-5, crowding out real structural surprises. Same failure shape as the rsl-siege-manager Python ↔ TypeScript case d14e8a7 addressed.

Apply the same `_suppress_structural` treatment when `file_category` is `doc` on at least one side. Preserves:

- `semantically_similar_to` (explicit LLM insight, per d14e8a7 doctrine)
- `EXTRACTED` edges (real references the doc literally contains)
- code ↔ paper (`.pdf` is `paper` category, a genuine cross-format signal)

`_file_category` falls back to `"doc"` for unknown extensions, so this also catches code ↔ unknown-extension INFERRED calls/uses. That matches the resolver-pollution profile and is covered by a test documenting the behavior.

### 2. Filter common JSON keys from god_nodes

The JSON extractor (#866) emits one node per JSON key, so common keys recurring across sibling records (`start`, `end`, `name`, `id`, `type`, `properties`, `value`, `key`, `data`, `items`, `title`, `description`, `version`) accumulate positional degree, not architectural meaning.

On the Go corpus, a `testhelpers/dates.json` file containing terms with `start`/`end` timestamps put both labels at degree 95 in god_nodes; `properties` and `name` from other JSON fixtures took two more top-10 slots. Four of the top-10 god_nodes were positional-key noise. After the filter, those slots are taken by real Go method abstractions (`ToLower`, `Process()`, `ZoneString()`, `List()`).

Gate is conjunctive: `source_file` must end in `.json` AND normalized label must be in the noise set. `start()` defined in a Go file still ranks; `ProductionEsConfig` in `elasticsearch.json` still ranks; only the generic-key + json combination is filtered. Case-insensitive on the label.

Set is intentionally narrow (13 labels). Not made configurable to avoid adding a knob for a ranking heuristic.

### Tests

10 new tests in `test_analyze.py`:

- code ↔ doc INFERRED `calls`/`uses` suppressed
- code ↔ doc EXTRACTED preserved (real references stay)
- code ↔ doc INFERRED `semantically_similar_to` preserved (d14e8a7 doctrine)
- code ↔ paper INFERRED `calls` preserved (genuine cross-format)
- code ↔ unknown-extension INFERRED suppressed (documents fallback behavior)
- god_nodes filters massive-degree JSON `start` while keeping real `DB()`
- god_nodes keeps `start` when defined in a `.go` source
- god_nodes keeps domain entity in a JSON source
- JSON-key filter is case-insensitive

Full suite: 821 pass, 11 pre-existing failures unchanged.

### Note on scope

Both changes touch `analyze.py` and address the same "headline output got noisy" failure mode. Happy to split into two PRs if preferred.
