### PR TITLE
fix: add .ets (ArkTS) extension to CODE_EXTENSIONS

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -24,7 +24,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json'}
+CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}


### PR DESCRIPTION
## Summary
- Adds `.ets` (ArkTS) to the `CODE_EXTENSIONS` set in `detect.py`
- ArkTS is the primary language for HarmonyOS/OpenHarmony application development
- `.ets` files are TypeScript-compatible — the tree-sitter TypeScript parser already handles them for AST extraction

## Problem
In OpenHarmony codebases (e.g., SceneBoard), `.ets` files make up ~90% of code. The detect module silently skips them, resulting in severely incomplete knowledge graphs.

**Before** (SceneBoard `product/phonebase` — 476 code files total):
- 0 `.ets` files detected
- 9 `.ts` files detected

**After**:
- 467 `.ets` files detected
- 9 `.ts` files detected

## Test Plan
- [x] `classify_file(Path("test.ets"))` returns `FileType.CODE`
- [x] `detect()` on OpenHarmony project correctly discovers all `.ets` source files
- [x] All other extensions continue to classify correctly

## Note
The tree-sitter TypeScript parser handles `.ets` files for AST extraction — the parser was never the bottleneck, only the detect module's file-type recognition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)