### PR TITLE
fix: prevent machine-specific Dart absolute paths from leaking into child node IDs

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -2716,6 +2716,8 @@ def extract_dart(path: Path) -> dict:
     except OSError:
         return {"error": f"cannot read {path}"}
 
+    # Use stem (not str(path)) for child IDs to keep them machine-independent.
+    stem = _file_stem(path)
     file_nid = _make_id(str(path))
     nodes = [{"id": file_nid, "label": path.name, "file_type": "code",
               "source_file": str(path), "source_location": None}]
@@ -2724,7 +2726,7 @@ def extract_dart(path: Path) -> dict:
 
     # Classes and mixins
     for m in re.finditer(r"^\s*(?:abstract\s+)?(?:class|mixin)\s+(\w+)", src, re.MULTILINE):
-        nid = _make_id(str(path), m.group(1))
+        nid = _make_id(stem, m.group(1))
         if nid not in defined:
             nodes.append({"id": nid, "label": m.group(1), "file_type": "code",
                           "source_file": str(path), "source_location": None})
@@ -2738,7 +2740,7 @@ def extract_dart(path: Path) -> dict:
         name = m.group(1)
         if name in {"if", "for", "while", "switch", "catch", "return"}:
             continue
-        nid = _make_id(str(path), name)
+        nid = _make_id(stem, name)
         if nid not in defined:
             nodes.append({"id": nid, "label": name, "file_type": "code",
                           "source_file": str(path), "source_location": None})

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -999,3 +999,41 @@ def test_pure_export_no_from_not_treated_as_reexport():
         result = extract_js(Path(f.name))
     reexports = [e for e in result["edges"] if e["relation"] == "re_exports"]
     assert reexports == [], f"Pure export should not create re_exports: {reexports}"
+
+
+def test_dart_child_node_ids_are_stem_based(tmp_path):
+    """Dart child node IDs must be built from _file_stem rather than absolute path."""
+    from graphify.extract import extract_dart, _file_stem, _make_id
+
+    src_file = tmp_path / "mydir" / "sample.dart"
+    src_file.parent.mkdir(parents=True, exist_ok=True)
+    src_file.write_bytes(b"class MyClass {}\nvoid myFunc() {}\n")
+
+    result = extract_dart(src_file)
+
+    stem = _file_stem(src_file)  # -> "mydir.sample"
+    expected_class_nid = _make_id(stem, "MyClass")   # -> "mydir_sample_myclass"
+    expected_func_nid  = _make_id(stem, "myFunc")    # -> "mydir_sample_myfunc"
+
+    node_ids = {n["id"] for n in result["nodes"]}
+
+    assert expected_class_nid in node_ids, (
+        f"Class node ID '{expected_class_nid}' not found in {node_ids}. "
+        "extract_dart may still be using str(path) instead of _file_stem(path)."
+    )
+    assert expected_func_nid in node_ids, (
+        f"Function node ID '{expected_func_nid}' not found in {node_ids}. "
+        "extract_dart may still be using str(path) instead of _file_stem(path)."
+    )
+
+    # Sanity-check: no child node ID should contain any path separator fragment.
+    file_nid = next(n["id"] for n in result["nodes"] if n.get("label") == src_file.name)
+    for node in result["nodes"]:
+        if node["id"] == file_nid:
+            continue
+        assert "_" + stem.replace(".", "_") in node["id"] or node["id"].startswith(stem.replace(".", "_")), (
+            f"Child node ID '{node['id']}' does not start with the expected stem prefix '{stem}'. "
+            "This suggests an absolute path is still leaking into the ID."
+        )
+
+


### PR DESCRIPTION
## Problem

`extract_dart` was building class and function node IDs from `str(path)` — the absolute local filesystem path — instead of `_file_stem(path)`, which is the convention used by every other extractor.

As a result, the same Dart symbol got a different node ID on every machine:

```
# Developer A
users_alice_projects_myapp_lib_auth_user_service_UserService

# Developer B — same file, different ID
users_bob_desktop_myapp_lib_auth_user_service_UserService
```

The `id_remap` post-processor (introduced in #502) remaps **file node IDs** to project-root-relative paths, but does not touch compound child node IDs — so class and function nodes permanently retained the absolute path of whoever ran `graphify` last.

This broke three things for any team sharing `graphify-out/` in version control:

- **Duplicate nodes** — every developer appends new orphaned nodes on incremental update instead of overwriting the existing ones.
- **Broken edges** — cross-file import and call edges point to non-existent IDs on other machines.
- **AI context degradation** — ghost nodes and dead edges cause incorrect code suggestions and hallucinated imports.

## ⚠️ Migration note

This is a breaking ID change for existing Dart graphs. Old absolute-path-derived node IDs will become orphans on the next incremental run. Rebuild from scratch after updating:

```bash
graphify . --force
```
