### PR TITLE
fix(analyze): exclude npm dep-block keys from god-node selection

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -68,6 +68,10 @@ def _is_file_node(G: nx.Graph, node_id: str) -> bool:
 _JSON_NOISE_LABELS: frozenset[str] = frozenset({
     "start", "end", "name", "id", "type", "properties",
     "value", "key", "data", "items", "title", "description", "version",
+    # npm package.json dependency-block keys — issue #2
+    # Lowercased to match the .strip().lower() comparison in _is_json_key_node.
+    "dependencies", "devdependencies", "peerdependencies",
+    "optionaldependencies", "bundleddependencies", "bundledependencies",
 })
 
 

--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -68,8 +68,6 @@ def _is_file_node(G: nx.Graph, node_id: str) -> bool:
 _JSON_NOISE_LABELS: frozenset[str] = frozenset({
     "start", "end", "name", "id", "type", "properties",
     "value", "key", "data", "items", "title", "description", "version",
-    # npm package.json dependency-block keys — issue #2
-    # Lowercased to match the .strip().lower() comparison in _is_json_key_node.
     "dependencies", "devdependencies", "peerdependencies",
     "optionaldependencies", "bundleddependencies", "bundledependencies",
 })

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -458,7 +458,7 @@ def test_is_json_key_node_non_json_file():
     assert _is_json_key_node(G, "n1") is False
 
 
-# --- npm dep-block key god-node filtering tests (issue #2) ---
+# --- npm dep-block key god-node filtering tests ---
 
 @pytest.mark.parametrize("dep_key", [
     "dependencies",

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,6 +1,7 @@
 """Tests for analyze.py."""
 import json
 import networkx as nx
+import pytest
 from pathlib import Path
 from graphify.build import build_from_json
 from graphify.cluster import cluster
@@ -455,6 +456,85 @@ def test_is_json_key_node_non_json_file():
     G = nx.Graph()
     G.add_node("n1", label="name", source_file="model.py")
     assert _is_json_key_node(G, "n1") is False
+
+
+# --- npm dep-block key god-node filtering tests (issue #2) ---
+
+@pytest.mark.parametrize("dep_key", [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+    "bundledDependencies",
+])
+def test_god_nodes_excludes_npm_dep_block_keys(dep_key: str) -> None:
+    """npm package.json dep-block keys must be filtered from god_nodes output.
+
+    Constructs a small graph with one node labelled with an npm dep-block key
+    (sourced from a .json file) and one real-domain node that has high degree.
+    Asserts that god_nodes() excludes the dep-block node even when it has the
+    highest degree, while the real-domain node is included.
+
+    Args:
+        dep_key: The npm dependency-block key label to test (parametrized).
+    """
+    G = nx.Graph()
+    # Real-domain node with a realistic source file.
+    G.add_node(
+        "real_node",
+        label="AuthService",
+        source_file="src/auth.py",
+        file_type="code",
+        source_location="L1",
+    )
+    # npm dep-block key node — sourced from a JSON file so _is_json_key_node fires.
+    G.add_node(
+        "dep_node",
+        label=dep_key,
+        source_file="frontend/package.json",
+        file_type="code",
+        source_location="L1",
+    )
+    # Wire up enough edges so dep_node has high degree — it would be a god-node
+    # without the filter.
+    for i in range(20):
+        peer = f"pkg_{i}"
+        G.add_node(
+            peer,
+            label=f"package-{i}",
+            source_file="frontend/package.json",
+            file_type="code",
+            source_location=f"L{i + 2}",
+        )
+        G.add_edge(
+            "dep_node",
+            peer,
+            relation="contains",
+            confidence="EXTRACTED",
+            source_file="frontend/package.json",
+            weight=1.0,
+        )
+    # Give real_node a couple of edges too.
+    G.add_edge(
+        "real_node",
+        "dep_node",
+        relation="imports",
+        confidence="EXTRACTED",
+        source_file="src/auth.py",
+        weight=1.0,
+    )
+
+    result = god_nodes(G, top_n=10)
+    result_ids = [r["id"] for r in result]
+
+    assert "dep_node" not in result_ids, (
+        f"god_nodes() should filter npm dep-block key '{dep_key}' "
+        f"but it appeared in the result: {result}"
+    )
+    assert "real_node" in result_ids, (
+        f"god_nodes() should include real-domain node 'AuthService' "
+        f"but it was absent: {result}"
+    )
 
 
 def test_is_json_key_node_real_label():


### PR DESCRIPTION
Closes #903

## Summary

The JSON extractor (`graphify/extract.py` `extract_json`) emits a node for every JSON object key, including `devDependencies` / `dependencies` / `peerDependencies` / `optionalDependencies` / `bundledDependencies`. On any JS/TS corpus with non-trivial dependency counts, the parent dep-block key accumulates `contains` + `imports` edges to every sibling entry and surfaces as a god-node.

`_JSON_NOISE_LABELS` (`graphify/analyze.py:68`) already filters generic JSON keys (`properties`, `items`, `name`, etc.) from god-node selection. This PR extends it with the npm `package.json` dependency-block keys, lowercased to match the existing `.strip().lower()` comparison in `_is_json_key_node`.

## Live validation — rsl-siege-manager @ `6085fd66`

`.graphifyignore`:
```
backend/tests/
frontend/src/**/__tests__/
frontend/src/test/
bot/tests/
```

### Before (v8 @ `b4c0f01`, no fix) — top-10 god-nodes

```
 1. BoardPage()     - 54 edges
 2. SiegeMember     - 52 edges
 3. postsTab        - 30 edges
 4. cn()            - 30 edges
 5. MembersPage()   - 28 edges
 6. PostsPage()     - 28 edges
 7. devDependencies - 25 edges    ← npm manifest key, noise
 8. BuildingType    - 23 edges
 9. MemberRole      - 22 edges
10. Position        - 22 edges
```

### After (this PR applied)

```
 1. BoardPage()              - 54 edges
 2. SiegeMember              - 52 edges
 3. postsTab                 - 30 edges
 4. cn()                     - 30 edges
 5. MembersPage()            - 28 edges
 6. PostsPage()              - 28 edges
 7. BuildingType             - 23 edges
 8. MemberRole               - 22 edges
 9. Position                 - 22 edges
10. NotificationBatchResponse - 22 edges
```

`devDependencies` filtered; positions 7–10 shift up.

## No-regression checks — bundled corpora

| Corpus | Nodes | Edges | Communities | Top-5 god-nodes |
|---|---|---|---|---|
| `worked/example` | 86 = 86 | 129 = 129 | 7 = 7 | identical |
| `worked/mixed-corpus` | 53 = 53 | 73 = 73 | 6 = 6 | identical |
| `worked/httpx` | 152 = 152 | 357 = 357 | 6 = 6 | identical |

Byte-identical baseline vs with-fix (no `package.json` in any → filter is a deterministic no-op).

## Changes

- `graphify/analyze.py`: +3 lines — 6 lowercased npm dep-block key entries appended to `_JSON_NOISE_LABELS` (both `bundledDependencies` and `bundleDependencies` spellings, matching `_DEP_KEYS` at `extract.py:5959-5962`).
- `tests/test_analyze.py`: +80 lines — `test_god_nodes_excludes_npm_dep_block_keys` parametrized × 5 keys.

## Test Results

```
882 passed, 17 failed (pre-existing on v8: 9 Windows symlink + 8 SQL tree-sitter), 4 skipped
+5 new tests, 0 regressions
```

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_