### PR TITLE
fix(cluster-only): ensure output directory exists before writing report (#934)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1824,6 +1824,7 @@ def main() -> None:
                           {"warning": "cluster-only mode — file stats not available"},
                           tokens, str(watch_path), suggested_questions=questions,
                           min_community_size=min_community_size, built_at_commit=_commit)
+        out.mkdir(parents=True, exist_ok=True)
         (out / "GRAPH_REPORT.md").write_text(report, encoding="utf-8")
         from graphify.export import backup_if_protected as _backup
         _backup(out)


### PR DESCRIPTION
Fixes #934.

## What

Adds `out.mkdir(parents=True, exist_ok=True)` before the first write into `out` in the `cluster-only` codepath (`graphify/__main__.py` line 1827 on `v8` HEAD).

## Why

`cluster-only` crashes with `FileNotFoundError` when `graphify-out/` doesn't exist at invocation — a natural state when archiving a previous run before re-clustering with new flags. The `extract` codepath creates `out` explicitly (line 2935); `cluster-only` assumed it existed, which is the asymmetry causing the bug.

The same pattern (`mkdir(parents=True, exist_ok=True)`) is already used at ~20 sites in the same file, so this fix aligns `cluster-only` with the rest of the codebase.

## Manual verification

Reproduced the original crash and confirmed the fix on the same React/Firebase PWA codebase that surfaced #919 / #934 (full reproducer documented in #934).

Also ran the existing test suite locally with the fix applied:
- 945 tests passed
- The 8 failing SQL tests in `test_multilang.py` are pre-existing in my local environment (missing optional `tree-sitter-sql` dependency) and fail identically with the fix reverted, so unrelated to this change.

## Tests

I held off adding a regression test specific to `cluster-only` because the codepath is currently invoked through the manual argparse-style parser in `main()` rather than a directly callable function, and I wasn't sure of the preferred pattern. Happy to add an end-to-end subprocess test, or to extract the codepath into a callable first if you prefer — let me know what would fit best.

---

First-time contributor — happy to iterate on anything.