### PR TITLE
fix(export): accept edges-only graph JSON for wiki export

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2218,6 +2218,8 @@ def main() -> None:
         from graphify.build import build_from_json as _bfj
 
         _raw = json.loads(graph_path.read_text(encoding="utf-8"))
+        if "links" not in _raw and "edges" in _raw:
+            _raw = dict(_raw, links=_raw["edges"])
         try:
             G = _jg.node_link_graph(_raw, edges="links")
         except TypeError:

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -115,6 +115,19 @@ def test_export_wiki_creates_articles(tmp_path):
     assert (wiki / "index.md").exists()
 
 
+def test_export_wiki_accepts_edges_only_graph_json(tmp_path):
+    out = _make_graph(tmp_path)
+    graph_path = out / "graph.json"
+    data = json.loads(graph_path.read_text())
+    data["edges"] = data.pop("links")
+    graph_path.write_text(json.dumps(data))
+
+    r = _run(["export", "wiki"], tmp_path)
+
+    assert r.returncode == 0, r.stderr
+    assert (out / "wiki" / "index.md").exists()
+
+
 # ── graphify export graphml ──────────────────────────────────────────────────
 
 def test_export_graphml_creates_file(tmp_path):


### PR DESCRIPTION
## Summary
- Normalize `edges` to `links` in the shared export loader before calling `node_link_graph(..., edges="links")`.
- Add a regression test that rewrites the CLI export fixture to an `edges`-only graph and verifies `graphify export wiki` succeeds.

## Test Plan
- `uv run --with pytest python -m pytest tests/test_cli_export.py::test_export_wiki_accepts_edges_only_graph_json tests/test_cli_export.py::test_export_wiki_creates_articles -q`
- Applied the patch to a fresh checkout of the current base branch with `git apply --check`, then reran the same focused tests.
