### PR TITLE
fix: ignore search punctuation in graph queries

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import math
+import re
 import sys
 from pathlib import Path
 import networkx as nx
@@ -51,16 +52,18 @@ def _strip_diacritics(text: str) -> str:
     return "".join(c for c in nfkd if not unicodedata.combining(c))
 
 
+def _search_tokens(text: str) -> list[str]:
+    return re.findall(r"\w+", _strip_diacritics(str(text)).lower())
+
+
 def _query_terms(question: str) -> list[str]:
     """Split a query into searchable terms, filtering only short English terms."""
     terms: list[str] = []
     for raw in question.split():
-        term = raw.lower().strip()
-        if not term:
-            continue
-        is_english_only = all("a" <= ch <= "z" for ch in term)
-        if not is_english_only or len(term) > 2:
-            terms.append(term)
+        for term in _search_tokens(raw):
+            is_english_only = all("a" <= ch <= "z" for ch in term)
+            if not is_english_only or len(term) > 2:
+                terms.append(term)
     return terms
 
 
@@ -97,7 +100,7 @@ def _compute_idf(G: nx.Graph, terms: list[str]) -> dict[str, float]:
 
 def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
     scored = []
-    norm_terms = [_strip_diacritics(t).lower() for t in terms]
+    norm_terms = [term for value in terms for term in _search_tokens(value)]
     idf = _compute_idf(G, norm_terms)
     for nid, data in G.nodes(data=True):
         norm_label = data.get("norm_label") or _strip_diacritics(data.get("label") or "").lower()
@@ -386,7 +389,9 @@ def _find_node(G: nx.Graph, label: str) -> list[str]:
     Results are ordered by three-tier precedence: exact match, then prefix match,
     then substring match. Node-ID exact matches are grouped with label exact matches.
     """
-    term = _strip_diacritics(label).lower()
+    term = " ".join(_search_tokens(label))
+    if not term:
+        return []
     exact: list[str] = []
     prefix: list[str] = []
     substring: list[str] = []

--- a/tests/test_query_cli.py
+++ b/tests/test_query_cli.py
@@ -51,6 +51,20 @@ def test_query_cli_heuristic_context_filter(monkeypatch, tmp_path, capsys):
     assert "build" not in out
 
 
+def test_query_cli_ignores_search_punctuation(monkeypatch, tmp_path, capsys):
+    graph_path = _write_graph(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "query", "what calls extract?", "--graph", str(graph_path)],
+    )
+    mainmod.main()
+    out = capsys.readouterr().out
+    assert "Start: ['extract']" in out
+    assert "cluster" in out
+
+
 def test_query_cli_rejects_oversized_graph(monkeypatch, tmp_path, capsys):
     """#F4: query CLI must refuse to parse a graph.json that exceeds the cap."""
     import pytest

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -11,6 +11,7 @@ from graphify.serve import (
     _pick_seeds,
     _bfs,
     _dfs,
+    _find_node,
     _filter_graph_by_context,
     _infer_context_filters,
     _query_terms,
@@ -80,9 +81,24 @@ def test_score_nodes_source_file_partial():
     assert "n2" in nids
 
 
+def test_score_nodes_ignores_trailing_punctuation():
+    G = _make_graph()
+    scored = _score_nodes(G, ["extract?"])
+    assert scored[0][1] == "n1"
+
+
+def test_find_node_ignores_trailing_punctuation():
+    G = _make_graph()
+    assert _find_node(G, "extract?") == ["n1"]
+
+
 def test_query_terms_filters_only_short_english_terms():
     terms = _query_terms("前端 dependency 依赖 install 安装 to of 包管理器 项目约定 a前")
     assert terms == ["前端", "dependency", "依赖", "install", "安装", "包管理器", "项目约定", "a前"]
+
+
+def test_query_terms_strips_search_punctuation():
+    assert _query_terms("what calls extract?") == ["what", "calls", "extract"]
 
 
 def test_query_graph_text_keeps_short_non_english_terms():
@@ -194,6 +210,12 @@ def test_query_graph_text_heuristic_context_filter_changes_traversal():
     assert "Context: call (heuristic)" in text
     assert "cluster" in text
     assert "build" not in text
+
+
+def test_query_graph_text_ignores_question_punctuation():
+    G = _make_graph()
+    text = _query_graph_text(G, "what calls extract?", mode="bfs", depth=2, token_budget=2000)
+    assert "Start: ['extract']" in text
 
 
 # --- _load_graph ---


### PR DESCRIPTION
Summary:
- Normalize graph query search tokens by stripping punctuation before scoring or node lookup.
- Add regressions for punctuated query, path/explain lookup helpers, and CLI query behavior.

Why:
- Fixes #978, where searches like "extract?" failed to match nodes labeled "extract".

Tests:
- PASS: python -m pytest tests\test_serve.py -k "punctuation or query_terms_strips or query_graph_text_ignores"
- FAIL: python -m pytest tests\test_query_cli.py -k punctuation (local NetworkX does not support the existing test fixture call node_link_data(..., edges="links"); fixture left unchanged per review)
- FAIL: python -m pytest (collection stops because local environment is missing optional dependency: ModuleNotFoundError: No module named 'datasketch' in tests/test_dedup.py)
- PASS: python -m graphify update . (graph rebuilt; graph.html skipped because graph has 5378 nodes, above the default 5000-node visualization limit)

Scope:
- Intentionally avoids unrelated refactors, dependency changes, and generated-file changes.
