### PR TITLE
fix: guard against empty choices and None message in LLM responses

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -345,6 +345,8 @@ def _call_openai_compat(
         keep_alive = os.environ.get("GRAPHIFY_OLLAMA_KEEP_ALIVE", "30m")
         kwargs["extra_body"] = {"options": {"num_ctx": num_ctx}, "keep_alive": keep_alive}
     resp = client.chat.completions.create(**kwargs)
+    if not resp.choices or resp.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     raw_content = resp.choices[0].message.content
     result = _parse_llm_json(raw_content or "{}")
     result["input_tokens"] = resp.usage.prompt_tokens if resp.usage else 0
@@ -1038,6 +1040,8 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
     if "moonshot" in cfg["base_url"]:
         kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
     resp = client.chat.completions.create(**kwargs)
+    if not resp.choices or resp.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return resp.choices[0].message.content or ""
 
 


### PR DESCRIPTION
## What

Add guards before accessing `resp.choices[0].message` in `_call_openai_compat` and `_call_llm`.

## Why

The OpenAI-compatible API spec allows HTTP 200 responses with an empty `choices` list or with `choices[0].message = None`. Both occur in production:

- **Empty `choices`**: content-filtered responses on some providers (e.g. Gemini returns `choices=[]` on `PROHIBITED_CONTENT` with HTTP 200)
- **`message = None`**: documented in the OpenAI spec as possible when the response is filtered

Without a guard, both cases raise an unhandled `IndexError` or `AttributeError` that crashes the caller.

`_call_openai_compat` already contains a comment documenting exactly this hazard:

```python
# An overwhelmed local model (typically Ollama) can return HTTP 200 with
# empty / null content or unparseable half-generated JSON.
```

The `_response_is_hollow` check that follows is the right recovery path — but it's unreachable when `choices` is empty. The new guard closes that gap.

## Change

```python
# before
resp = client.chat.completions.create(**kwargs)
raw_content = resp.choices[0].message.content  # IndexError if choices=[]

# after
resp = client.chat.completions.create(**kwargs)
if not resp.choices or resp.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
raw_content = resp.choices[0].message.content
```

Same fix applied to `_call_llm` (line 1041).

## Proof

This crash vector is confirmed by Gemini's own documentation and by a live test that reproduces the `choices[0].message = None` case with an actual API call to `gemini-2.5-flash-preview`.