### PR TITLE
fix(cli): export html falls back to per-node community attribute when sidecar is missing

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2624,6 +2624,29 @@ def main() -> None:
             cohesion = {}
             gods_data = []
 
+        # Fallback: graph.json carries the per-node community as a node attribute
+        # (`to_json` writes it on every node). The analysis sidecar is the
+        # canonical source — but the post-commit / watch rebuild path doesn't
+        # regenerate it, and `extract` may have its temp files cleaned up. When
+        # that happens, `graphify export html` previously bailed with
+        # "Single community - aggregated view not useful." even though the
+        # per-node attribute had the right data all along. Reconstruct from
+        # the graph itself so downstream subcommands (html, obsidian, wiki,
+        # svg, graphml, neo4j) don't silently produce a degraded artifact.
+        if not communities:
+            reconstructed: dict[int, list[str]] = {}
+            for node_id, data in G.nodes(data=True):
+                cid_raw = data.get("community")
+                if cid_raw is None:
+                    continue
+                try:
+                    cid = int(cid_raw)
+                except (TypeError, ValueError):
+                    continue
+                reconstructed.setdefault(cid, []).append(str(node_id))
+            if reconstructed:
+                communities = reconstructed
+
         labels: dict[int, str] = {}
         if labels_path.exists():
             labels = {int(k): v for k, v in json.loads(labels_path.read_text(encoding="utf-8")).items()}

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -286,3 +286,86 @@ def test_cluster_only_creates_output_dir_when_missing(tmp_path):
     r = _run(["cluster-only", ".", "--graph", str(graph_src), "--no-viz"], tmp_path)
     assert r.returncode == 0, r.stderr
     assert (tmp_path / "graphify-out" / "GRAPH_REPORT.md").exists()
+
+
+# ── communities-fallback when .graphify_analysis.json is absent ──────────────
+# The watch / post-commit rebuild path only writes graph.json + GRAPH_REPORT.md;
+# it does NOT regenerate .graphify_analysis.json. The full `graphify extract`
+# pipeline also removes its temp files at the end of the run on some skill
+# workflows. In both cases the per-node `community` attribute is intact on
+# every node in graph.json — that's the source of truth `to_json` writes.
+# Without these tests, `graphify export html|obsidian|wiki|svg|graphml|neo4j`
+# silently bails or generates a degraded artifact whenever the sidecar is
+# missing, even though the data is right there.
+
+def test_export_html_falls_back_to_node_community_attribute(tmp_path):
+    """When .graphify_analysis.json is absent, export html should reconstruct
+    communities from the per-node attribute in graph.json rather than bailing
+    out with 'Single community - aggregated view not useful.'.
+    """
+    out = _make_graph(tmp_path)
+    # Simulate the watch-rebuild / cleanup case: graph.json + labels survive,
+    # analysis sidecar is gone.
+    (out / ".graphify_analysis.json").unlink()
+
+    r = _run(["export", "html"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    html = out / "graph.html"
+    assert html.exists(), "graph.html should be generated from the fallback"
+    assert html.stat().st_size > 0
+    # The success message comes from to_html — confirm we're not hitting the
+    # "Single community" bail-out path.
+    assert "Single community" not in r.stdout
+    assert "Single community" not in r.stderr
+
+
+def test_export_html_fallback_recovers_multiple_communities(tmp_path):
+    """Stronger assertion: the reconstructed `communities` dict should have the
+    SAME community count as the analysis sidecar would, so downstream code
+    (aggregation thresholds, member counts) sees identical input.
+    """
+    out = _make_graph(tmp_path)
+
+    # Read the canonical community count from the analysis sidecar
+    analysis = json.loads((out / ".graphify_analysis.json").read_text(encoding="utf-8"))
+    expected_count = len(analysis["communities"])
+
+    # And the count we'd reconstruct from graph.json's node attributes
+    graph = json.loads((out / "graph.json").read_text(encoding="utf-8"))
+    reconstructed_cids = {
+        n["community"] for n in graph.get("nodes", [])
+        if n.get("community") is not None
+    }
+    assert len(reconstructed_cids) == expected_count, (
+        f"reconstruction would lose communities: sidecar={expected_count} vs "
+        f"graph.json={len(reconstructed_cids)}"
+    )
+
+    # Now remove the sidecar and confirm the CLI still succeeds end-to-end.
+    (out / ".graphify_analysis.json").unlink()
+    r = _run(["export", "html"], tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (out / "graph.html").exists()
+
+
+def test_export_html_no_community_data_at_all_still_succeeds(tmp_path):
+    """If a graph.json was somehow written without any per-node `community`
+    attribute (older versions of to_json, hand-built graphs), the fallback
+    should produce an empty communities dict and the renderer should still
+    not crash. Whether the aggregated view is useful is a separate question.
+    """
+    out = _make_graph(tmp_path)
+    (out / ".graphify_analysis.json").unlink()
+
+    # Strip the community attribute from every node
+    graph_path = out / "graph.json"
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    for n in graph.get("nodes", []):
+        n.pop("community", None)
+    graph_path.write_text(json.dumps(graph), encoding="utf-8")
+
+    r = _run(["export", "html"], tmp_path)
+    # Should NOT crash. It may print a warning and skip rendering, but exit
+    # code stays clean — same behaviour as the pre-fallback empty-communities
+    # path, just no longer silently failing on the common case.
+    assert r.returncode == 0, r.stderr


### PR DESCRIPTION
## Summary

`graphify export html|obsidian|wiki|svg|graphml|neo4j` reads its `communities` dict exclusively from `.graphify_analysis.json`. When that sidecar is missing — which happens routinely after a watch / post-commit rebuild, or when temp files get cleaned up post-`extract` — the CLI proceeds with `communities = {}` and downstream rendering silently degrades or bails out entirely.

Observed failure on the current `v8` tip:

```
$ graphify export html
Graph has 64703 nodes (above 5000 limit). Building aggregated community view...
Single community - aggregated view not useful. Skipping graph.html.
```

even though the same `graph.json` has **2,026** distinct `community` values sitting on its nodes. `to_html` just received an empty `communities` dict and the aggregator collapsed to one meta-node before the renderer could see them.

## Repro (one minute)

```
# Build a graph as usual
graphify extract . --no-cluster=false

# Simulate the watch-rebuild / cleanup case — the sidecar is missing,
# graph.json + labels survive
rm graphify-out/.graphify_analysis.json

# Try to render
graphify export html
# → "Single community - aggregated view not useful. Skipping graph.html."
```

The same condition arises silently after every post-commit rebuild on large graphs (the watch path only writes `graph.json` + `GRAPH_REPORT.md`, never the analysis sidecar), and after several skill workflows that `rm -f graphify-out/.graphify_*` as part of cleanup.

## Root cause

`graphify/__main__.py` line ~2617:

```python
communities: dict[int, list[str]] = {}
if analysis_path.exists():
    _an = json.loads(analysis_path.read_text(encoding=\"utf-8\"))
    communities = {int(k): v for k, v in _an.get(\"communities\", {}).items()}
    ...
```

If the sidecar is gone, `communities` stays empty even though `to_json` already wrote the per-node `community` attribute on every node of `graph.json`. The data is right there; we just don't read it.

## Fix

When the sidecar is absent or its `communities` field is empty, reconstruct `cid -> [node_ids]` from `G.nodes(data=True)`. The sidecar remains the canonical source of truth when present; the reconstruction is a strict fallback that activates only when the canonical source isn't available.

```python
if not communities:
    reconstructed: dict[int, list[str]] = {}
    for node_id, data in G.nodes(data=True):
        cid_raw = data.get(\"community\")
        if cid_raw is None:
            continue
        try:
            cid = int(cid_raw)
        except (TypeError, ValueError):
            continue
        reconstructed.setdefault(cid, []).append(str(node_id))
    if reconstructed:
        communities = reconstructed
```

That's the entire diff in `__main__.py` (16 lines). Every downstream subcommand (`html`, `obsidian`, `wiki`, `svg`, `graphml`, `neo4j`) sees the same dict shape it always did — just populated from the graph itself instead of an externally-cached sidecar.

## Properties preserved

1. **Sidecar still wins when present.** `cohesion` and `gods_data` are still read from the analysis JSON when it exists; the fallback only touches `communities`.
2. **No new public API.** No new flag, no new env var. The recovery is implicit from the data that's already in `graph.json`.
3. **Defensive types.** `int()` coercion + try/except handles the cosmetic case where a graph was hand-edited or migrated and `community` ended up as a string. Bad values are skipped, not crashed on.
4. **Graceful no-data case.** If a graph genuinely has no per-node community attribute (older `to_json` versions, manually-constructed graphs), the fallback produces an empty dict and downstream code behaves exactly as it did before this fix — same "Single community" bail-out, same exit code. The fix doesn't change semantics for graphs that legitimately can't be aggregated; it only fixes the common case where the data was present and we ignored it.

## Tests

3 new tests in `tests/test_cli_export.py`. All pass. Full file (26 tests) green; ruff clean.

| Test | Covers |
|---|---|
| `test_export_html_falls_back_to_node_community_attribute` | Sidecar removed → `graph.html` is generated, no "Single community" bail-out |
| `test_export_html_fallback_recovers_multiple_communities` | Reconstructed community count matches what the sidecar would have provided (no silent data loss) |
| `test_export_html_no_community_data_at_all_still_succeeds` | Graphs missing the per-node attribute (older `to_json` outputs) still exit cleanly |

## Test plan

- [x] `uv run pytest tests/test_cli_export.py` — 26/26 pass
- [x] `uv run ruff check graphify/__main__.py tests/test_cli_export.py` — clean
- [x] End-to-end repro: `rm graphify-out/.graphify_analysis.json && graphify export html` on a real 64K-node graph → `graph.html` (1.4MB) generated with 2,026 community nodes and 3,235 cross-community edges

## Relationship to #1000

These two PRs are independent. #1000 fixes the post-commit hook's delete-handling path. This one fixes a separate failure mode in the `export` subcommands. They share the same surface area (the watch-rebuild / sidecar lifecycle) but the fixes touch disjoint code (`watch.py::_check_shrink` vs `__main__.py::export`). Either can land without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)