### PR TITLE
fix(update): evict nodes from re-extracted files, not just by id-match

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -394,13 +394,22 @@ def _rebuild_code(
                 existing = json.loads(existing_graph.read_text(encoding="utf-8"))
                 existing_graph_data = existing
                 new_ast_ids = {n["id"] for n in result["nodes"]}
+                # Evict preserved nodes whose source_file was just re-extracted.
+                # Without this, a rename like `def foo → def bar` leaves the
+                # old `foo` node in the graph forever: its old node-id no
+                # longer appears in new_ast_ids, so the ID-only filter keeps
+                # it. The same applies to deleted symbols.
+                #
+                # Done unconditionally — both incremental (changed_paths
+                # supplied) and full-corpus (changed_paths is None) rebuilds
+                # need it. Previously the full-corpus path (used by `graphify
+                # update .`) left stale nodes behind on every rename/deletion.
                 evict_sources: set[str] = set(deleted_paths)
-                if changed_paths is not None:
-                    for p in extract_targets:
-                        try:
-                            evict_sources.add(str(p.relative_to(project_root)))
-                        except ValueError:
-                            evict_sources.add(str(p))
+                for p in extract_targets:
+                    try:
+                        evict_sources.add(str(p.relative_to(project_root)))
+                    except ValueError:
+                        evict_sources.add(str(p))
                 preserved_nodes = [
                     n for n in existing.get("nodes", [])
                     if n["id"] not in new_ast_ids

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,4 +1,5 @@
 """Tests for watch.py - file watcher helpers (no watchdog required)."""
+import json
 import os
 import sys
 import time
@@ -294,3 +295,67 @@ def test_watch_loads_graphifyignore_once(tmp_path, monkeypatch):
         (tmp_path / "ignored" / f"f{i}.py").write_text("x\n", encoding="utf-8")
     time.sleep(0.7)
     assert calls["n"] == 1, f"_load_graphifyignore called {calls['n']} times; expected 1"
+
+
+def test_rebuild_code_full_corpus_evicts_renamed_symbols(tmp_path):
+    """Regression: after `graphify update .` (full-corpus rebuild path,
+    changed_paths is None), nodes for symbols that no longer exist in the
+    source must be dropped — not preserved alongside the new nodes.
+
+    Before the fix, the preserve filter only evicted by source_file when an
+    explicit changed_paths list was supplied. The CLI path passes None, so
+    every rename/deletion accreted ghost nodes forever.
+    """
+    from graphify.watch import _rebuild_code
+
+    src = tmp_path / "app.py"
+    src.write_text("def read_page():\n    return 1\n", encoding="utf-8")
+    assert _rebuild_code(tmp_path)
+
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    before = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels_before = {n.get("label", "") for n in before["nodes"]}
+    assert any("read_page" in lab for lab in labels_before), (
+        f"baseline failed: read_page not in initial graph: {labels_before}"
+    )
+
+    # Rename the function in-place. No explicit changed_paths — same code
+    # path the CLI takes for `graphify update .`.
+    src.write_text("def read_page_RENAMED():\n    return 1\n", encoding="utf-8")
+    assert _rebuild_code(tmp_path, force=True)
+
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels_after = {n.get("label", "") for n in after["nodes"]}
+    assert any("read_page_RENAMED" in lab for lab in labels_after), (
+        f"renamed symbol missing from rebuilt graph: {labels_after}"
+    )
+    # The old symbol must be gone — the bug this regression locks down.
+    stale = [lab for lab in labels_after if "read_page" in lab and "RENAMED" not in lab]
+    assert not stale, f"stale nodes for renamed symbol survived rebuild: {stale}"
+
+
+def test_rebuild_code_full_corpus_evicts_deleted_symbols(tmp_path):
+    """Counterpart to the rename test: a deletion (not rename) must also
+    drop the node. Otherwise `graphify explain <deleted_symbol>` keeps
+    serving a non-existent symbol indefinitely.
+    """
+    from graphify.watch import _rebuild_code
+
+    src = tmp_path / "app.py"
+    src.write_text(
+        "def kept():\n    return kept()\n\n"
+        "def doomed():\n    return 1\n",
+        encoding="utf-8",
+    )
+    assert _rebuild_code(tmp_path)
+
+    src.write_text("def kept():\n    return kept()\n", encoding="utf-8")
+    assert _rebuild_code(tmp_path, force=True)
+
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    after = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels_after = {n.get("label", "") for n in after["nodes"]}
+    assert any("kept" in lab for lab in labels_after)
+    assert not any("doomed" in lab for lab in labels_after), (
+        f"deleted symbol survived rebuild: {labels_after}"
+    )


### PR DESCRIPTION
## Summary

\`graphify update .\` is documented as the AST-only refresh after edits. In practice it's **additive**: a rename like \`def foo → def bar\` leaves the old \`foo\` node in the graph forever, alongside the new \`bar\` node. Same for outright deletions.

Reproduced:

\`\`\`bash
# initial state
echo 'def read_page(): pass' > app.py
graphify extract .
graphify explain read_page             # works

# edit: rename in-place
echo 'def read_page_RENAMED(): pass' > app.py
graphify update . --force
graphify explain read_page             # still works — BUG, function no longer exists
graphify explain read_page_RENAMED     # also works
# → graph now contains BOTH symbols. Agents querying \`read_page\` get
#   confident "yes it exists" answers about a deleted function.
\`\`\`

## Root cause

\`graphify/watch.py\` \`_rebuild_code\` preserves nodes from the previous graph and filters them by:

\`\`\`python
preserved_nodes = [
    n for n in existing.get("nodes", [])
    if n["id"] not in new_ast_ids
    and (not evict_sources or n.get("source_file") not in evict_sources)
]
\`\`\`

The \`evict_sources\` set is **only populated when \`changed_paths is not None\`** (the watcher path). The CLI path (\`graphify update .\`) calls \`_rebuild_code\` with \`changed_paths=None\`, so \`evict_sources\` stays empty — the filter degenerates to "drop only nodes whose id matches a new one". Since a renamed function gets a new node-id, the old node passes both filters and lives forever.

## Fix

Always populate \`evict_sources\` with every file in \`extract_targets\`. A file being re-extracted is by definition authoritative for its own nodes — anything previously preserved from that source path is stale.

Same eviction loop, just hoisted out of the \`if changed_paths is not None:\` guard.

## Test plan

Two regression tests in \`tests/test_watch.py\` exercising the CLI code path (no \`changed_paths\`):

- \`test_rebuild_code_full_corpus_evicts_renamed_symbols\` — write \`def read_page\`, rebuild, rename to \`def read_page_RENAMED\`, rebuild again, assert the old node is gone.
- \`test_rebuild_code_full_corpus_evicts_deleted_symbols\` — write two functions, rebuild, delete one, rebuild again, assert only the surviving function is in the graph.

Both fail on \`v8\` before this patch and pass after.

Full suite: \`1261 passed, 11 skipped\` on this branch.

## Related

#595 (broader graph-hygiene primitives — rename/merge-node/drop-edge). This PR is narrower: it fixes the implicit graph-hygiene contract of \`update\` rather than introducing new primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)