### PR TITLE
docs: clarify code-only semantic extraction

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -7,6 +7,8 @@ graphify processes your files in three passes:
 **Pass 1 — Code structure (free, no API calls)**
 Tree-sitter parses your code files and extracts classes, functions, imports, call graphs, and inline comments. This runs locally with no LLM involved. 25 languages supported. SQL files get special treatment: tables, views, foreign keys, and JOIN relationships are extracted deterministically.
 
+Code files are not sent to the LLM semantic extractor in the normal pipeline. If a corpus contains only code files, Pass 3 is skipped entirely; semantic extraction is reserved for docs, papers, images, and transcripts.
+
 **Pass 2 — Video and audio (local, no API calls)**
 Video and audio files are transcribed with faster-whisper. To focus the transcript on your domain, the transcription prompt is seeded with your top god nodes (the most-connected concepts in your code graph so far). Transcripts are cached — re-runs skip already-processed files.
 

--- a/tests/test_install_strings.py
+++ b/tests/test_install_strings.py
@@ -10,6 +10,7 @@ or partial change is caught by CI.
 """
 from __future__ import annotations
 import json
+from pathlib import Path
 
 from graphify.__main__ import (
     _SETTINGS_HOOK,
@@ -115,3 +116,10 @@ def test_report_is_still_referenced_as_fallback():
         f"The fix should demote the report, not delete the reference — users need to know "
         f"it's available for broad-architecture queries."
     )
+
+
+def test_how_it_works_clarifies_code_only_semantic_extraction():
+    doc = Path("docs/how-it-works.md").read_text(encoding="utf-8")
+    assert "Code files are not sent to the LLM semantic extractor" in doc
+    assert "code files, Pass 3 is skipped entirely" in doc
+    assert "docs, papers, images, and transcripts" in doc


### PR DESCRIPTION
## Summary
- Clarify that code files are handled by the local Tree-sitter/deterministic extraction path.
- State that code-only corpora skip the semantic LLM pass.
- Keep semantic extraction scoped to docs, papers, images, and transcripts.

## Tests
- `python -m pytest tests/test_install_strings.py`

## Notes
Closes #836
