### PR TITLE
Fix: remap hyperedges in community-aggregated meta-graph view

### DIFF
--- a/graphify/export.py
+++ b/graphify/export.py
@@ -656,6 +656,30 @@ def to_html(
                 return
             meta_communities = {cid: [str(cid)] for cid in communities}
             mc = {cid: len(members) for cid, members in communities.items()}
+            # Remap hyperedges from semantic node IDs to community IDs
+            raw_hyperedges = G.graph.get("hyperedges", [])
+            if raw_hyperedges:
+                remapped = []
+                for he in raw_hyperedges:
+                    he_members = he.get("nodes") or he.get("members") or []
+                    comm_ids, seen = [], set()
+                    for nid in he_members:
+                        c = node_to_community.get(nid)
+                        if c is None:
+                            continue
+                        s = str(c)
+                        if s in seen:
+                            continue
+                        seen.add(s)
+                        comm_ids.append(s)
+                    if len(comm_ids) < 2:
+                        continue
+                    remapped.append({
+                        "id": he.get("id", ""),
+                        "label": he.get("label") or he.get("relation", "").replace("_", " "),
+                        "nodes": comm_ids,
+                    })
+                meta.graph["hyperedges"] = remapped
             to_html(meta, meta_communities, output_path,
                     community_labels=community_labels, member_counts=mc)
             print(f"graph.html written (aggregated: {meta.number_of_nodes()} community nodes, {meta.number_of_edges()} cross-community edges)")


### PR DESCRIPTION
## Summary

When a graph exceeds `GRAPHIFY_VIZ_NODE_LIMIT` (default 1000 via `_viz_node_limit()`, falling back to `MAX_NODES_FOR_VIZ` = 5000), `to_html()` builds a community-aggregated meta-graph and recursively calls itself. The recursive call never carried hyperedges onto the meta-graph, so the rendered `graph.html` always emits `const hyperedges = [];` — even when `graph.json` contains plenty.

The visible result: the `afterDrawing` handler that renders hyperedge regions silently no-ops on every large project, even though hyperedges are extracted, persisted to `graph.json`, and merged correctly through the rest of the pipeline.

## Root Cause

In `graphify/export.py` — `to_html` at the over-limit branch builds a fresh meta-graph and recursively calls itself, but never sets `meta.graph["hyperedges"]`. Even if forwarded as-is, the hyperedges reference semantic node IDs (e.g., `"UserService"`) that don't exist in the meta-graph (which uses community IDs like `"3"` as node IDs).

## Fix

Remap hyperedges from semantic node IDs to community IDs before the recursive call. Drop entries that collapse to <2 distinct communities — they wouldn't render as a polygon anyway.

- Handles both `"nodes"` and `"members"` keys for backward compatibility with different hyperedge formats
- Deduplicates community IDs per hyperedge
- Falls back from `label` to `relation` for display text when label is missing
- Attaches remapped hyperedges to `meta.graph["hyperedges"]` so the recursive call picks them up

## Testing

- All 37 existing tests in `tests/test_export.py` and `tests/test_hypergraph.py` pass

Fixes #1005
