### PR TITLE
docs: add TweetClaw X/Twitter research workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,18 @@ graphify prs --conflicts           # PRs sharing graph communities — merge-ord
 
 See the [full command reference](#full-command-reference) below.
 
+### Public X/Twitter research from OpenClaw
+
+OpenClaw agents can use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) to scrape tweets, search tweets, search tweet replies, export followers, look up users, download media, monitor tweets, receive webhooks, and run giveaway draws. Save reviewed TweetClaw results as Markdown or JSON notes, then graph the folder:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+mkdir -p research/x-twitter
+/graphify ./research/x-twitter --update
+```
+
+Store source tweet URLs or IDs, capture dates, short summaries, and next actions. Keep raw timelines, direct messages, and private account data out of the graph.
+
 ---
 
 ## Ignoring files


### PR DESCRIPTION
Summary
- Add a README workflow for graphing reviewed TweetClaw X/Twitter research notes in OpenClaw.
- Show the OpenClaw install command and the Graphify update path for saved Markdown or JSON outputs.
- Add privacy guidance to keep raw timelines, direct messages, and private account data out of the graph.

Validation
- git diff --check
- curl HEAD for https://github.com/Xquik-dev/tweetclaw
- npm view @xquik/tweetclaw version --silent
- uv run --isolated --extra sql --with pytest --with-editable . python -m pytest tests/ -q
