### PR TITLE
fix(opencode): remove invalid general-purpose agent guidance

### DIFF
--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -110,7 +110,7 @@ Omit any category with 0 files from the summary.
 Then act on it:
 - If `total_files` is 0: stop with "No supported files found in [path]."
 - If `skipped_sensitive` is non-empty: mention file count skipped, not the file names.
-- If `total_words` > 2,000,000 OR `total_files` > 200: do not stop for an interactive subfolder choice. Show the warning and choose a bounded extraction plan deterministically: prefer the largest supported subdirectories that fit the budget, or reduce semantic chunk size and continue. Tell the user which policy was applied.
+- If `total_words` > 2,000,000 OR `total_files` > 200: do not stop for an interactive subfolder choice. Show the warning, reduce semantic chunks to 10-12 files each, and continue with all supported files. Tell the user this smaller-chunk policy was applied.
 - Otherwise: proceed directly to Step 2.5 if video files were detected, or Step 3 if not.
 
 ### Step 2.5 - Transcribe video / audio files (only if video files detected)
@@ -312,6 +312,8 @@ Wait for all subagents. For each result:
 - If a subagent failed or returned invalid JSON, print a warning and skip that chunk - do not abort
 
 If more than half the chunks failed or are missing, stop and tell the user to retry OpenCode @agent dispatch with smaller chunks or use the serial fallback, which writes `graphify-out/.graphify_chunk_NN.json` before merge.
+
+Serial fallback: process chunks one at a time in the main OpenCode session. For each chunk, read only that chunk's files, produce the same JSON schema, write it to `graphify-out/.graphify_chunk_NN.json`, then continue with the normal merge step below.
 
 Merge all chunk files into `.graphify_semantic_new.json`. **After each Agent call completes, read the real token counts from the Agent tool result's `usage` field and write them back into the chunk JSON before merging** — the chunk JSON itself always has placeholder zeros. Then run:
 ```bash

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -110,7 +110,7 @@ Omit any category with 0 files from the summary.
 Then act on it:
 - If `total_files` is 0: stop with "No supported files found in [path]."
 - If `skipped_sensitive` is non-empty: mention file count skipped, not the file names.
-- If `total_words` > 2,000,000 OR `total_files` > 200: show the warning and the top 5 subdirectories by file count, then ask which subfolder to run on. Wait for the user's answer before proceeding.
+- If `total_words` > 2,000,000 OR `total_files` > 200: do not stop for an interactive subfolder choice. Show the warning and choose a bounded extraction plan deterministically: prefer the largest supported subdirectories that fit the budget, or reduce semantic chunk size and continue. Tell the user which policy was applied.
 - Otherwise: proceed directly to Step 2.5 if video files were detected, or Step 3 if not.
 
 ### Step 2.5 - Transcribe video / audio files (only if video files detected)
@@ -308,10 +308,10 @@ Output exactly this JSON (no other text):
 Wait for all subagents. For each result:
 - Check that `graphify-out/.graphify_chunk_NN.json` exists on disk — this is the success signal
 - If the file exists and contains valid JSON with `nodes` and `edges`, include it and save to cache
-- If the file is missing, the subagent was likely dispatched as read-only (Explore type) — print a warning: "chunk N missing from disk — subagent may have been read-only. Re-run with general-purpose agent." Do not silently skip.
+- If the file is missing, the OpenCode @agent dispatch did not produce a writable chunk output — print a warning: "chunk N missing from disk — OpenCode @agent dispatch did not produce a writable chunk output. Retry @agent dispatch, reduce chunk size, or use the serial fallback." Do not silently skip.
 - If a subagent failed or returned invalid JSON, print a warning and skip that chunk - do not abort
 
-If more than half the chunks failed or are missing, stop and tell the user to re-run and ensure `subagent_type="general-purpose"` is used.
+If more than half the chunks failed or are missing, stop and tell the user to retry OpenCode @agent dispatch with smaller chunks or use the serial fallback, which writes `graphify-out/.graphify_chunk_NN.json` before merge.
 
 Merge all chunk files into `.graphify_semantic_new.json`. **After each Agent call completes, read the real token counts from the Agent tool result's `usage` field and write them back into the chunk JSON before merging** — the chunk JSON itself always has placeholder zeros. Then run:
 ```bash

--- a/graphify/skill-opencode.md
+++ b/graphify/skill-opencode.md
@@ -201,7 +201,7 @@ else:
 
 Before dispatching subagents, print a timing estimate:
 - Load `total_words` and file counts from `graphify-out/.graphify_detect.json`
-- Estimate agents needed: `ceil(uncached_non_code_files / 22)` (chunk size is 20-25)
+- Estimate agents needed: `ceil(uncached_non_code_files / 22)` by default, or `ceil(uncached_non_code_files / 11)` if the smaller-chunk large-corpus policy was applied
 - Estimate time: ~45s per agent batch (they run in parallel, so total ≈ 45s × ceil(agents/parallel_limit))
 - Print: "Semantic extraction: ~N files → X agents, estimated ~Ys"
 
@@ -231,7 +231,7 @@ Only dispatch subagents for files listed in `graphify-out/.graphify_uncached.txt
 
 **Step B1 - Split into chunks**
 
-Load files from `graphify-out/.graphify_uncached.txt`. Split into chunks of 20-25 files each. Each image gets its own chunk (vision needs separate context). When splitting, group files from the same directory together so related artifacts land in the same chunk and cross-file relationships are more likely to be extracted.
+Load files from `graphify-out/.graphify_uncached.txt`. Split into chunks of 20-25 files each by default, or 10-12 files each if the smaller-chunk large-corpus policy was applied. Each image gets its own chunk (vision needs separate context). When splitting, group files from the same directory together so related artifacts land in the same chunk and cross-file relationships are more likely to be extracted.
 
 **Step B2 - Dispatch ALL subagents in a single message (OpenCode)**
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -119,6 +119,8 @@ def test_opencode_skill_uses_opencode_agent_guidance():
     assert 'subagent_type="general-purpose"' not in skill
     assert "@agent" in skill
     assert "serial fallback" in skill
+    assert "reduce semantic chunks to 10-12 files each" in skill
+    assert "process chunks one at a time" in skill
     assert "Wait for the user's answer before proceeding" not in skill
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -111,6 +111,17 @@ def test_opencode_skill_contains_mention():
     assert "@mention" in skill
 
 
+def test_opencode_skill_uses_opencode_agent_guidance():
+    """OpenCode skill must not reference Codex/Claude agent type names."""
+    import graphify
+    skill = (Path(graphify.__file__).parent / "skill-opencode.md").read_text()
+    assert "general-purpose" not in skill
+    assert 'subagent_type="general-purpose"' not in skill
+    assert "@agent" in skill
+    assert "serial fallback" in skill
+    assert "Wait for the user's answer before proceeding" not in skill
+
+
 def test_claw_skill_is_sequential():
     """OpenClaw skill file must describe sequential extraction."""
     import graphify

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -120,6 +120,7 @@ def test_opencode_skill_uses_opencode_agent_guidance():
     assert "@agent" in skill
     assert "serial fallback" in skill
     assert "reduce semantic chunks to 10-12 files each" in skill
+    assert "10-12 files each if the smaller-chunk large-corpus policy was applied" in skill
     assert "process chunks one at a time" in skill
     assert "Wait for the user's answer before proceeding" not in skill
 


### PR DESCRIPTION
## Summary
- Remove OpenCode guidance that referenced the unsupported `general-purpose` agent type.
- Replace missing chunk recovery with OpenCode @agent retry, smaller chunk, or serial fallback guidance.
- Avoid stopping large OpenCode runs for an interactive subfolder prompt.

## Tests
- `python -m pytest tests/test_install.py tests/test_install_strings.py`

## Notes
Closes #825
