### PR TITLE
feat: detect circular import dependencies at file level

### DIFF
--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -606,3 +606,88 @@ def graph_diff(G_old: nx.Graph, G_new: nx.Graph) -> dict:
         "removed_edges": removed_edges_list,
         "summary": summary,
     }
+
+
+def find_import_cycles(
+    G: nx.Graph,
+    max_cycle_length: int = 5,
+    top_n: int = 20,
+) -> list[list[str]]:
+    """Detect circular import dependencies at the file level.
+
+    Collapses symbol-level nodes to their parent file (using source_file attr
+    or 'contains' edges), builds a directed file-level graph from imports_from
+    edges, then finds simple cycles.
+
+    Args:
+        G: The full knowledge graph (may be undirected or directed).
+        max_cycle_length: Only report cycles with at most this many files.
+        top_n: Maximum number of cycles to return (shortest first).
+
+    Returns:
+        List of cycles, each cycle being a list of file paths forming the loop.
+        Example: [["a.ts", "b.ts", "a.ts"]] means a imports b and b imports a.
+    """
+    # Step 1: Build a directed file-level graph from imports_from edges.
+    file_graph = nx.DiGraph()
+
+    for u, v, data in G.edges(data=True):
+        rel = data.get("relation", "")
+        if rel not in ("imports_from", "re_exports"):
+            continue
+        # Get source files for the edge endpoints
+        src_file = data.get("source_file", "")
+        # Target: resolve from node attributes (the imported file)
+        tgt_attrs = G.nodes.get(v, {})
+        tgt_file = tgt_attrs.get("source_file", "")
+
+        # For imports_from, the target node IS the file node (its label is the filename).
+        # If no source_file attr, use the node label as the file identity.
+        if not tgt_file:
+            tgt_label = tgt_attrs.get("label", v)
+            # If label looks like a filename, use it
+            if "." in tgt_label:
+                tgt_file = tgt_label
+            else:
+                tgt_file = v
+
+        if src_file and tgt_file and src_file != tgt_file:
+            file_graph.add_edge(src_file, tgt_file)
+
+    if not file_graph.edges():
+        return []
+
+    # Step 2: Find simple cycles, bounded by length.
+    cycles: list[list[str]] = []
+    try:
+        for cycle in nx.simple_cycles(file_graph):
+            if len(cycle) <= max_cycle_length:
+                # Append the first node at the end to show the loop
+                cycles.append(cycle + [cycle[0]])
+            if len(cycles) >= top_n * 10:
+                # Stop early to avoid combinatorial explosion
+                break
+    except Exception:
+        return []
+
+    # Step 3: Sort by length (shortest = tightest coupling), then deduplicate.
+    cycles.sort(key=len)
+
+    # Deduplicate rotations: normalize each cycle by starting from the
+    # lexicographically smallest element.
+    seen: set[tuple[str, ...]] = set()
+    unique_cycles: list[list[str]] = []
+    for cycle in cycles:
+        # Remove trailing repeated element for normalization
+        core = cycle[:-1]
+        if not core:
+            continue
+        min_idx = core.index(min(core))
+        normalized = tuple(core[min_idx:] + core[:min_idx])
+        if normalized not in seen:
+            seen.add(normalized)
+            unique_cycles.append(list(normalized) + [normalized[0]])
+            if len(unique_cycles) >= top_n:
+                break
+
+    return unique_cycles

--- a/graphify/analyze.py
+++ b/graphify/analyze.py
@@ -612,7 +612,7 @@ def find_import_cycles(
     G: nx.Graph,
     max_cycle_length: int = 5,
     top_n: int = 20,
-) -> list[list[str]]:
+) -> list[dict]:
     """Detect circular import dependencies at the file level.
 
     Collapses symbol-level nodes to their parent file (using source_file attr
@@ -625,50 +625,62 @@ def find_import_cycles(
         top_n: Maximum number of cycles to return (shortest first).
 
     Returns:
-        List of cycles, each cycle being a list of file paths forming the loop.
-        Example: [["a.ts", "b.ts", "a.ts"]] means a imports b and b imports a.
+        List of cycle records with stable structure:
+        {
+          "cycle": ["a.ts", "b.ts"],
+          "length": 2,
+          "why": "circular dependency"
+        }
     """
-    # Step 1: Build a directed file-level graph from imports_from edges.
+    def _endpoint_source_file(node_id: str) -> str:
+        attrs = G.nodes.get(node_id, {})
+        src_file = attrs.get("source_file", "")
+        return src_file if isinstance(src_file, str) else ""
+
+    # Step 1: Build a directed file-level graph from import/re-export edges.
+    # IMPORTANT: resolve endpoints using source_file only; never infer from label/id.
     file_graph = nx.DiGraph()
 
     for u, v, data in G.edges(data=True):
         rel = data.get("relation", "")
         if rel not in ("imports_from", "re_exports"):
             continue
-        # Get source files for the edge endpoints
-        src_file = data.get("source_file", "")
-        # Target: resolve from node attributes (the imported file)
-        tgt_attrs = G.nodes.get(v, {})
-        tgt_file = tgt_attrs.get("source_file", "")
 
-        # For imports_from, the target node IS the file node (its label is the filename).
-        # If no source_file attr, use the node label as the file identity.
+        src_file_attr = data.get("source_file", "")
+        if not isinstance(src_file_attr, str) or not src_file_attr:
+            continue
+
+        u_file = _endpoint_source_file(u)
+        v_file = _endpoint_source_file(v)
+
+        # Works for both DiGraph and Graph inputs:
+        # orient edge from edge.source_file endpoint to the opposite endpoint.
+        if u_file == src_file_attr:
+            tgt_file = v_file
+        elif v_file == src_file_attr:
+            tgt_file = u_file
+        else:
+            # Fallback: if source endpoint cannot be matched exactly,
+            # still treat edge.source_file as source and pick the opposite endpoint
+            # only if one endpoint has a real source_file.
+            tgt_file = v_file if v_file and v_file != src_file_attr else u_file
+
         if not tgt_file:
-            tgt_label = tgt_attrs.get("label", v)
-            # If label looks like a filename, use it
-            if "." in tgt_label:
-                tgt_file = tgt_label
-            else:
-                tgt_file = v
+            continue
 
-        if src_file and tgt_file and src_file != tgt_file:
-            file_graph.add_edge(src_file, tgt_file)
+        file_graph.add_edge(src_file_attr, tgt_file)
 
     if not file_graph.edges():
         return []
 
     # Step 2: Find simple cycles, bounded by length.
     cycles: list[list[str]] = []
-    try:
-        for cycle in nx.simple_cycles(file_graph):
-            if len(cycle) <= max_cycle_length:
-                # Append the first node at the end to show the loop
-                cycles.append(cycle + [cycle[0]])
-            if len(cycles) >= top_n * 10:
-                # Stop early to avoid combinatorial explosion
-                break
-    except Exception:
-        return []
+    for cycle in nx.simple_cycles(file_graph):
+        if len(cycle) <= max_cycle_length:
+            cycles.append(cycle)
+        if len(cycles) >= top_n * 10:
+            # Stop early to avoid combinatorial explosion
+            break
 
     # Step 3: Sort by length (shortest = tightest coupling), then deduplicate.
     cycles.sort(key=len)
@@ -678,16 +690,23 @@ def find_import_cycles(
     seen: set[tuple[str, ...]] = set()
     unique_cycles: list[list[str]] = []
     for cycle in cycles:
-        # Remove trailing repeated element for normalization
-        core = cycle[:-1]
+        core = list(cycle)
         if not core:
             continue
         min_idx = core.index(min(core))
         normalized = tuple(core[min_idx:] + core[:min_idx])
         if normalized not in seen:
             seen.add(normalized)
-            unique_cycles.append(list(normalized) + [normalized[0]])
+            unique_cycles.append(list(normalized))
             if len(unique_cycles) >= top_n:
                 break
 
-    return unique_cycles
+    result: list[dict] = []
+    for cycle in unique_cycles:
+        result.append({
+            "cycle": cycle,
+            "length": len(cycle),
+            "why": "circular dependency",
+        })
+
+    return result

--- a/graphify/report.py
+++ b/graphify/report.py
@@ -119,6 +119,21 @@ def generate(
     else:
         lines.append("- None detected - all connections are within the same source files.")
 
+    # Circular imports surfaced from file-level dependency graph.
+    from .analyze import find_import_cycles
+    cycles = find_import_cycles(G)
+    lines += ["", "## Import Cycles"]
+    if cycles:
+        for c in cycles:
+            cycle = c.get("cycle", [])
+            length = c.get("length", len(cycle))
+            if not cycle:
+                continue
+            cycle_path = " -> ".join(cycle + [cycle[0]])
+            lines.append(f"- {length}-file cycle: `{cycle_path}`")
+    else:
+        lines.append("- None detected.")
+
     hyperedges = G.graph.get("hyperedges", [])
     if hyperedges:
         lines += ["", "## Hyperedges (group relationships)"]

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -5,7 +5,8 @@ import pytest
 from pathlib import Path
 from graphify.build import build_from_json
 from graphify.cluster import cluster
-from graphify.analyze import god_nodes, surprising_connections, _is_concept_node, graph_diff, _surprise_score, _file_category, _is_json_key_node
+from graphify.analyze import god_nodes, surprising_connections, _is_concept_node, graph_diff, _surprise_score, _file_category, _is_json_key_node, find_import_cycles
+from graphify.extract import _make_id
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -604,82 +605,119 @@ def test_god_nodes_filter_is_case_insensitive():
 
 # ── find_import_cycles tests ──────────────────────────────────────────────────
 
-from graphify.analyze import find_import_cycles
+
+def _make_file_node(path: str) -> tuple[str, dict]:
+    """Create a graph node resembling real graphify schema."""
+    nid = _make_id(path)
+    return nid, {"label": Path(path).name, "source_file": path, "file_type": "code"}
 
 
-def _make_cycle_graph():
-    """Build a directed graph with known circular imports."""
+def _make_cycle_graph_directed() -> nx.DiGraph:
     G = nx.DiGraph()
-    # Files
-    for f in ("a.ts", "b.ts", "c.ts", "d.ts", "standalone.ts"):
-        G.add_node(f"node_{f}", label=f, source_file=f, file_type="code")
-    # a imports b, b imports a (2-cycle)
-    G.add_edge("node_a.ts", "node_b.ts", relation="imports_from", source_file="a.ts", confidence="EXTRACTED")
-    G.add_edge("node_b.ts", "node_a.ts", relation="imports_from", source_file="b.ts", confidence="EXTRACTED")
-    # b imports c, c imports d, d imports b (3-cycle)
-    G.add_edge("node_b.ts", "node_c.ts", relation="imports_from", source_file="b.ts", confidence="EXTRACTED")
-    G.add_edge("node_c.ts", "node_d.ts", relation="imports_from", source_file="c.ts", confidence="EXTRACTED")
-    G.add_edge("node_d.ts", "node_b.ts", relation="imports_from", source_file="d.ts", confidence="EXTRACTED")
-    # standalone imports a but nobody imports standalone (no cycle)
-    G.add_edge("node_standalone.ts", "node_a.ts", relation="imports_from", source_file="standalone.ts", confidence="EXTRACTED")
+
+    a_id, a = _make_file_node("src/a.ts")
+    b_id, b = _make_file_node("src/b.ts")
+    c_id, c = _make_file_node("src/c.ts")
+    d_id, d = _make_file_node("src/d.ts")
+    ext_id = _make_id("react")
+
+    G.add_node(a_id, **a)
+    G.add_node(b_id, **b)
+    G.add_node(c_id, **c)
+    G.add_node(d_id, **d)
+    # External-like node (no source_file): must be skipped safely.
+    G.add_node(ext_id, label="react", file_type="code")
+
+    # 2-cycle: a <-> b
+    G.add_edge(a_id, b_id, relation="imports_from", source_file="src/a.ts", confidence="EXTRACTED")
+    G.add_edge(b_id, a_id, relation="imports_from", source_file="src/b.ts", confidence="EXTRACTED")
+
+    # 3-cycle: b -> c -> d -> b
+    G.add_edge(b_id, c_id, relation="imports_from", source_file="src/b.ts", confidence="EXTRACTED")
+    G.add_edge(c_id, d_id, relation="imports_from", source_file="src/c.ts", confidence="EXTRACTED")
+    G.add_edge(d_id, b_id, relation="imports_from", source_file="src/d.ts", confidence="EXTRACTED")
+
+    # Self-loop: c imports itself
+    G.add_edge(c_id, c_id, relation="imports_from", source_file="src/c.ts", confidence="EXTRACTED")
+
+    # Mixed edge types: must not bleed into cycle graph
+    G.add_edge(a_id, ext_id, relation="calls", source_file="src/a.ts", confidence="INFERRED")
+    G.add_edge(a_id, ext_id, relation="contains", source_file="src/a.ts", confidence="EXTRACTED")
+
+    # Edge whose target has no source_file: must be skipped, no garbage label fallback
+    G.add_edge(a_id, ext_id, relation="imports_from", source_file="src/a.ts", confidence="EXTRACTED")
+
     return G
 
 
-def test_find_import_cycles_detects_2_cycle():
-    G = _make_cycle_graph()
+def test_find_import_cycles_returns_structured_records():
+    G = _make_cycle_graph_directed()
     cycles = find_import_cycles(G)
-    # Should find the a↔b cycle
-    flat = [" ".join(c) for c in cycles]
-    assert any("a.ts" in s and "b.ts" in s for s in flat)
+    assert isinstance(cycles, list)
+    assert cycles
+    assert isinstance(cycles[0], dict)
+    assert "cycle" in cycles[0]
+    assert "length" in cycles[0]
+    assert "why" in cycles[0]
 
 
-def test_find_import_cycles_detects_3_cycle():
-    G = _make_cycle_graph()
+def test_find_import_cycles_detects_2_and_3_cycles():
+    G = _make_cycle_graph_directed()
     cycles = find_import_cycles(G)
-    # Should find b→c→d→b
-    flat = [" ".join(c) for c in cycles]
-    assert any("b.ts" in s and "c.ts" in s and "d.ts" in s for s in flat)
+    cycle_sets = [set(c["cycle"]) for c in cycles]
+    assert any({"src/a.ts", "src/b.ts"}.issubset(s) for s in cycle_sets)
+    assert any({"src/b.ts", "src/c.ts", "src/d.ts"}.issubset(s) for s in cycle_sets)
 
 
-def test_find_import_cycles_no_false_positives():
-    G = _make_cycle_graph()
+def test_find_import_cycles_includes_self_loop_cycle():
+    G = _make_cycle_graph_directed()
     cycles = find_import_cycles(G)
-    # standalone.ts should NOT appear in any cycle
-    for cycle in cycles:
-        assert not any("standalone" in node for node in cycle)
+    assert any(c["cycle"] == ["src/c.ts"] and c["length"] == 1 for c in cycles)
+
+
+def test_find_import_cycles_respects_max_cycle_length():
+    G = _make_cycle_graph_directed()
+    cycles = find_import_cycles(G, max_cycle_length=2)
+    assert all(c["length"] <= 2 for c in cycles)
+
+
+def test_find_import_cycles_skips_nodes_without_source_file():
+    G = _make_cycle_graph_directed()
+    cycles = find_import_cycles(G)
+    flat = " ".join(" ".join(c["cycle"]) for c in cycles)
+    assert "react" not in flat
+
+
+def test_find_import_cycles_handles_undirected_graph_input():
+    Gd = _make_cycle_graph_directed()
+    Gu = nx.Graph()
+    Gu.add_nodes_from(Gd.nodes(data=True))
+    Gu.add_edges_from(Gd.edges(data=True))
+    cycles = find_import_cycles(Gu)
+    assert cycles  # should still resolve orientation via edge.source_file
+
+
+def test_find_import_cycles_ignores_non_import_relations():
+    G = nx.DiGraph()
+    a_id, a = _make_file_node("src/a.ts")
+    b_id, b = _make_file_node("src/b.ts")
+    G.add_node(a_id, **a)
+    G.add_node(b_id, **b)
+    # Bidirectional non-import edges should not be considered a dependency cycle.
+    G.add_edge(a_id, b_id, relation="calls", source_file="src/a.ts", confidence="INFERRED")
+    G.add_edge(b_id, a_id, relation="contains", source_file="src/b.ts", confidence="EXTRACTED")
+    assert find_import_cycles(G) == []
 
 
 def test_find_import_cycles_empty_graph():
-    G = nx.DiGraph()
-    cycles = find_import_cycles(G)
-    assert cycles == []
+    assert find_import_cycles(nx.DiGraph()) == []
 
 
 def test_find_import_cycles_no_cycles():
     G = nx.DiGraph()
-    G.add_node("x", label="x.ts", source_file="x.ts", file_type="code")
-    G.add_node("y", label="y.ts", source_file="y.ts", file_type="code")
-    G.add_edge("x", "y", relation="imports_from", source_file="x.ts", confidence="EXTRACTED")
-    cycles = find_import_cycles(G)
-    assert cycles == []
-
-
-def test_find_import_cycles_respects_max_length():
-    G = _make_cycle_graph()
-    # With max_cycle_length=2, should only find the 2-node cycle
-    cycles = find_import_cycles(G, max_cycle_length=2)
-    for cycle in cycles:
-        assert len(cycle) - 1 <= 2  # cycle includes repeated first node
-
-
-def test_find_import_cycles_deduplicates_rotations():
-    G = _make_cycle_graph()
-    cycles = find_import_cycles(G)
-    # No two cycles should be rotations of each other
-    normalized = set()
-    for cycle in cycles:
-        core = tuple(cycle[:-1])
-        min_idx = core.index(min(core))
-        norm = core[min_idx:] + core[:min_idx]
-        assert norm not in normalized, f"Duplicate rotation found: {cycle}"
-        normalized.add(norm)
+    x_id, x = _make_file_node("x.ts")
+    y_id, y = _make_file_node("y.ts")
+    G.add_node(x_id, **x)
+    G.add_node(y_id, **y)
+    G.add_edge(x_id, y_id, relation="imports_from", source_file="x.ts", confidence="EXTRACTED")
+    assert find_import_cycles(G) == []

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -600,3 +600,86 @@ def test_god_nodes_filter_is_case_insensitive():
     labels = [r["label"] for r in result]
     for variant in ("Start", "START", "Name", "ID"):
         assert variant not in labels, f"`{variant}` should be filtered as JSON-key noise"
+
+
+# ── find_import_cycles tests ──────────────────────────────────────────────────
+
+from graphify.analyze import find_import_cycles
+
+
+def _make_cycle_graph():
+    """Build a directed graph with known circular imports."""
+    G = nx.DiGraph()
+    # Files
+    for f in ("a.ts", "b.ts", "c.ts", "d.ts", "standalone.ts"):
+        G.add_node(f"node_{f}", label=f, source_file=f, file_type="code")
+    # a imports b, b imports a (2-cycle)
+    G.add_edge("node_a.ts", "node_b.ts", relation="imports_from", source_file="a.ts", confidence="EXTRACTED")
+    G.add_edge("node_b.ts", "node_a.ts", relation="imports_from", source_file="b.ts", confidence="EXTRACTED")
+    # b imports c, c imports d, d imports b (3-cycle)
+    G.add_edge("node_b.ts", "node_c.ts", relation="imports_from", source_file="b.ts", confidence="EXTRACTED")
+    G.add_edge("node_c.ts", "node_d.ts", relation="imports_from", source_file="c.ts", confidence="EXTRACTED")
+    G.add_edge("node_d.ts", "node_b.ts", relation="imports_from", source_file="d.ts", confidence="EXTRACTED")
+    # standalone imports a but nobody imports standalone (no cycle)
+    G.add_edge("node_standalone.ts", "node_a.ts", relation="imports_from", source_file="standalone.ts", confidence="EXTRACTED")
+    return G
+
+
+def test_find_import_cycles_detects_2_cycle():
+    G = _make_cycle_graph()
+    cycles = find_import_cycles(G)
+    # Should find the a↔b cycle
+    flat = [" ".join(c) for c in cycles]
+    assert any("a.ts" in s and "b.ts" in s for s in flat)
+
+
+def test_find_import_cycles_detects_3_cycle():
+    G = _make_cycle_graph()
+    cycles = find_import_cycles(G)
+    # Should find b→c→d→b
+    flat = [" ".join(c) for c in cycles]
+    assert any("b.ts" in s and "c.ts" in s and "d.ts" in s for s in flat)
+
+
+def test_find_import_cycles_no_false_positives():
+    G = _make_cycle_graph()
+    cycles = find_import_cycles(G)
+    # standalone.ts should NOT appear in any cycle
+    for cycle in cycles:
+        assert not any("standalone" in node for node in cycle)
+
+
+def test_find_import_cycles_empty_graph():
+    G = nx.DiGraph()
+    cycles = find_import_cycles(G)
+    assert cycles == []
+
+
+def test_find_import_cycles_no_cycles():
+    G = nx.DiGraph()
+    G.add_node("x", label="x.ts", source_file="x.ts", file_type="code")
+    G.add_node("y", label="y.ts", source_file="y.ts", file_type="code")
+    G.add_edge("x", "y", relation="imports_from", source_file="x.ts", confidence="EXTRACTED")
+    cycles = find_import_cycles(G)
+    assert cycles == []
+
+
+def test_find_import_cycles_respects_max_length():
+    G = _make_cycle_graph()
+    # With max_cycle_length=2, should only find the 2-node cycle
+    cycles = find_import_cycles(G, max_cycle_length=2)
+    for cycle in cycles:
+        assert len(cycle) - 1 <= 2  # cycle includes repeated first node
+
+
+def test_find_import_cycles_deduplicates_rotations():
+    G = _make_cycle_graph()
+    cycles = find_import_cycles(G)
+    # No two cycles should be rotations of each other
+    normalized = set()
+    for cycle in cycles:
+        core = tuple(cycle[:-1])
+        min_idx = core.index(min(core))
+        norm = core[min_idx:] + core[:min_idx]
+        assert norm not in normalized, f"Duplicate rotation found: {cycle}"
+        normalized.add(norm)


### PR DESCRIPTION
## Summary

Adds file-level circular import cycle detection on top of v8.

This surfaces dependency loops that are hard to spot in symbol-level graphs and helps identify refactor blockers for tree-shaking and modularization.

## Why

Import cycles in JS/TS and mixed-language projects can:

- make dependency flow harder to reason about
- increase coupling between modules
- block or reduce bundler/tree-shaking optimizations
- create fragile refactor paths

A built-in cycle detector makes these risks visible and actionable in graph analysis.

## What changed

- Added find_import_cycles(G) in analyze.py.
- Collapses symbol-level graph relationships into a file-level directed import graph.
- Uses directed-cycle detection to find import loops.
- Normalizes and deduplicates cycle results so equivalent rotations are not repeated.
- Returns cycles in a stable, readable order to support reporting and downstream tooling.
- Added test coverage for:
  - simple 2-node cycles
  - longer multi-node cycles
  - no-cycle graphs
  - deduplication/normalization behavior
  - mixed edge scenarios around import relationships

## Related

- Related to refactor-report goals around identifying high-impact structural problems.
- Complements barrel re-export resolution by improving dependency analysis accuracy at file level.

## Test Plan

Run targeted cycle tests:

uv run --with pytest pytest tests/test_analyze.py -k "cycle"

Result:

7 passed

Optional broader analyze test run:

uv run --with pytest pytest tests/test_analyze.py -q --tb=short