### PR TITLE
fix(detect): save_manifest drops untouched files on incremental runs

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -854,9 +854,18 @@ def save_manifest(
     kind="semantic" — written by `graphify extract` after semantic extraction.
                       Stamps semantic_hash; preserves existing ast_hash.
     kind="both"     — full pipeline: stamps both hashes (default).
+
+    The manifest is seeded from the existing on-disk manifest (pruned to files
+    that still exist) before stamping the files in this run. Without this, an
+    incremental run that only processed a handful of files would drop every
+    other file out of the manifest, so the next detect_incremental() would flag
+    the whole corpus as "new". Entries for deleted files are pruned, so
+    deletions still self-heal.
     """
     existing = load_manifest(manifest_path)
-    manifest: dict[str, dict] = {}
+    manifest: dict[str, dict] = {
+        f: e for f, e in existing.items() if Path(f).exists()
+    }
     for file_list in files.values():
         for f in file_list:
             try:


### PR DESCRIPTION
## Summary

Fixes #917.

`save_manifest()` rebuilt the manifest only from the `files` passed to it, so an incremental `extract`/`update` run that processed a handful of files wiped every other file's entry. The next `detect_incremental()` then flagged the entire corpus as new, forcing a full re-extraction.

This seeds the output `manifest` from the existing on-disk manifest (pruned to files that still exist) before stamping this run's files.

## Test plan

- [ ] Full build → manifest contains whole corpus
- [ ] Incremental update touching a few files → manifest still contains the whole corpus, with touched files re-stamped
- [ ] Delete a file, run update → deleted file pruned from manifest
- [ ] `detect_incremental()` after an incremental run reports only changed files, not the whole corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)