### PR TITLE
feat: doc anchor extraction (Phase 1)

### DIFF
--- a/docs/PHASE1_DOC_ANCHORS.md
+++ b/docs/PHASE1_DOC_ANCHORS.md
@@ -1,0 +1,52 @@
+# Phase 1: Doc Anchors
+
+## What
+
+Adds deterministic extraction of explicit documentation anchors from markdown files, producing `file_type: "doc"` nodes and cross-linking edges to code symbols.
+
+## Why
+
+Graphify already extracts structural headings from markdown as `file_type: "document"`. Doc anchors provide a separate, explicit navigation layer that users or LLMs can place to create direct links between documentation sections and code symbols — without relying on semantic inference.
+
+## Supported Patterns
+
+| Pattern | Example | Node ID | Edge |
+|---------|---------|---------|------|
+| YAML frontmatter `graphify_id` | `graphify_id: auth_flow` | `doc_stem_auth_flow` | none |
+| YAML frontmatter `anchors` | `anchors: [setup, teardown]` | `doc_stem_setup` | none |
+| HTML comment `GRAPH` | `<!-- GRAPH: SessionManager -->` | `doc_stem_sessionmanager` | `explains` → `sessionmanager` |
+| HTML comment `SEE` | `<!-- SEE: validate_token -->` | `doc_stem_validatetoken` | `references` → `validatetoken` |
+| HTML comment `ANCHOR` | `<!-- ANCHOR: foo -->` | `doc_stem_foo` | `references` → `foo` |
+| Fenced directive | ````graphify id=auth_flow` | `doc_stem_auth_flow` | none |
+| Header with explicit ID | `## Title {#anchor}` | `doc_stem_anchor` | none |
+
+## New Edge Relations
+
+- `explains` — doc section explicitly describes a code symbol (from `GRAPH:` directive)
+- `references` — doc section points to a code symbol (from `SEE:` or `ANCHOR:` directive)
+- `documented-by` — inverse of `explains` (for future use)
+- `validates` — doc section describes validation logic (for future use)
+- `orchestrates` — doc section describes orchestration/flow (for future use)
+- `persists-via` — doc section describes persistence mechanism (for future use)
+
+## Integration
+
+- **`validate.py`**: Added `"doc"` to `VALID_FILE_TYPES`
+- **`extract.py`**: Added `extract_doc_anchors()` + 4 private helpers; wired into `extract()` after ID remapping, before cross-file import resolution
+- **`skill.md`**: Updated `file_type` valid values (6 → 7), added new edge relations to schema, added Part A.5 extraction step, updated Part C merge
+
+## Design Decisions
+
+1. **Separate `doc` type from `document`** — avoids collision with `extract_markdown`'s structural heading extraction. Both can coexist for the same file.
+2. **Deterministic only** — no semantic inference in v1. Only explicit, user-placed directives are extracted.
+3. **Edges preserved** — `extract_doc_anchors` returns both `nodes` and `edges` (not `edges: []`), enabling cross-linking from day one.
+4. **Runs after AST + semantic merge** — anchor edges are available for the global label-to-node index used by cross-file call resolution.
+
+## Tests
+
+- `tests/test_doc_anchors.py` — 14 tests covering all 4 patterns, dedup, validation, coexistence with document nodes, ID format matching, error handling
+- `tests/test_validate.py` — added `test_doc_file_type_valid`
+
+## Migration
+
+No migration needed. Existing graphs are unaffected. New runs will automatically extract doc anchors from any `.md`, `.mdx`, or `.qmd` files in the corpus.

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4944,6 +4944,178 @@ def extract_markdown(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges, "input_tokens": 0, "output_tokens": 0}
 
 
+# ── Doc anchor extraction ─────────────────────────────────────────────────────
+
+def _extract_yaml_anchors(text: str, stem: str, str_path: str,
+                          nodes: list, edges: list) -> None:
+    """Extract anchors from YAML frontmatter: graphify_id: or anchors: [...]."""
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return
+    frontmatter = m.group(1)
+
+    gid = re.search(r"^graphify_id:\s*(\S+)", frontmatter, re.MULTILINE)
+    if gid:
+        anchor_id = gid.group(1).strip().strip("\"'")
+        nid = _make_id("doc", stem, anchor_id)
+        nodes.append({
+            "id": nid,
+            "label": f"{stem} / {anchor_id}",
+            "file_type": "doc",
+            "source_file": str_path,
+            "source_location": "L1",
+            "section": anchor_id,
+            "content": None,
+        })
+
+    anchors_m = re.search(r"^anchors:\s*\[(.*?)\]", frontmatter, re.MULTILINE)
+    if anchors_m:
+        for item in anchors_m.group(1).split(","):
+            anchor = item.strip().strip("\"'")
+            if anchor:
+                nid = _make_id("doc", stem, anchor)
+                nodes.append({
+                    "id": nid,
+                    "label": f"{stem} / {anchor}",
+                    "file_type": "doc",
+                    "source_file": str_path,
+                    "source_location": "L1",
+                    "section": anchor,
+                    "content": None,
+                })
+
+
+def _extract_html_comment_anchors(text: str, stem: str, str_path: str,
+                                   nodes: list, edges: list) -> None:
+    """Extract anchors from HTML comments: <!-- GRAPH: symbol -->, <!-- SEE: symbol -->."""
+    seen: set[str] = set()
+    for m in re.finditer(r"<!--\s*(GRAPH|SEE|ANCHOR)\s*:\s*([^>]+?)\s*-->", text):
+        directive = m.group(1).upper()
+        target = m.group(2).strip()
+        if not target or target in seen:
+            continue
+        seen.add(target)
+
+        line = text[:m.start()].count("\n") + 1
+        nid = _make_id("doc", stem, target)
+
+        if nid not in {n["id"] for n in nodes}:
+            nodes.append({
+                "id": nid,
+                "label": f"{stem} / {target}",
+                "file_type": "doc",
+                "source_file": str_path,
+                "source_location": f"L{line}",
+                "section": target,
+                "content": None,
+            })
+
+        relation = "explains" if directive == "GRAPH" else "references"
+        edges.append({
+            "source": nid,
+            "target": _make_id(target),
+            "relation": relation,
+            "confidence": "EXTRACTED",
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": 1.0,
+        })
+
+
+def _extract_fenced_anchors(text: str, stem: str, str_path: str,
+                             nodes: list, edges: list) -> None:
+    """Extract anchors from fenced directives: ```graphify id=foo ... ```."""
+    seen: set[str] = set()
+    for m in re.finditer(r"```graphify\s+(.*?)```", text, re.DOTALL):
+        attrs = m.group(1).strip()
+        id_m = re.search(r"id=(\S+)", attrs)
+        if not id_m:
+            continue
+        anchor_id = id_m.group(1).strip()
+        if anchor_id in seen:
+            continue
+        seen.add(anchor_id)
+
+        line = text[:m.start()].count("\n") + 1
+        nid = _make_id("doc", stem, anchor_id)
+        content = attrs.replace(f"id={anchor_id}", "").strip() or None
+
+        if nid not in {n["id"] for n in nodes}:
+            nodes.append({
+                "id": nid,
+                "label": f"{stem} / {anchor_id}",
+                "file_type": "doc",
+                "source_file": str_path,
+                "source_location": f"L{line}",
+                "section": anchor_id,
+                "content": content,
+            })
+
+
+def _extract_header_anchors(text: str, stem: str, str_path: str,
+                             nodes: list, edges: list) -> None:
+    """Extract anchors from section headers with explicit IDs: ## Title {#anchor}."""
+    seen: set[str] = set()
+    for m in re.finditer(r"^(#{1,6})\s+(.+?)\s*\{#([^}]+)\}", text, re.MULTILINE):
+        title = m.group(2).strip()
+        anchor_id = m.group(3).strip()
+        if anchor_id in seen:
+            continue
+        seen.add(anchor_id)
+
+        line = text[:m.start()].count("\n") + 1
+        nid = _make_id("doc", stem, anchor_id)
+
+        next_header = re.search(r"^#{1,6}\s+", text[m.end():], re.MULTILINE)
+        if next_header:
+            content = text[m.end():m.end() + next_header.start()].strip()[:300]
+        else:
+            content = text[m.end():].strip()[:300]
+
+        if nid not in {n["id"] for n in nodes}:
+            nodes.append({
+                "id": nid,
+                "label": f"{title} ({stem})",
+                "file_type": "doc",
+                "source_file": str_path,
+                "source_location": f"L{line}",
+                "section": title,
+                "content": content if content else None,
+            })
+
+
+def extract_doc_anchors(doc_files: list[Path]) -> dict:
+    """Extract section anchors from markdown documentation files.
+
+    Detects four anchor patterns:
+    1. YAML frontmatter: graphify_id: auth_flow  or  anchors: [setup, teardown]
+    2. HTML comments: <!-- GRAPH: symbol_name --> or <!-- SEE: symbol_name -->
+    3. Fenced directives: ```graphify id=foo
+    4. Section headers with explicit IDs: ## Title {#anchor}
+
+    Returns nodes+edges with file_type="doc". Edges use relation="explains"
+    (EXTRACTED) when an anchor explicitly names a code symbol.
+    """
+    nodes: list[dict] = []
+    edges: list[dict] = []
+
+    for path in doc_files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        stem = _file_stem(path)
+        str_path = str(path)
+
+        _extract_yaml_anchors(text, stem, str_path, nodes, edges)
+        _extract_html_comment_anchors(text, stem, str_path, nodes, edges)
+        _extract_fenced_anchors(text, stem, str_path, nodes, edges)
+        _extract_header_anchors(text, stem, str_path, nodes, edges)
+
+    return {"nodes": nodes, "edges": edges, "input_tokens": 0, "output_tokens": 0}
+
+
 # ── Pascal / Delphi extractor ─────────────────────────────────────────────────
 
 _pascal_unit_cache: dict[str, dict[str, str]] = {}
@@ -6469,6 +6641,17 @@ def extract(
                 e["source"] = id_remap[e["source"]]
             if e.get("target") in id_remap:
                 e["target"] = id_remap[e["target"]]
+
+    # Doc anchor extraction: merge explicit doc anchors into the graph
+    doc_paths = [p for p in paths if p.suffix in (".md", ".mdx", ".qmd")]
+    if doc_paths:
+        try:
+            doc_result = extract_doc_anchors(doc_paths)
+            all_nodes.extend(doc_result.get("nodes", []))
+            all_edges.extend(doc_result.get("edges", []))
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("Doc anchor extraction failed, skipping: %s", exc)
 
     # Add cross-file class-level edges (Python only - uses Python parser internally)
     py_paths = [p for p in paths if p.suffix == ".py"]

--- a/graphify/skill.md
+++ b/graphify/skill.md
@@ -267,6 +267,71 @@ else:
 "
 ```
 
+#### Part A.5 - Doc anchor extraction (deterministic, free)
+
+After AST extraction, run doc anchor extraction on all markdown files. This extracts
+explicit graph navigation directives (YAML frontmatter anchors, HTML comments, fenced
+directives, section headers with IDs) that users or LLMs placed for graph navigation.
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json
+from graphify.extract import extract_doc_anchors
+from pathlib import Path
+
+detect = json.loads(Path('graphify-out/.graphify_detect.json').read_text(encoding=\"utf-8\"))
+doc_files = []
+for f in detect.get('files', {}).get('document', []):
+    p = Path(f)
+    if p.suffix in ('.md', '.mdx', '.qmd'):
+        doc_files.append(p)
+
+if doc_files:
+    result = extract_doc_anchors(doc_files)
+    Path('graphify-out/.graphify_doc_anchors.json').write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+    print(f'Doc anchors: {len(result[\"nodes\"])} nodes, {len(result[\"edges\"])} edges')
+else:
+    Path('graphify-out/.graphify_doc_anchors.json').write_text(json.dumps({'nodes':[],'edges':[],'input_tokens':0,'output_tokens':0}, ensure_ascii=False), encoding=\"utf-8\")
+    print('No doc files with anchors')
+"
+```
+
+In Part C (merge), add doc anchors to the merged result alongside AST + semantic:
+
+```bash
+$(cat graphify-out/.graphify_python) -c "
+import json
+from pathlib import Path
+
+ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
+sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+doc = json.loads(Path('graphify-out/.graphify_doc_anchors.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_doc_anchors.json').exists() else {'nodes':[],'edges':[]}
+
+seen = {n['id'] for n in ast['nodes']}
+merged_nodes = list(ast['nodes'])
+for n in sem['nodes']:
+    if n['id'] not in seen:
+        merged_nodes.append(n)
+        seen.add(n['id'])
+for n in doc['nodes']:
+    if n['id'] not in seen:
+        merged_nodes.append(n)
+        seen.add(n['id'])
+
+merged_edges = ast['edges'] + sem['edges'] + doc.get('edges', [])
+merged_hyperedges = sem.get('hyperedges', [])
+merged = {
+    'nodes': merged_nodes,
+    'edges': merged_edges,
+    'hyperedges': merged_hyperedges,
+    'input_tokens': sem.get('input_tokens', 0),
+    'output_tokens': sem.get('output_tokens', 0),
+}
+Path('graphify-out/.graphify_extract.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
+print(f'Merged: {len(merged_nodes)} nodes, {len(merged_edges)} edges ({len(ast[\"nodes\"])} AST + {len(sem[\"nodes\"])} semantic + {len(doc[\"nodes\"])} doc anchors)')
+"
+```
+
 #### Part B - Semantic extraction (parallel subagents)
 
 **Fast path:** If detection found zero docs, papers, and images (code-only corpus), skip Part B entirely and go straight to Part C. AST handles code - there is nothing for semantic subagents to do.
@@ -345,7 +410,7 @@ Rules:
 
 Code files: focus on semantic edges AST cannot find (call relationships, shared data, arch patterns).
   Do not re-extract imports - AST already has those.
-Doc/paper files: extract named concepts, entities, citations. For rationale (WHY decisions were made, trade-offs, design intent): store as a `rationale` attribute on the relevant concept node — do NOT create a separate rationale node or fragment node. Only create a node for something that is itself a named entity or concept. Use `file_type:"rationale"` for concept-like nodes (ideas, principles, mechanisms, design patterns). `file_type` MUST be one of exactly these six values: `code`, `document`, `paper`, `image`, `rationale`, `concept`. Any other value is invalid and will be rejected.
+Doc/paper files: extract named concepts, entities, citations. For rationale (WHY decisions were made, trade-offs, design intent): store as a `rationale` attribute on the relevant concept node — do NOT create a separate rationale node or fragment node. Only create a node for something that is itself a named entity or concept. Use `file_type:"rationale"` for concept-like nodes (ideas, principles, mechanisms, design patterns). `file_type` MUST be one of exactly these seven values: `code`, `document`, `paper`, `image`, `rationale`, `concept`, `doc`. Any other value is invalid and will be rejected.
 Code files: when adding `calls` edges, source MUST be the caller (the function/class doing the calling), target MUST be the callee. Never reverse this direction.
 Image files: use vision to understand what the image IS - do not just OCR.
   UI screenshot: layout patterns, design decisions, key elements, purpose.
@@ -390,7 +455,7 @@ confidence_score is REQUIRED on every edge - never omit it, never use 0.5 as a d
 Node ID format: lowercase, only `[a-z0-9_]`, no dots or slashes. Format: `{stem}_{entity}` where stem is `{parent_dir}_{filename_without_ext}` (the **immediate** parent directory name + the filename stem, both lowercased with non-alphanumeric chars replaced by `_`) and entity is the symbol name similarly normalized. Only one level of parent is used — not the full path. Examples: `src/auth/session.py` + `ValidateToken` → `auth_session_validatetoken`; `lib/utils/helpers.py` + `parse_url` → `utils_helpers_parse_url`; `tests/test_foo.py` + `_helper` → `tests_test_foo_helper`. Top-level files (no parent dir, e.g. `setup.py`) use just the filename stem: `setup_my_func`. This must match the ID the AST extractor generates — using just the filename (e.g., `session_validatetoken`) or the full path (e.g., `src_auth_session_validatetoken`) will create orphan ghost-duplicate nodes. If you are re-extracting a project that had ghost duplicates under the old format, the user should run `graphify extract --force` to rebuild cleanly. CRITICAL: never append chunk numbers, sequence numbers, or any suffix to an ID (no `_c1`, `_c2`, `_chunk2`, etc.). IDs must be deterministic from the label alone — the same entity must always produce the same ID regardless of which chunk processes it.
 
 Generate the extraction JSON matching this schema exactly:
-{"nodes":[{"id":"session_validatetoken","label":"Human Readable Name","file_type":"code|document|paper|image|rationale|concept","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to|rationale_for","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
+{"nodes":[{"id":"session_validatetoken","label":"Human Readable Name","file_type":"code|document|paper|image|rationale|concept|doc","source_file":"relative/path","source_location":null,"source_url":null,"captured_at":null,"author":null,"contributor":null}],"edges":[{"source":"node_id","target":"node_id","relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to|rationale_for|explains|documented-by|validates|orchestrates|persists-via","confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,"source_file":"relative/path","source_location":null,"weight":1.0}],"hyperedges":[{"id":"snake_case_id","label":"Human Readable Label","nodes":["node_id1","node_id2","node_id3"],"relation":"participate_in|implement|form","confidence":"EXTRACTED|INFERRED","confidence_score":0.75,"source_file":"relative/path"}],"input_tokens":0,"output_tokens":0}
 
 Then write the JSON to disk using the Write tool at this exact absolute path (no relative paths — Write resolves relative paths against an undefined cwd and the file will be silently lost):
 CHUNK_PATH
@@ -475,7 +540,7 @@ print(f'Extraction complete - {len(deduped)} nodes, {len(all_edges)} edges ({len
 ```
 Clean up temp files: `rm -f graphify-out/.graphify_cached.json graphify-out/.graphify_uncached.txt graphify-out/.graphify_semantic_new.json`
 
-#### Part C - Merge AST + semantic into final extraction
+#### Part C - Merge AST + semantic + doc anchors into final extraction
 
 ```bash
 $(cat graphify-out/.graphify_python) -c "
@@ -484,16 +549,21 @@ from pathlib import Path
 
 ast = json.loads(Path('graphify-out/.graphify_ast.json').read_text(encoding=\"utf-8\"))
 sem = json.loads(Path('graphify-out/.graphify_semantic.json').read_text(encoding=\"utf-8\"))
+doc = json.loads(Path('graphify-out/.graphify_doc_anchors.json').read_text(encoding=\"utf-8\")) if Path('graphify-out/.graphify_doc_anchors.json').exists() else {'nodes':[],'edges':[]}
 
-# Merge: AST nodes first, semantic nodes deduplicated by id
+# Merge: AST nodes first, semantic nodes deduplicated by id, doc anchors last
 seen = {n['id'] for n in ast['nodes']}
 merged_nodes = list(ast['nodes'])
 for n in sem['nodes']:
     if n['id'] not in seen:
         merged_nodes.append(n)
         seen.add(n['id'])
+for n in doc['nodes']:
+    if n['id'] not in seen:
+        merged_nodes.append(n)
+        seen.add(n['id'])
 
-merged_edges = ast['edges'] + sem['edges']
+merged_edges = ast['edges'] + sem['edges'] + doc.get('edges', [])
 merged_hyperedges = sem.get('hyperedges', [])
 merged = {
     'nodes': merged_nodes,
@@ -505,7 +575,7 @@ merged = {
 Path('graphify-out/.graphify_extract.json').write_text(json.dumps(merged, indent=2, ensure_ascii=False), encoding=\"utf-8\")
 total = len(merged_nodes)
 edges = len(merged_edges)
-print(f'Merged: {total} nodes, {edges} edges ({len(ast[\"nodes\"])} AST + {len(sem[\"nodes\"])} semantic)')
+print(f'Merged: {total} nodes, {edges} edges ({len(ast[\"nodes\"])} AST + {len(sem[\"nodes\"])} semantic + {len(doc[\"nodes\"])} doc anchors)')
 "
 ```
 

--- a/graphify/validate.py
+++ b/graphify/validate.py
@@ -1,7 +1,7 @@
 # validate extraction JSON against the graphify schema before graph assembly
 from __future__ import annotations
 
-VALID_FILE_TYPES = {"code", "document", "paper", "image", "rationale", "concept"}
+VALID_FILE_TYPES = {"code", "document", "paper", "image", "rationale", "concept", "doc"}
 VALID_CONFIDENCES = {"EXTRACTED", "INFERRED", "AMBIGUOUS"}
 REQUIRED_NODE_FIELDS = {"id", "label", "file_type", "source_file"}
 REQUIRED_EDGE_FIELDS = {"source", "target", "relation", "confidence", "source_file"}

--- a/tests/test_doc_anchors.py
+++ b/tests/test_doc_anchors.py
@@ -1,0 +1,162 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from graphify.extract import extract_doc_anchors, _make_id
+from graphify.validate import validate_extraction
+
+
+class TestDocAnchors:
+    def test_yaml_frontmatter_graphify_id(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("---\ngraphify_id: auth_flow\n---\n# Auth Documentation\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 1
+            assert result["nodes"][0]["file_type"] == "doc"
+            assert result["nodes"][0]["section"] == "auth_flow"
+
+    def test_yaml_frontmatter_anchors_list(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("---\nanchors: [setup, teardown, validate]\n---\nContent\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 3
+            labels = {n["label"] for n in result["nodes"]}
+            assert any("setup" in label for label in labels)
+
+    def test_html_comment_graph_directive(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- GRAPH: SessionManager -->\nSome text\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 1
+            assert len(result["edges"]) == 1
+            assert result["edges"][0]["relation"] == "explains"
+            assert result["edges"][0]["confidence"] == "EXTRACTED"
+
+    def test_html_comment_see_directive(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- SEE: validate_token -->\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["edges"]) == 1
+            assert result["edges"][0]["relation"] == "references"
+
+    def test_html_comment_anchor_directive(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- ANCHOR: some_anchor -->\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["edges"]) == 1
+            assert result["edges"][0]["relation"] == "references"
+
+    def test_fenced_directive(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("```graphify id=auth_flow\nThis explains the auth flow\n```\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 1
+            node = result["nodes"][0]
+            assert node["section"] == "auth_flow"
+            assert node["content"] == "This explains the auth flow"
+
+    def test_header_with_explicit_id(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("## Authentication {#auth-init}\nContent about auth.\n## Next Section {#next}\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 2
+            node = result["nodes"][0]
+            assert "Authentication" in node["label"]
+            assert node["section"] == "Authentication"
+            assert node["content"] is not None
+
+    def test_no_anchors_returns_empty(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("# Regular Markdown\n\nNo anchors here.\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert result["nodes"] == []
+            assert result["edges"] == []
+
+    def test_dedup_same_anchor_in_one_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- GRAPH: Foo -->\n<!-- GRAPH: Foo -->\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["nodes"]) == 1
+
+    def test_validation_passes(self):
+        """Doc anchors alone may have dangling edges (target code symbols from AST).
+        Validation should pass when combined with AST nodes that provide the targets."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- GRAPH: Bar -->\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+
+            # Edge should target _make_id("Bar") = "bar"
+            assert len(result["edges"]) == 1
+            assert result["edges"][0]["target"] == _make_id("Bar")
+
+            # When combined with a matching AST node, validation passes
+            combined = {
+                "nodes": result["nodes"] + [
+                    {"id": _make_id("Bar"), "label": "Bar", "file_type": "code", "source_file": "bar.py"}
+                ],
+                "edges": result["edges"],
+            }
+            errors = validate_extraction(combined)
+            assert errors == [], f"Validation errors: {errors}"
+
+    def test_doc_anchor_coexists_with_document_node(self):
+        """A doc anchor node and a regular document node from the same file must coexist."""
+        from graphify.extract import extract_markdown
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("# Auth Guide\n\n<!-- GRAPH: SessionManager -->\n\n## Setup {#setup}\n")
+            f.flush()
+            path = Path(f.name)
+
+            md_result = extract_markdown(path)
+            doc_result = extract_doc_anchors([path])
+
+            md_node_ids = {n["id"] for n in md_result["nodes"]}
+            doc_node_ids = {n["id"] for n in doc_result["nodes"]}
+
+            assert len(md_node_ids & doc_node_ids) == 0, "No ID collision between document and doc nodes"
+
+            combined_nodes = md_result["nodes"] + doc_result["nodes"]
+            combined_ids = {n["id"] for n in combined_nodes}
+            assert len(combined_ids) == len(combined_nodes), "All IDs unique when combined"
+
+            doc_types = {n.get("file_type") for n in combined_nodes}
+            assert "document" in doc_types
+            assert "doc" in doc_types
+
+    def test_multiple_files(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f1:
+            f1.write("<!-- GRAPH: Alpha -->\n")
+            f1.flush()
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f2:
+                f2.write("<!-- GRAPH: Beta -->\n")
+                f2.flush()
+                result = extract_doc_anchors([Path(f1.name), Path(f2.name)])
+                assert len(result["nodes"]) == 2
+
+    def test_edge_target_matches_ast_id_format(self):
+        """Edge targets from GRAPH directives should match _make_id(symbol) format."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("<!-- GRAPH: SessionManager -->\n")
+            f.flush()
+            result = extract_doc_anchors([Path(f.name)])
+            assert len(result["edges"]) == 1
+            expected_target = _make_id("SessionManager")
+            assert result["edges"][0]["target"] == expected_target
+
+    def test_oserror_handled_gracefully(self):
+        """Non-existent files should be skipped without raising."""
+        result = extract_doc_anchors([Path("/nonexistent/path/file.md")])
+        assert result["nodes"] == []
+        assert result["edges"] == []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -85,3 +85,12 @@ def test_assert_valid_raises_on_errors():
 
 def test_assert_valid_passes_silently():
     assert_valid(VALID)  # should not raise
+
+
+def test_doc_file_type_valid():
+    data = {
+        "nodes": [{"id": "n1", "label": "X", "file_type": "doc", "source_file": "x.md"}],
+        "edges": [],
+    }
+    errors = validate_extraction(data)
+    assert errors == []


### PR DESCRIPTION
﻿## Phase 1: Doc Anchors

Adds deterministic extraction of explicit documentation anchors from markdown files, producing file_type=doc nodes and cross-linking edges to code symbols.

### Supported patterns

| Pattern | Example | Edge |
|---------|---------|------|
| YAML frontmatter graphify_id | graphify_id: auth_flow | - |
| YAML frontmatter anchors | anchors: [setup, teardown] | - |
| HTML comment GRAPH | GRAPH: SessionManager | explains -> sessionmanager |
| HTML comment SEE | SEE: validate_token | references -> validatetoken |
| Fenced directive | graphify id=auth_flow | - |
| Header with explicit ID | ## Title {#anchor} | - |

### Changes

- validate.py: Added doc to VALID_FILE_TYPES (1 line)
- extract.py: Added extract_doc_anchors() + 4 private helpers (~160 lines), wired into extract() after ID remapping
- skill.md: Updated file_type valid values (6 -> 7), added new edge relations to schema, added Part A.5 extraction step, updated Part C merge
- Tests: 14 new tests in test_doc_anchors.py + 1 in test_validate.py
- Docs: docs/PHASE1_DOC_ANCHORS.md

### Design

- Separate doc type from document - avoids collision with extract_markdown structural heading extraction
- Deterministic only - no semantic inference in v1
- Edges preserved - enables cross-linking from day one
- Zero breaking changes - existing graphs unaffected

### Tests

26 passed in 0.24s

All existing extract tests pass (51/53; 2 pre-existing symlink failures on Windows, unrelated).
