### PR TITLE
fix: CJK/Unicode labels silently skipped in _norm/_norm_label dedup (follow-up to #811)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -228,8 +228,8 @@ def build(
 
 
 def _norm_label(label: str) -> str:
-    """Canonical dedup key — lowercase, alphanumeric only."""
-    return re.sub(r"[^a-z0-9 ]", "", label.lower()).strip()
+    """Canonical dedup key — Unicode-aware, preserves CJK/word characters."""
+    return re.sub(r"[^\w ]", "", label.casefold(), flags=re.UNICODE).strip()
 
 
 def deduplicate_by_label(nodes: list[dict], edges: list[dict]) -> tuple[list[dict], list[dict]]:

--- a/graphify/build.py
+++ b/graphify/build.py
@@ -229,7 +229,8 @@ def build(
 
 def _norm_label(label: str) -> str:
     """Canonical dedup key — Unicode-aware, preserves CJK/word characters."""
-    return re.sub(r"[^\w ]", "", label.casefold(), flags=re.UNICODE).strip()
+    label = unicodedata.normalize("NFKC", label)
+    return re.sub(r"[\W_ ]+", " ", label.casefold(), flags=re.UNICODE).strip()
 
 
 def deduplicate_by_label(nodes: list[dict], edges: list[dict]) -> tuple[list[dict], list[dict]]:

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -15,8 +15,8 @@ from rapidfuzz.distance import JaroWinkler
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 def _norm(label: str) -> str:
-    """Lowercase + collapse non-alphanumeric runs to space."""
-    return re.sub(r"[^a-z0-9]+", " ", label.lower()).strip()
+    """Lowercase + collapse non-alphanumeric runs to space (Unicode-aware)."""
+    return re.sub(r"[^\w]+", " ", label.casefold(), flags=re.UNICODE).strip()
 
 
 def _entropy(label: str) -> float:

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -6,6 +6,7 @@ Jaro-Winkler verification → same-community boost → union-find merge.
 from __future__ import annotations
 import math
 import re
+import unicodedata
 from collections import defaultdict
 
 from datasketch import MinHash, MinHashLSH
@@ -16,7 +17,8 @@ from rapidfuzz.distance import JaroWinkler
 
 def _norm(label: str) -> str:
     """Lowercase + collapse non-alphanumeric runs to space (Unicode-aware)."""
-    return re.sub(r"[^\w]+", " ", label.casefold(), flags=re.UNICODE).strip()
+    label = unicodedata.normalize("NFKC", label)
+    return re.sub(r"[\W_]+", " ", label.casefold(), flags=re.UNICODE).strip()
 
 
 def _entropy(label: str) -> float:


### PR DESCRIPTION
## Summary

Follow-up to **#811**: the original fix correctly changed `_make_id()` and `_normalize_id()` to use `[^\w]+` with `re.UNICODE`, but **two more functions** still use ASCII-only regex patterns, causing CJK/Unicode labels to be silently stripped:

### Affected functions

| Function | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| `dedup.py` `_norm()` | `[^a-z0-9]+` | `[^\w]+` + `re.UNICODE` + `casefold()` |
| `build.py` `_norm_label()` | `[^a-z0-9 ]` | `[^\w ]` + `re.UNICODE` + `casefold()` |

### Impact

When processing repos with Chinese/Japanese/Korean identifiers, these two functions strip all Unicode characters from labels before dedup comparison. This causes:
- **False dedup merges**: different Chinese labels like `道具处理类_初始化` and `道具处理类_数据处理` both normalize to empty strings, getting merged into a single node
- **Silent data loss**: CJK nodes that should be distinct entities are collapsed into one

### What changed

- `dedup.py:17` — `lower()` → `casefold()`, `[^a-z0-9]+` → `[^\w]+` with `flag=re.UNICODE`
- `build.py:230` — `lower()` → `casefold()`, `[^a-z0-9 ]` → `[^\w ]` with `flag=re.UNICODE`

Using `casefold()` instead of `lower()` for better Unicode case folding (e.g. German ß → ss).

### References

- Original issue: #811
- The upstream fixed `extract.py:_make_id()` and `build.py:_normalize_id()` but missed these two dedup functions.