### PR TITLE
feat: add generic .tab structured extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To remove graphify from all platforms at once: `graphify uninstall` (add `--purg
 
 | Type | Extensions |
 |------|-----------|
-| Code (31 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json` |
+| Code (32 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json .tab` |
 | Docs | `.md .mdx .qmd .html .txt .rst .yaml .yml` |
 | Office | `.docx .xlsx` (requires `pip install graphifyy[office]`) |
 | Google Workspace | `.gdoc .gsheet .gslides` (opt-in; requires `gws` auth and `--google-workspace`; Sheets need `pip install graphifyy[google]`) |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -25,7 +25,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json'}
+CODE_EXTENSIONS = {'.py', '.ts', '.js', '.jsx', '.tsx', '.mjs', '.ejs', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tab'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1,5 +1,6 @@
 """Deterministic structural extraction from source code using tree-sitter. Outputs nodes+edges dicts."""
 from __future__ import annotations
+import csv
 import importlib
 import json
 import os
@@ -7,9 +8,11 @@ import re
 import sys
 import unicodedata
 from dataclasses import dataclass, field
+from io import StringIO
 from pathlib import Path
 from typing import Callable, Any
 from .cache import load_cached, save_cached
+from graphify.detect import CODE_EXTENSIONS
 
 _RECURSION_LIMIT = 10_000
 
@@ -7278,6 +7281,397 @@ def extract_json(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+_TAB_MAX_BYTES = 5 * 1024 * 1024
+_TAB_MAX_ROWS = 10_000
+_TAB_MAX_COLUMNS = 200
+_TAB_MAX_VALUE_NODES = 500
+_TAB_MAX_PATH_REFS = 10_000
+
+
+def _decode_tab_bytes(raw: bytes) -> tuple[str, str]:
+    for enc in ("utf-8-sig", "utf-8", "gb18030"):
+        try:
+            return raw.decode(enc), enc
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", errors="replace"), "utf-8-replace"
+
+
+def _read_tab_text(path: Path) -> tuple[str, list[str], bool]:
+    warnings: list[str] = []
+    truncated = False
+    with path.open("rb") as f:
+        raw = f.read(_TAB_MAX_BYTES + 1)
+    if len(raw) > _TAB_MAX_BYTES:
+        truncated = True
+        warnings.append(f"truncated to {_TAB_MAX_BYTES} bytes")
+        raw = raw[:_TAB_MAX_BYTES]
+        last_newline = max(raw.rfind(b"\n"), raw.rfind(b"\r"))
+        if last_newline >= 0:
+            raw = raw[:last_newline + 1]
+        else:
+            warnings.append("no complete tab-delimited record inside byte limit")
+            raw = b""
+    text, encoding = _decode_tab_bytes(raw)
+    if encoding == "utf-8-replace":
+        warnings.append("decoded with replacement after utf-8/gb18030 failed")
+    return text, warnings, truncated
+
+
+def _normalise_tab_headers(raw_headers: list[str]) -> list[tuple[str, str]]:
+    seen: dict[str, int] = {}
+    out: list[tuple[str, str]] = []
+    for idx, raw in enumerate(raw_headers, start=1):
+        label = raw.strip().strip("\r")
+        if not label:
+            label = f"column_{idx}"
+        base = label
+        count = seen.get(base, 0) + 1
+        seen[base] = count
+        key = base if count == 1 else f"{base}_{count}"
+        out.append((key, label))
+    return out
+
+
+def _pad_tab_row(row: list[str], width: int) -> list[str]:
+    if len(row) < width:
+        return row + [""] * (width - len(row))
+    return row
+
+
+def _choose_tab_identity(headers: list[tuple[str, str]], rows: list[list[str]]) -> int | None:
+    if not rows or not headers:
+        return None
+    best_idx: int | None = None
+    best_score = -1.0
+    for idx in range(len(headers)):
+        values = [r[idx].strip() for r in rows if idx < len(r) and r[idx].strip()]
+        if not values:
+            continue
+        unique = len(set(values))
+        if idx == 0 and unique == len(values):
+            return 0
+        uniqueness = unique / max(len(values), 1)
+        coverage = len(values) / max(len(rows), 1)
+        score = uniqueness * 0.7 + coverage * 0.3
+        if uniqueness >= 0.8 and coverage >= 0.8 and score > best_score:
+            best_idx = idx
+            best_score = score
+    return best_idx
+
+
+_TAB_PATH_EXTENSIONS = {
+    *CODE_EXTENSIONS,
+    ".txt", ".md", ".xml", ".yaml", ".yml",
+}
+
+
+_TAB_PROJECT_ROOT_MARKERS = {
+    ".git", "pyproject.toml", "package.json", "go.mod", "Cargo.toml", "graphify-out",
+}
+
+
+def _normalise_tab_path_value(value: str) -> str:
+    return value.strip().strip('"\'').replace("\\", "/")
+
+
+def _is_tab_url_value(value: str) -> bool:
+    return re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", value) is not None
+
+
+def _looks_like_tab_path(value: str) -> bool:
+    cleaned = _normalise_tab_path_value(value)
+    if not cleaned or len(cleaned) > 512:
+        return False
+    if _is_tab_url_value(cleaned):
+        return False
+    suffix = Path(cleaned).suffix.lower()
+    if suffix in _TAB_PATH_EXTENSIONS:
+        return True
+    if "/" in cleaned:
+        parts = [p for p in cleaned.split("/") if p and p not in (".", "..")]
+        return len(parts) >= 2 and any("." in p for p in parts[-1:])
+    return False
+
+
+def _find_tab_project_root(tab_path: Path) -> Path | None:
+    for parent in tab_path.resolve().parents:
+        if any((parent / marker).exists() for marker in _TAB_PROJECT_ROOT_MARKERS):
+            return parent
+    return None
+
+
+def _is_safe_relative_tab_path(normalised: str) -> bool:
+    path = Path(normalised)
+    if path.is_absolute() or re.match(r"^[A-Za-z]:/", normalised):
+        return False
+    return ".." not in path.parts
+
+
+def _tab_path_candidates(tab_path: Path, normalised: str) -> list[Path]:
+    if not _is_safe_relative_tab_path(normalised):
+        return []
+    candidates = [(tab_path.parent / normalised).resolve()]
+    project_root = _find_tab_project_root(tab_path)
+    if project_root is not None:
+        root_candidate = (project_root / normalised).resolve()
+        if root_candidate not in candidates:
+            candidates.append(root_candidate)
+    return candidates
+
+
+def _tab_reference_node(raw_value: str, tab_path: Path) -> tuple[str, str, str, str]:
+    normalised = _normalise_tab_path_value(raw_value)
+    for candidate in _tab_path_candidates(tab_path, normalised):
+        if candidate.exists():
+            return _make_id(str(tab_path), "ref", normalised), candidate.name, str(tab_path), normalised
+    return _make_id(str(tab_path), "ref", normalised), normalised, str(tab_path), normalised
+
+
+def _tab_source_path(source_file: str, root: Path | None) -> Path:
+    path = Path(source_file)
+    if path.is_absolute():
+        return path.resolve()
+    if root is not None:
+        return (root / path).resolve()
+    return path.resolve()
+
+
+def _tab_file_node_index(nodes: list[dict], root: Path | None) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for node in nodes:
+        if node.get("file_type") != "code":
+            continue
+        source_file = node.get("source_file")
+        if not source_file:
+            continue
+        source_path = _tab_source_path(source_file, root)
+        if node.get("label") != source_path.name:
+            continue
+        index[str(source_path)] = node["id"]
+    return index
+
+
+def _redirect_tab_reference_edges(
+    nodes: list[dict],
+    edges: list[dict],
+    *,
+    root: Path | None,
+    remove_unresolved: bool,
+) -> set[str]:
+    path_to_file_nid = _tab_file_node_index(nodes, root)
+    redirected_stub_ids: set[str] = set()
+    for edge in edges:
+        target_ref = edge.get("target_ref")
+        if not target_ref or edge.get("relation") != "references":
+            continue
+        source_file = edge.get("source_file")
+        if not source_file:
+            if remove_unresolved:
+                edge.pop("target_ref", None)
+            continue
+        tab_path = _tab_source_path(source_file, root)
+        for candidate in _tab_path_candidates(tab_path, target_ref):
+            target_nid = path_to_file_nid.get(str(candidate.resolve()))
+            if target_nid:
+                redirected_stub_ids.add(edge["target"])
+                edge["target"] = target_nid
+                edge.pop("target_ref", None)
+                break
+        else:
+            if remove_unresolved:
+                edge.pop("target_ref", None)
+    return redirected_stub_ids
+
+
+def _tab_value_columns(
+    headers: list[tuple[str, str]],
+    rows: list[list[str]],
+    identity_idx: int | None,
+) -> set[int]:
+    selected: set[int] = set()
+    row_count = max(len(rows), 1)
+    max_unique = min(20, max(2, int(row_count * 0.2)))
+    for idx, _ in enumerate(headers):
+        if idx == identity_idx:
+            continue
+        values = [r[idx].strip() for r in rows if idx < len(r) and r[idx].strip()]
+        if not values:
+            continue
+        unique_values = set(values)
+        if len(unique_values) <= 1:
+            continue
+        if len(unique_values) > max_unique:
+            continue
+        if any(len(v) > 80 for v in unique_values):
+            continue
+        if any(_looks_like_tab_path(v) for v in unique_values):
+            continue
+        selected.add(idx)
+    return selected
+
+
+def extract_tab(path: Path) -> dict:
+    """Extract structural nodes and edges from a generic tab-delimited file."""
+    try:
+        text, warnings, truncated = _read_tab_text(path)
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": f"{type(e).__name__}: {e}"}
+
+    str_path = str(path)
+    stem = _file_stem(path)
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen_ids: set[str] = set()
+
+    def add_node(
+        nid: str,
+        label: str,
+        file_type: str,
+        line: int,
+        extra: dict | None = None,
+    ) -> None:
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            node = {
+                "id": nid,
+                "label": label,
+                "file_type": file_type,
+                "source_file": str_path,
+                "source_location": f"L{line}",
+            }
+            if extra:
+                node.update(extra)
+            nodes.append(node)
+
+    def add_edge(
+        src: str,
+        tgt: str,
+        relation: str,
+        line: int,
+        context: str,
+        extra: dict | None = None,
+    ) -> None:
+        edge = {
+            "source": src,
+            "target": tgt,
+            "relation": relation,
+            "context": context,
+            "confidence": "EXTRACTED",
+            "source_file": str_path,
+            "source_location": f"L{line}",
+            "weight": 1.0,
+        }
+        if extra:
+            edge.update(extra)
+        edges.append(edge)
+
+    def finish_result() -> dict:
+        result = {"nodes": nodes, "edges": edges, "input_tokens": 0, "output_tokens": 0}
+        if warnings:
+            print(
+                f"  warning: {path} indexed with limits: {'; '.join(warnings)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            result["warnings"] = warnings
+        if truncated:
+            result["truncated"] = True
+        return result
+
+    file_nid = _make_id(str(path))
+    add_node(file_nid, path.name, "code", 1)
+
+    reader = csv.reader(StringIO(text), delimiter="\t")
+    parsed = list(reader)
+    if not parsed:
+        return finish_result()
+
+    raw_headers = parsed[0][:_TAB_MAX_COLUMNS]
+    headers = _normalise_tab_headers(raw_headers)
+    rows = parsed[1:_TAB_MAX_ROWS + 1]
+    max_width = min(_TAB_MAX_COLUMNS, max([len(raw_headers), *(len(r) for r in rows)] or [0]))
+    if max_width == 0:
+        return finish_result()
+    while len(headers) < max_width:
+        idx = len(headers) + 1
+        extra_idx = idx - len(raw_headers)
+        headers.append((f"extra_{extra_idx}", f"extra_{extra_idx}"))
+    rows = [_pad_tab_row(r[:max_width], max_width) for r in rows]
+
+    if len(parsed) - 1 > _TAB_MAX_ROWS:
+        warnings.append(f"indexed first {_TAB_MAX_ROWS} rows")
+        truncated = True
+    if max((len(r) for r in parsed if r), default=0) > _TAB_MAX_COLUMNS:
+        warnings.append(f"indexed first {_TAB_MAX_COLUMNS} columns")
+        truncated = True
+
+    for _idx, (key, label) in enumerate(headers, start=1):
+        col_nid = _make_id(stem, "column", key)
+        add_node(col_nid, f"{label} (column)", "code", 1)
+        add_edge(file_nid, col_nid, "contains", 1, "table")
+
+    identity_idx = _choose_tab_identity(headers, rows)
+    value_columns = _tab_value_columns(headers, rows, identity_idx)
+    value_node_count = 0
+    value_node_skipped = False
+    path_ref_count = 0
+    path_ref_skipped = False
+    for row_offset, row in enumerate(rows, start=2):
+        row_label = f"row {row_offset}"
+        if identity_idx is not None and identity_idx < len(row):
+            value = row[identity_idx].strip()
+            if value:
+                identity_label = headers[identity_idx][1]
+                row_label = f"{identity_label} {value}"
+        row_nid = _make_id(stem, "row", str(row_offset), row_label)
+        add_node(row_nid, row_label, "code", row_offset)
+        add_edge(file_nid, row_nid, "contains", row_offset, "table")
+        for cell in row:
+            if not _looks_like_tab_path(cell):
+                continue
+            if path_ref_count >= _TAB_MAX_PATH_REFS:
+                path_ref_skipped = True
+                continue
+            ref_nid, ref_label, ref_source, target_ref = _tab_reference_node(cell, path)
+            if ref_nid not in seen_ids:
+                seen_ids.add(ref_nid)
+                nodes.append({
+                    "id": ref_nid,
+                    "label": ref_label,
+                    "file_type": "code",
+                    "source_file": ref_source,
+                    "source_location": f"L{row_offset}",
+                })
+            add_edge(row_nid, ref_nid, "references", row_offset, "path", {"target_ref": target_ref})
+            path_ref_count += 1
+        for idx in value_columns:
+            if idx >= len(row):
+                continue
+            value = row[idx].strip()
+            if not value:
+                continue
+            header_label = headers[idx][1]
+            value_label = f"{header_label}={value}"
+            value_nid = _make_id(stem, "value", header_label, value)
+            if value_nid not in seen_ids:
+                if value_node_count >= _TAB_MAX_VALUE_NODES:
+                    value_node_skipped = True
+                    continue
+                add_node(value_nid, value_label, "concept", row_offset, {"context": "table_value"})
+                value_node_count += 1
+            add_edge(row_nid, value_nid, "sets", row_offset, "value")
+
+    if path_ref_skipped:
+        warnings.append(f"indexed first {_TAB_MAX_PATH_REFS} path references")
+        truncated = True
+    if value_node_skipped:
+        warnings.append(f"indexed first {_TAB_MAX_VALUE_NODES} value nodes")
+        truncated = True
+
+    return finish_result()
+
+
 _DISPATCH: dict[str, Any] = {
     ".py": extract_python,
     ".js": extract_js,
@@ -7345,14 +7739,16 @@ _DISPATCH: dict[str, Any] = {
     ".sh": extract_bash,
     ".bash": extract_bash,
     ".json": extract_json,
+    ".tab": extract_tab,
+    ".TAB": extract_tab,
 }
 
 
 def _get_extractor(path: Path) -> Any | None:
     """Return the correct extractor function for a file, or None if unsupported."""
-    if path.name.endswith(".blade.php"):
+    if path.name.lower().endswith(".blade.php"):
         return extract_blade
-    return _DISPATCH.get(path.suffix)
+    return _DISPATCH.get(path.suffix.lower())
 
 
 def _extract_single_file(args: tuple) -> tuple[int, dict]:
@@ -7508,6 +7904,7 @@ def extract(
     *,
     parallel: bool = True,
     max_workers: int | None = None,
+    preserve_tab_target_refs: bool = False,
 ) -> dict:
     """Extract AST nodes and edges from a list of code files.
 
@@ -7548,11 +7945,11 @@ def extract(
             root = Path(*paths[0].parts[:common_len]) if common_len else Path(".")
     except Exception:
         root = Path(".")
-    if cache_root is not None:
-        root = cache_root
     root = root.resolve()
 
-    effective_root = cache_root or root
+    effective_root = (cache_root or root).resolve()
+    if cache_root is not None:
+        root = effective_root
     total = len(paths)
 
     # Phase 1: separate cached hits from uncached work
@@ -7620,6 +8017,21 @@ def extract(
     _merge_swift_extensions(per_file, all_nodes, all_edges)
     _disambiguate_colliding_node_ids(all_nodes, all_edges, all_raw_calls, root)
     _rewire_unique_stub_nodes(all_nodes, all_edges)
+
+    # .tab extraction emits path references as tab-owned stubs so incremental
+    # rebuilds cannot overwrite richer scanned file nodes. When the referenced
+    # file is part of this aggregate extraction, redirect the edge to the real
+    # file node and drop the transient stub before later graph analysis. Watch
+    # changed-file rebuilds keep unresolved target_ref metadata until preserved
+    # nodes have been merged.
+    redirected_tab_stub_ids = _redirect_tab_reference_edges(
+        all_nodes,
+        all_edges,
+        root=root,
+        remove_unresolved=not preserve_tab_target_refs,
+    )
+    if redirected_tab_stub_ids:
+        all_nodes = [n for n in all_nodes if n.get("id") not in redirected_tab_stub_ids]
 
     # Add cross-file class-level edges (Python only - uses Python parser internally)
     py_paths = [p for p in paths if p.suffix == ".py"]

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -324,7 +324,7 @@ def _rebuild_code(
     project_root = Path.cwd().resolve() if not watch_path.is_absolute() else watch_root
     report_root = _report_root_label(watch_path)
     try:
-        from graphify.extract import extract, _get_extractor
+        from graphify.extract import extract, _get_extractor, _redirect_tab_reference_edges
         from graphify.detect import detect
         from graphify.build import build_from_json
         from graphify.cluster import cluster, remap_communities_to_previous, score_all
@@ -373,7 +373,11 @@ def _rebuild_code(
             extract_targets = code_files
 
         commit = _git_head()
-        result = extract(extract_targets, cache_root=watch_root) if extract_targets else {
+        result = extract(
+            extract_targets,
+            cache_root=watch_root,
+            preserve_tab_target_refs=changed_paths is not None,
+        ) if extract_targets else {
             "nodes": [], "edges": [], "hyperedges": [],
             "input_tokens": 0, "output_tokens": 0,
         }
@@ -420,6 +424,18 @@ def _rebuild_code(
                 }
             except Exception:
                 pass  # corrupt graph.json - proceed with AST-only
+
+        redirected_tab_stub_ids = _redirect_tab_reference_edges(
+            result["nodes"],
+            result["edges"],
+            root=project_root,
+            remove_unresolved=True,
+        )
+        if redirected_tab_stub_ids:
+            result["nodes"] = [
+                n for n in result["nodes"]
+                if n.get("id") not in redirected_tab_stub_ids
+            ]
 
         _relativize_source_files(result, project_root)
         out.mkdir(exist_ok=True)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -9,6 +9,12 @@ def test_classify_python():
 def test_classify_typescript():
     assert classify_file(Path("bar.ts")) == FileType.CODE
 
+def test_classify_tab_as_code():
+    assert classify_file(Path("config.tab")) == FileType.CODE
+
+def test_classify_uppercase_tab_as_code():
+    assert classify_file(Path("CONFIG.TAB")) == FileType.CODE
+
 def test_classify_markdown():
     assert classify_file(Path("README.md")) == FileType.DOCUMENT
 

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -1,0 +1,444 @@
+"""Tests for generic .tab structured extraction."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.extract import _make_id, collect_files, extract, extract_tab
+from graphify.validate import validate_extraction
+
+
+def labels(result: dict) -> set[str]:
+    return {n["label"] for n in result["nodes"]}
+
+
+def relations(result: dict) -> set[str]:
+    return {e["relation"] for e in result["edges"]}
+
+
+def edge_labels(result: dict, relation: str) -> set[tuple[str, str]]:
+    by_id = {n["id"]: n["label"] for n in result["nodes"]}
+    return {
+        (by_id.get(e["source"], e["source"]), by_id.get(e["target"], e["target"]))
+        for e in result["edges"]
+        if e["relation"] == relation
+    }
+
+
+def test_uppercase_tab_dispatches_to_extractor(tmp_path):
+    path = tmp_path / "CONFIG.TAB"
+    path.write_text("ID\tName\n1\tAlpha\n", encoding="utf-8")
+
+    result = extract([path], cache_root=tmp_path, parallel=False)
+
+    assert "CONFIG.TAB" in labels(result)
+    assert "ID (column)" in labels(result)
+    assert "ID 1" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_collect_files_includes_uppercase_tab(tmp_path):
+    path = tmp_path / "CONFIG.TAB"
+    path.write_text("ID\tName\n1\tAlpha\n", encoding="utf-8")
+
+    assert path in collect_files(tmp_path)
+
+
+def test_extract_tab_finds_file_columns_and_rows(tmp_path):
+    path = tmp_path / "sample.tab"
+    path.write_text("ID\tName\tMode\n1\tAlpha\tactive\n2\tBeta\tinactive\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "sample.tab" in labels(result)
+    assert "ID (column)" in labels(result)
+    assert "Name (column)" in labels(result)
+    assert "Mode (column)" in labels(result)
+    assert "ID 1" in labels(result)
+    assert "ID 2" in labels(result)
+    assert "contains" in relations(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_decodes_gb18030(tmp_path):
+    path = tmp_path / "sample_gb18030.tab"
+    body = "AIType\tScriptFile\tIsPositive\n17673\tscripts\\Map\\成都\\ai\\动物表现\\动物逃跑.lua\t0\n"
+    path.write_bytes(body.encode("gb18030"))
+
+    result = extract_tab(path)
+
+    assert "AIType 17673" in labels(result)
+    assert "ScriptFile (column)" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_decodes_utf8_bom(tmp_path):
+    path = tmp_path / "bom.tab"
+    path.write_bytes("ID\tName\n1\tAlpha\n".encode("utf-8-sig"))
+
+    result = extract_tab(path)
+
+    assert "ID 1" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_handles_crlf(tmp_path):
+    path = tmp_path / "crlf.tab"
+    path.write_bytes(b"ID\tName\r\n1\tAlpha\r\n")
+
+    result = extract_tab(path)
+
+    assert "ID 1" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_header_only_file(tmp_path):
+    path = tmp_path / "header-only.tab"
+    path.write_text("ID\tName\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "ID (column)" in labels(result)
+    assert "Name (column)" in labels(result)
+    assert "ID 1" not in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_single_column_file(tmp_path):
+    path = tmp_path / "single-column.tab"
+    path.write_text("Name\nAlpha\nBeta\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "Name (column)" in labels(result)
+    assert "Name Alpha" in labels(result)
+    assert "Name Beta" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_falls_back_to_line_number_when_no_identity_column(tmp_path):
+    path = tmp_path / "no-identity.tab"
+    path.write_text("A\tB\nx\t1\nx\t1\n\t\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "row 2" in labels(result)
+    assert "row 3" in labels(result)
+    assert "row 4" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_handles_ragged_rows(tmp_path):
+    path = tmp_path / "ragged.tab"
+    path.write_text("ID\tName\n1\tAlpha\tExtra\n2\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "ID 1" in labels(result)
+    assert "ID 2" in labels(result)
+    assert "extra_1 (column)" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_falls_back_to_line_number_for_empty_identity(tmp_path):
+    path = tmp_path / "empty-id.tab"
+    path.write_text("ID\tName\n\tAlpha\n2\tBeta\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "row 2" in labels(result)
+    assert "ID 2" in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_empty_file_returns_file_node_only(tmp_path):
+    path = tmp_path / "empty.tab"
+    path.write_text("", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert labels(result) == {"empty.tab"}
+    assert result["edges"] == []
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_blank_file_returns_file_node_only(tmp_path):
+    path = tmp_path / "blank.tab"
+    path.write_text("\n\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert labels(result) == {"blank.tab"}
+    assert result["edges"] == []
+    assert validate_extraction(result) == []
+
+
+def test_extract_tab_normalizes_empty_and_duplicate_headers(tmp_path):
+    path = tmp_path / "headers.tab"
+    path.write_text("\tName\tName\n1\tAlpha\tBeta\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "column_1 (column)" in labels(result)
+    assert len([n for n in result["nodes"] if n["label"] == "Name (column)"]) == 2
+    assert validate_extraction(result) == []
+
+
+def test_path_like_cells_emit_references_to_existing_file(tmp_path):
+    scripts = tmp_path / "scripts" / "ai"
+    scripts.mkdir(parents=True)
+    target = scripts / "StandardAI.lua"
+    target.write_text("function tick() end\n", encoding="utf-8")
+    tab = tmp_path / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/StandardAI.lua\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert ("ID 1", "StandardAI.lua") in edge_labels(result, "references")
+    target_nodes = [n for n in result["nodes"] if n["label"] == "StandardAI.lua"]
+    assert target_nodes
+    assert target_nodes[0]["source_file"] == str(tab)
+    assert _make_id(str(target)) not in {n["id"] for n in result["nodes"]}
+    assert validate_extraction(result) == []
+
+
+def test_path_reference_connects_to_scanned_file_node(tmp_path):
+    scripts = tmp_path / "scripts" / "ai"
+    scripts.mkdir(parents=True)
+    target = scripts / "StandardAI.lua"
+    target.write_text("function tick() end\n", encoding="utf-8")
+    tab = tmp_path / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/StandardAI.lua\n", encoding="utf-8")
+
+    result = extract([tab, target], cache_root=tmp_path, parallel=False)
+
+    target_file_ids = {
+        n["id"]
+        for n in result["nodes"]
+        if n["label"] == "StandardAI.lua" and n["source_file"].endswith("scripts/ai/StandardAI.lua")
+    }
+    assert target_file_ids
+    assert any(
+        e["target"] in target_file_ids
+        for e in result["edges"]
+        if e["relation"] == "references"
+    )
+    assert not any(e.get("target_ref") for e in result["edges"])
+    assert not any(
+        n["label"] == "StandardAI.lua" and n["source_file"].endswith("ai.tab")
+        for n in result["nodes"]
+    )
+    assert validate_extraction(result) == []
+
+
+def test_path_reference_resolves_against_project_root_fallback(tmp_path):
+    (tmp_path / ".git").mkdir()
+    scripts = tmp_path / "scripts" / "ai"
+    scripts.mkdir(parents=True)
+    target = scripts / "StandardAI.lua"
+    target.write_text("function tick() end\n", encoding="utf-8")
+    config_dir = tmp_path / "data" / "config"
+    config_dir.mkdir(parents=True)
+    tab = config_dir / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/StandardAI.lua\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert ("ID 1", "StandardAI.lua") in edge_labels(result, "references")
+    target_nodes = [n for n in result["nodes"] if n["label"] == "StandardAI.lua"]
+    assert target_nodes
+    assert target_nodes[0]["source_file"] == str(tab)
+    assert _make_id(str(target)) not in {n["id"] for n in result["nodes"]}
+    assert validate_extraction(result) == []
+
+
+def test_project_root_path_reference_connects_to_scanned_file_node(tmp_path):
+    (tmp_path / ".git").mkdir()
+    scripts = tmp_path / "scripts" / "ai"
+    scripts.mkdir(parents=True)
+    target = scripts / "StandardAI.lua"
+    target.write_text("function tick() end\n", encoding="utf-8")
+    config_dir = tmp_path / "data" / "config"
+    config_dir.mkdir(parents=True)
+    tab = config_dir / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/StandardAI.lua\n", encoding="utf-8")
+
+    result = extract([tab, target], cache_root=tmp_path, parallel=False)
+
+    target_file_ids = {
+        n["id"]
+        for n in result["nodes"]
+        if n["label"] == "StandardAI.lua" and n["source_file"].endswith("scripts/ai/StandardAI.lua")
+    }
+    assert target_file_ids
+    assert any(
+        e["target"] in target_file_ids
+        for e in result["edges"]
+        if e["relation"] == "references"
+    )
+    assert not any(e.get("target_ref") for e in result["edges"])
+    assert not any(
+        n["label"] == "StandardAI.lua" and n["source_file"].endswith("ai.tab")
+        for n in result["nodes"]
+    )
+    assert validate_extraction(result) == []
+
+
+def test_path_like_cells_emit_stub_for_missing_file(tmp_path):
+    tab = tmp_path / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/MissingAI.lua\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert ("ID 1", "scripts/ai/MissingAI.lua") in edge_labels(result, "references")
+    stub_nodes = [n for n in result["nodes"] if n["label"] == "scripts/ai/MissingAI.lua"]
+    assert stub_nodes
+    assert stub_nodes[0]["source_file"] == str(tab)
+    assert validate_extraction(result) == []
+
+
+def test_existing_absolute_path_is_kept_as_tab_owned_stub(tmp_path):
+    outside = tmp_path.parent / "OutsideAI.lua"
+    outside.write_text("function tick() end\n", encoding="utf-8")
+    tab = tmp_path / "ai.tab"
+    tab.write_text(f"ID\tScript\n1\t{outside}\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert ("ID 1", str(outside)) in edge_labels(result, "references")
+    stub_nodes = [n for n in result["nodes"] if n["label"] == str(outside)]
+    assert stub_nodes
+    assert stub_nodes[0]["source_file"] == str(tab)
+    assert str(outside) not in {n["source_file"] for n in result["nodes"]}
+    assert validate_extraction(result) == []
+
+
+def test_parent_traversal_path_is_kept_as_tab_owned_stub(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "OutsideAI.lua").write_text("function tick() end\n", encoding="utf-8")
+    config_dir = project / "data" / "config"
+    config_dir.mkdir(parents=True)
+    tab = config_dir / "ai.tab"
+    tab.write_text("ID\tScript\n1\t../../../outside/OutsideAI.lua\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert ("ID 1", "../../../outside/OutsideAI.lua") in edge_labels(result, "references")
+    stub_nodes = [n for n in result["nodes"] if n["label"] == "../../../outside/OutsideAI.lua"]
+    assert stub_nodes
+    assert stub_nodes[0]["source_file"] == str(tab)
+    assert str(outside / "OutsideAI.lua") not in {n["source_file"] for n in result["nodes"]}
+    assert validate_extraction(result) == []
+
+
+def test_url_values_are_not_local_path_references(tmp_path):
+    tab = tmp_path / "urls.tab"
+    tab.write_text("ID\tUrl\n1\thttps://cdn.example.com/config.json\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert "https://cdn.example.com/config.json" not in labels(result)
+    assert "references" not in relations(result)
+    assert validate_extraction(result) == []
+
+
+def test_path_columns_do_not_create_value_nodes(tmp_path):
+    tab = tmp_path / "paths.tab"
+    tab.write_text(
+        "ID\tScript\n"
+        "1\tscripts/ai/A.lua\n"
+        "2\tscripts/ai/B.lua\n"
+        "3\tscripts/ai/A.lua\n",
+        encoding="utf-8",
+    )
+
+    result = extract_tab(tab)
+
+    assert "Script=scripts/ai/A.lua" not in labels(result)
+    assert "Script=scripts/ai/B.lua" not in labels(result)
+    assert "references" in relations(result)
+    assert validate_extraction(result) == []
+
+
+def test_backslash_paths_are_normalized(tmp_path):
+    tab = tmp_path / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts\\Map\\成都\\ai\\动物表现\\动物逃跑.lua\n", encoding="utf-8")
+
+    result = extract_tab(tab)
+
+    assert any("scripts/Map/成都/ai/动物表现/动物逃跑.lua" == label for label in labels(result))
+    assert "references" in relations(result)
+    assert validate_extraction(result) == []
+
+
+def test_low_cardinality_non_constant_values_emit_sets_edges(tmp_path):
+    path = tmp_path / "modes.tab"
+    path.write_text("ID\tMode\n1\tactive\n2\tinactive\n3\tactive\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "Mode=active" in labels(result)
+    assert "Mode=inactive" in labels(result)
+    value_nodes = [n for n in result["nodes"] if n["label"] == "Mode=active"]
+    assert value_nodes[0].get("context") == "table_value"
+    assert "sets" in relations(result)
+    assert validate_extraction(result) == []
+
+
+def test_constant_columns_do_not_create_value_hubs(tmp_path):
+    path = tmp_path / "constant.tab"
+    path.write_text("ID\tAlertRange\n1\t768\n2\t768\n3\t768\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "AlertRange=768" not in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_high_cardinality_columns_do_not_create_value_nodes(tmp_path):
+    path = tmp_path / "high-cardinality.tab"
+    rows = ["ID\tName"] + [f"{i}\tName{i}" for i in range(1, 31)]
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert "Name=Name1" not in labels(result)
+    assert validate_extraction(result) == []
+
+
+def test_tab_row_cap_sets_warning_not_error(tmp_path, monkeypatch, capsys):
+    import graphify.extract as gx
+
+    monkeypatch.setattr(gx, "_TAB_MAX_ROWS", 2)
+    path = tmp_path / "large.tab"
+    path.write_text("ID\tName\n1\tA\n2\tB\n3\tC\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert result.get("truncated") is True
+    assert "warnings" in result
+    assert "error" not in result
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert validate_extraction(result) == []
+
+
+def test_tab_byte_cap_does_not_decode_partial_record(tmp_path, monkeypatch, capsys):
+    import graphify.extract as gx
+
+    monkeypatch.setattr(gx, "_TAB_MAX_BYTES", 4)
+    path = tmp_path / "partial.tab"
+    path.write_text("ID\tName\n1\tAlpha\n", encoding="utf-8")
+
+    result = extract_tab(path)
+
+    assert labels(result) == {"partial.tab"}
+    assert result["edges"] == []
+    assert result.get("truncated") is True
+    assert "error" not in result
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert validate_extraction(result) == []

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,4 +1,5 @@
 """Tests for watch.py - file watcher helpers (no watchdog required)."""
+import json
 import os
 import sys
 import time
@@ -36,6 +37,7 @@ def test_watched_extensions_includes_code():
     assert ".ts" in _WATCHED_EXTENSIONS
     assert ".go" in _WATCHED_EXTENSIONS
     assert ".rs" in _WATCHED_EXTENSIONS
+    assert ".tab" in _WATCHED_EXTENSIONS
 
 def test_watched_extensions_includes_docs():
     assert ".md" in _WATCHED_EXTENSIONS
@@ -208,6 +210,46 @@ def test_rebuild_code_skips_cluster_when_topology_unchanged(tmp_path, monkeypatc
     assert _rebuild_code(tmp_path)
     assert _rebuild_code(tmp_path)
     assert calls["n"] == 1
+
+
+def test_rebuild_code_changed_tab_keeps_reference_connected_to_preserved_file(tmp_path):
+    from graphify.watch import _rebuild_code
+
+    (tmp_path / ".git").mkdir()
+    scripts = tmp_path / "scripts" / "ai"
+    scripts.mkdir(parents=True)
+    target = scripts / "StandardAI.lua"
+    target.write_text("function tick() end\n", encoding="utf-8")
+    config_dir = tmp_path / "data" / "config"
+    config_dir.mkdir(parents=True)
+    tab = config_dir / "ai.tab"
+    tab.write_text("ID\tScript\n1\tscripts/ai/StandardAI.lua\n", encoding="utf-8")
+
+    assert _rebuild_code(tmp_path, no_cluster=True, force=True)
+
+    tab.write_text(
+        "ID\tScript\n"
+        "1\tscripts/ai/StandardAI.lua\n"
+        "2\tscripts/ai/StandardAI.lua\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(tmp_path, changed_paths=[tab], no_cluster=True, force=True)
+
+    graph = json.loads((tmp_path / "graphify-out" / "graph.json").read_text(encoding="utf-8"))
+    target_ids = {
+        n["id"]
+        for n in graph["nodes"]
+        if n["label"] == "StandardAI.lua" and n["source_file"] == "scripts/ai/StandardAI.lua"
+    }
+    assert target_ids
+    reference_edges = [e for e in graph["links"] if e["relation"] == "references"]
+    assert reference_edges
+    assert all(e["target"] in target_ids for e in reference_edges)
+    assert not any(e.get("target_ref") for e in graph["links"])
+    assert not any(
+        n["label"] == "StandardAI.lua" and n["source_file"].endswith("ai.tab")
+        for n in graph["nodes"]
+    )
 
 
 # --- .graphifyignore honored in watch handler (gh-928) ---


### PR DESCRIPTION
## Summary

Adds generic structured extraction for `.tab` files and wires the new file type through graphify's detect -> extract -> watch -> build flow.

## Why

Some projects use tab-delimited configuration files as code-adjacent artifacts rather than plain documents. These files often define entities, columns, row identities, enum-like values, and references to scripts such as Lua AI behavior files. Treating `.tab` files as unsupported input misses important graph edges between configuration and executable code.

The implementation intentionally does not require schema-specific headers such as `AIType` or `ScriptFile`, because real `.tab` files can use many different schemas. Instead, it extracts generic table structure and path-like references while keeping false positives bounded.

## How

- Classifies `.tab`/`.TAB` as code and includes them in collection and watch rebuilds.
- Adds `extract_tab()` to parse tab-delimited files with UTF-8 BOM, UTF-8, and GB18030 decoding.
- Emits file, column, row, low-cardinality value, and path reference nodes/edges.
- Avoids treating URL values as local path references.
- Keeps direct `.tab` extraction references as tab-owned stubs so incremental rebuilds cannot overwrite richer scanned file nodes.
- Redirects `.tab` reference edges to real scanned file nodes during aggregate extraction and after watch incremental preserved-node merging.
- Rejects absolute and parent-traversal path resolution as real local targets to avoid out-of-corpus node pollution.

## Review Notes

The main subtlety is path references. A `.tab` cell may point at `scripts/ai/StandardAI.lua`. If that Lua file is scanned in the same graph, the final `references` edge should point to the Lua file node. If only the `.tab` file is rebuilt incrementally, the temporary tab-owned stub must not replace the preserved Lua node. This PR handles both cases with a two-stage redirect:

- `extract_tab()` emits a tab-owned reference stub plus temporary `target_ref` metadata.
- `extract()` and `watch._rebuild_code()` redirect the edge to a real scanned/preserved file node when available, then drop the temporary stub/metadata.

## Validation

- `uv run pytest tests/test_detect.py tests/test_watch.py tests/test_tab.py -q`
  - `146 passed, 2 skipped`
- `uv run python -m compileall graphify tests -q`
  - passed
- `uv run pytest tests/ -q`
  - `1285 passed, 7 failed`
  - The remaining failures are all in `tests/test_security.py`; in this local environment, `example.com` and `arxiv.org` resolve to `198.18.x.x`, so the existing SSRF protection rejects them as private/internal IPs before mocked fetch behavior is reached.
