### PR TITLE
fix(extract): filter language built-in globals from call edges (#726)

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -14,6 +14,36 @@ from .cache import load_cached, save_cached
 _RECURSION_LIMIT = 10_000
 
 
+
+# Language built-in globals that AST may classify as call targets when used as
+# constructors or coercion functions (e.g. String(x), Number(x), Boolean(x)).
+# Without this filter they become god-nodes accumulating spurious edges from
+# every call site across the codebase, polluting "God Nodes", "Surprising
+# Connections", and "Suggested Questions" sections of the report.
+#
+# Filter applied at BOTH same-file resolution and cross-file resolution.
+# See issue #726 and related discussion.
+_LANGUAGE_BUILTIN_GLOBALS = frozenset({
+    # JavaScript / TypeScript ECMAScript built-ins
+    "String", "Number", "Boolean", "Object", "Array", "Symbol", "BigInt",
+    "Date", "RegExp", "Error", "TypeError", "RangeError", "SyntaxError",
+    "ReferenceError", "EvalError", "URIError",
+    "Promise", "Map", "Set", "WeakMap", "WeakSet", "JSON", "Math",
+    "Reflect", "Proxy", "Intl",
+    "parseInt", "parseFloat", "isNaN", "isFinite",
+    "encodeURIComponent", "decodeURIComponent", "encodeURI", "decodeURI",
+    # Browser / Node common globals
+    "fetch", "URL", "URLSearchParams", "FormData", "Blob", "File",
+    "Headers", "Request", "Response", "AbortController", "AbortSignal",
+    "TextEncoder", "TextDecoder", "console",
+    # Python built-in callables that get confused with user code
+    "str", "int", "float", "bool", "list", "dict", "set", "tuple", "bytes",
+    "len", "range", "enumerate", "zip", "map", "filter", "sum", "min", "max",
+    "print", "open", "isinstance", "type", "super", "sorted", "reversed",
+    "any", "all", "abs", "round", "next", "iter", "hash", "id", "repr",
+    "callable", "getattr", "setattr", "hasattr", "delattr", "vars", "dir",
+})
+
 def _raise_recursion_limit() -> None:
     if sys.getrecursionlimit() < _RECURSION_LIMIT:
         sys.setrecursionlimit(_RECURSION_LIMIT)
@@ -1721,7 +1751,7 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                         # Try reading the node directly (e.g. Java name field is the callee)
                         callee_name = _read_text(func_node, source)
 
-            if callee_name:
+            if callee_name and callee_name not in _LANGUAGE_BUILTIN_GLOBALS:
                 tgt_nid = label_to_nid.get(callee_name.lower())
                 if tgt_nid and tgt_nid != caller_nid:
                     pair = (caller_nid, tgt_nid)
@@ -3567,7 +3597,7 @@ def extract_go(path: Path) -> dict:
                     is_member_call = receiver_name not in go_imported_pkgs
                     if field:
                         callee_name = _read_text(field, source)
-            if callee_name:
+            if callee_name and callee_name not in _LANGUAGE_BUILTIN_GLOBALS:
                 tgt_nid = label_to_nid.get(callee_name.lower())
                 if tgt_nid and tgt_nid != caller_nid:
                     pair = (caller_nid, tgt_nid)
@@ -3768,7 +3798,7 @@ def extract_rust(path: Path) -> dict:
                     name = func_node.child_by_field_name("name")
                     if name:
                         callee_name = _read_text(name, source)
-            if callee_name:
+            if callee_name and callee_name not in _LANGUAGE_BUILTIN_GLOBALS:
                 tgt_nid = label_to_nid.get(callee_name.lower())
                 if tgt_nid and tgt_nid != caller_nid:
                     pair = (caller_nid, tgt_nid)
@@ -4747,7 +4777,7 @@ def extract_elixir(path: Path) -> dict:
             if child.type == "identifier":
                 callee_name = source[child.start_byte:child.end_byte].decode("utf-8", errors="replace")
                 break
-        if callee_name:
+        if callee_name and callee_name not in _LANGUAGE_BUILTIN_GLOBALS:
             tgt_nid = label_to_nid.get(callee_name.lower())
             if tgt_nid and tgt_nid != caller_nid:
                 pair = (caller_nid, tgt_nid)
@@ -6485,6 +6515,11 @@ def extract(
         for rc in result.get("raw_calls", []):
             callee = rc.get("callee", "")
             if not callee:
+                continue
+            # Skip language built-in globals (String, Number, Boolean, etc.) —
+            # they accumulate spurious edges from every call site, creating
+            # god-nodes and cross-language false positives in the report.
+            if callee in _LANGUAGE_BUILTIN_GLOBALS:
                 continue
             # Skip member-call callees: obj.log() → "log" has no import evidence
             # and collides with any top-level function named "log" in the corpus.


### PR DESCRIPTION
Partial fix for #726. Prevents `String()`, `Number()`, `Boolean()`, `fetch()`, and other ECMAScript/Python language built-ins from becoming god-nodes by adding a 89-entry `_LANGUAGE_BUILTIN_GLOBALS` frozenset and filtering at both same-file (4 sites) and cross-file resolution.

## Real-world impact

Reproduced on a 3848-node Next.js + TypeScript codebase (1021 code files):

| Metric | Before | After |
|---|---|---|
| `String()` god-node degree | 134 edges | 1 (file containment) |
| `String()` cross-community edges | 30+ communities | 0 |
| Total graph edges | 5232 | 4946 (−286 spurious) |
| Top god-node | `String()` (134) | `withCache()` (49) |

"Surprising Connections" no longer shows entries like:
```
parseMinImpressions() --calls--> String()  [INFERRED]
  docker/opencli/source/adlibrary/lib.js → src/components/data-table/data-table-pagination.tsx
```

## Root cause

Tree-sitter classifies `String(value)` as `call_expression` with callee `"String"`. With no local declaration matching, the callee goes to `raw_calls` for cross-file resolution. The resolver matches any node whose label is `"String"` (typically the first inline call expression encountered) and creates INFERRED edges from every `String(...)` call in the corpus.

## Implementation

Same architecture as merged PR #908 (Rust scoped_identifier / trait-method blocklist) — name-blocklist filtering for ambiguous cross-corpus names.

Builtins blocked: 89 entries spanning JS/TS ECMAScript (String, Number, Boolean, Promise, Map, Set, JSON, Math, parseInt, etc.), Browser/Node (fetch, URL, URLSearchParams, FormData, Headers, Request, Response, AbortController, TextEncoder/TextDecoder, console), and Python (str, int, float, list, dict, set, len, range, enumerate, zip, map, filter, print, isinstance, etc.).

## Tests

All 122 existing tests pass: `test_extract.py` (53), `test_analyze.py` (24), `test_build.py` (19), `test_cluster.py` (26). No new tests because existing fixtures do not include calls to builtins — filter is a no-op against current corpus. Validation done on real 3848-node Next.js codebase.

## Scope

Partial fix for #726 — addresses the `String()`-style god-node pattern specifically. Cross-repo origin filtering also mentioned in #726 is not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)