### PR TITLE
fix: accept "edges" schema in affected and benchmark commands

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -145,6 +145,11 @@ def load_graph(path: Path) -> nx.Graph:
     from networkx.readwrite import json_graph
 
     raw = json.loads(path.read_text(encoding="utf-8"))
+    # Normalize schema: graphs written by `extract --no-cluster` store edges
+    # under the key "edges"; networkx node-link format uses "links". Accept
+    # either. Mirrors the idiom in graphify/global_graph.py.
+    if "links" not in raw and "edges" in raw:
+        raw = dict(raw, links=raw["edges"])
     try:
         return json_graph.node_link_graph(raw, edges="links")
     except TypeError:

--- a/graphify/benchmark.py
+++ b/graphify/benchmark.py
@@ -101,6 +101,11 @@ def run_benchmark(
     from graphify.security import check_graph_file_size_cap
     check_graph_file_size_cap(Path(graph_path))
     data = json.loads(Path(graph_path).read_text(encoding="utf-8"))
+    # Normalize schema: graphs written by `extract --no-cluster` store edges
+    # under the key "edges"; networkx node-link format uses "links". Accept
+    # either. Mirrors the idiom in graphify/global_graph.py.
+    if "links" not in data and "edges" in data:
+        data = dict(data, links=data["edges"])
     try:
         G = json_graph.node_link_graph(data, edges="links")
     except TypeError:

--- a/tests/test_affected_cli.py
+++ b/tests/test_affected_cli.py
@@ -58,3 +58,38 @@ def test_affected_cli_relation_filter_limits_reverse_traversal(monkeypatch, tmp_
     assert "Relations: calls" in out
     assert "X()" in out
     assert "__init__.py" not in out
+
+
+def _write_graph_edges_schema(tmp_path):
+    """Write a graph using the "edges" top-level key (what `extract --no-cluster`
+    produces) rather than the networkx node-link "links" key.
+    """
+    graph = nx.DiGraph()
+    graph.add_node("target", label="Foo", source_file="pkg/foo.py", source_location="L1")
+    graph.add_node("caller", label="X()", source_file="app.py", source_location="L4")
+    graph.add_edge("caller", "target", relation="calls", context="call", confidence="EXTRACTED")
+    raw = json_graph.node_link_data(graph, edges="links")
+    raw["edges"] = raw.pop("links")
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps(raw), encoding="utf-8")
+    return graph_path
+
+
+def test_affected_cli_handles_edges_schema(monkeypatch, tmp_path, capsys):
+    """Regression: graphs written by `extract --no-cluster` use the "edges"
+    key, not "links". affected previously crashed loading those graphs with
+    `could not load graph: 'links'`.
+    """
+    graph_path = _write_graph_edges_schema(tmp_path)
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "affected", "Foo", "--graph", str(graph_path)],
+    )
+
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    assert "Affected nodes for Foo" in out
+    assert "X()" in out

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -85,6 +85,22 @@ def test_run_benchmark_per_question_list(tmp_path):
         assert "query_tokens" in p
         assert "reduction" in p
 
+
+def test_run_benchmark_handles_edges_schema(tmp_path):
+    """Regression: graphs written by `extract --no-cluster` use the key "edges"
+    (not "links"). benchmark previously crashed loading those graphs.
+    """
+    G = _make_graph()
+    # Build a raw payload that mirrors what `extract --no-cluster` writes:
+    # top-level "edges" key, no "links" key.
+    raw = json_graph.node_link_data(G, edges="links")
+    raw["edges"] = raw.pop("links")
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text(json.dumps(raw))
+    result = run_benchmark(str(graph_file), corpus_words=5_000)
+    assert "reduction_ratio" in result
+    assert result["reduction_ratio"] > 1.0
+
 def test_run_benchmark_estimates_corpus_if_no_words(tmp_path):
     G = _make_graph()
     graph_file = tmp_path / "graph.json"


### PR DESCRIPTION
## Summary

`graphify affected` and `graphify benchmark` both crash on graphs produced by `graphify extract --no-cluster`:

```
$ graphify extract . --no-cluster
[graphify extract] wrote graphify-out/graph.json — N nodes, M edges (no clustering)

$ graphify affected SomeSymbol
error: could not load graph: 'links'

$ graphify benchmark graph.json
Traceback ... KeyError: 'links' in node_link_graph
```

Both commands call `json_graph.node_link_graph(raw, edges="links")` wrapped in `try/except TypeError`. The failing case throws a `KeyError` (the JSON has `edges`, not `links`), so the existing fallback never triggers.

The fix is to normalize the schema before the networkx call — the same idiom already used in `graphify/global_graph.py:34-35`:

```python
if "links" not in raw and "edges" in raw:
    raw = dict(raw, links=raw["edges"])
```

## Reproduction

```bash
# in any folder with code
graphify extract . --no-cluster
graphify affected AnySymbol       # was: error: could not load graph: 'links'
graphify benchmark graphify-out/graph.json   # was: KeyError 'links'
```

After this PR, both run cleanly on either schema.

## Test plan

Added regression tests that write a graph with the `edges` top-level key (mimicking `extract --no-cluster`) and assert each command succeeds:

- `tests/test_affected_cli.py::test_affected_cli_handles_edges_schema`
- `tests/test_benchmark.py::test_run_benchmark_handles_edges_schema`

Full suite: `1261 passed, 11 skipped` on this branch.

## Context

Found while integrating graphify into an external skill catalog. Full eval (token-reduction A/B, build-cost curve, quality + staleness probes) measured −93% tokens vs grep+read at parity evidence rate using `graphify explain`. Both `affected` and `benchmark` were on the original "don't recommend in agent flows" list because of this crash; this PR removes them from that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)