### PR TITLE
fix(cli): apply remap_communities_to_previous in cluster-only path

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -2238,7 +2238,7 @@ def main() -> None:
             sys.exit(1)
         from networkx.readwrite import json_graph as _jg
         from graphify.build import build_from_json
-        from graphify.cluster import cluster, score_all
+        from graphify.cluster import cluster, score_all, remap_communities_to_previous
         from graphify.analyze import god_nodes, surprising_connections, suggest_questions
         from graphify.report import generate
         from graphify.export import to_json, to_html
@@ -2250,6 +2250,18 @@ def main() -> None:
         print(f"Graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
         print("Re-clustering...")
         communities = cluster(G, resolution=co_resolution, exclude_hubs_percentile=co_exclude_hubs)
+        # Mirror the watch/update path (#822): map new cids to prior ones by
+        # node-overlap so the existing .graphify_labels.json keeps attaching
+        # to the same conceptual community after re-clustering. Without this,
+        # labels follow raw cid index and become misaligned whenever the
+        # graph has changed between labeling and cluster-only (#1027).
+        previous_node_community = {
+            n["id"]: n["community"]
+            for n in _raw.get("nodes", [])
+            if n.get("community") is not None and n.get("id") is not None
+        }
+        if previous_node_community:
+            communities = remap_communities_to_previous(communities, previous_node_community)
         cohesion = score_all(G, communities)
         gods = god_nodes(G)
         surprises = surprising_connections(G, communities)

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -288,6 +288,58 @@ def test_cluster_only_creates_output_dir_when_missing(tmp_path):
     assert (tmp_path / "graphify-out" / "GRAPH_REPORT.md").exists()
 
 
+# Regression test for #1027 - cluster-only must remap labels via node overlap
+
+def test_cluster_only_remaps_labels_to_previous_cids(tmp_path):
+    """cluster-only must invoke remap_communities_to_previous so the existing
+    .graphify_labels.json keeps tracking the same conceptual communities after
+    re-clustering. Without the remap call, Leiden's size-descending cid order
+    re-applies labels by raw index and they silently misalign with cluster
+    contents (#1027). Mirror of the watch/update fix from #822.
+    """
+    out = _make_graph(tmp_path)
+    graph_json = out / "graph.json"
+    labels_json = out / ".graphify_labels.json"
+
+    # Tag every node with an out-of-band community id and write a labels file
+    # keyed on those ids. After cluster-only, at least one of those sentinel
+    # ids must survive in the labels file (= remap succeeded by node overlap).
+    # If the cluster-only branch skips remap, Leiden returns small ints
+    # (0, 1, ...) and the sentinel keys disappear entirely.
+    g = json.loads(graph_json.read_text(encoding="utf-8"))
+    nodes = g.get("nodes", [])
+    assert len(nodes) >= 4, "fixture must have enough nodes to form 2+ communities"
+    sentinel_a, sentinel_b = 4242, 9999
+    half = len(nodes) // 2
+    for i, n in enumerate(nodes):
+        n["community"] = sentinel_a if i < half else sentinel_b
+    graph_json.write_text(json.dumps(g), encoding="utf-8")
+    labels_json.write_text(
+        json.dumps({str(sentinel_a): "First Group", str(sentinel_b): "Second Group"}),
+        encoding="utf-8",
+    )
+
+    r = _run(["cluster-only", ".", "--no-viz"], tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    # Real signal: labels.json keys must align with the community ids actually
+    # written to graph.json's per-node community attribute. Without remap,
+    # Leiden returns small cids (0, 1, ...) but labels.json still carries the
+    # old sentinel keys, so the intersection is empty and labels are orphaned.
+    final_graph = json.loads(graph_json.read_text(encoding="utf-8"))
+    final_labels = json.loads(labels_json.read_text(encoding="utf-8"))
+    actual_cids = {n.get("community") for n in final_graph.get("nodes", [])}
+    label_cids = {int(k) for k in final_labels.keys()}
+    overlap = actual_cids & label_cids
+    assert overlap, (
+        f"After cluster-only with prior labels keyed on cids {label_cids}, at "
+        f"least one of those cids must still appear in graph.json's community "
+        f"attribute ({actual_cids}). Without remap_communities_to_previous "
+        f"(#1027) Leiden renumbers communities to 0,1,... and the prior labels "
+        f"become orphaned. Final labels: {final_labels}"
+    )
+
+
 # ── communities-fallback when .graphify_analysis.json is absent ──────────────
 # The watch / post-commit rebuild path only writes graph.json + GRAPH_REPORT.md;
 # it does NOT regenerate .graphify_analysis.json. The full `graphify extract`


### PR DESCRIPTION
## Summary
`cluster-only` re-runs Leiden clustering and then re-applies the existing
`.graphify_labels.json` by raw cid index, without invoking the
`remap_communities_to_previous` safety net that #822 added to the
`watch` / `update` paths. As a result, labels become misaligned with the
actual community contents whenever the graph has changed between the
labeling pass and the `cluster-only` invocation — including the official
`update --no-cluster` + `cluster-only` workflow introduced by #822.

Closes #1027.

## What changed
Mirror the existing pattern in `graphify/watch.py:_rebuild_code`:

- Build `previous_node_community` from `_raw` (already loaded a few lines
  above) using each node's `community` attribute.
- Call `remap_communities_to_previous(communities, previous_node_community)`
  immediately after `cluster(...)` so the existing labels file keeps
  tracking the same conceptual communities by node-overlap, not by raw
  cid index.

Diff is contained to the `elif cmd == "cluster-only":` branch in
`graphify/__main__.py` (one import addition, one block right after the
`cluster(...)` call).

## Test
Added `tests/test_cli_export.py::test_cluster_only_remaps_labels_to_previous_cids`.

The test tags every node with out-of-band sentinel community ids
(`4242` / `9999`), writes a labels file keyed on those ids, then runs
`graphify cluster-only`. With the fix, at least one sentinel cid still
appears in the final `graph.json` community attributes (= remap matched
by node overlap). Without the fix, Leiden renumbers to `0, 1, ...` and
the prior labels become orphaned.

Verified locally:

```
=== WITH fix ===
1 passed in 17.56s

=== WITHOUT fix (stashed source change) ===
FAILED tests/test_cli_export.py::test_cluster_only_remaps_labels_to_previous_cids
1 failed in 17.14s
```

Full suite passes:
```
pytest tests/ -q --ignore=tests/bench_extract.py
1317 passed in 58.20s
```

## Open question
The `remap_communities_to_previous` helper already exists in
`graphify.cluster` and is used correctly in `watch.py:_rebuild_code`.
#822's description explicitly mentions:

> "stabilize clustering output with deterministic partition input
>  ordering, seeded Leiden when supported, and overlap-based remapping
>  of new communities to prior IDs"

— but `cluster-only` was not updated alongside the watch/update path. The
neighbouring code paths re-applying labels (`watch.py:_rebuild_code`,
`update`) all go through remap; `cluster-only` is the only
re-clustering CLI entry point that omitted it.

Was there a design reason to deliberately keep `cluster-only` without
the remap (e.g. a use case where label inheritance is undesirable)?
If so, happy to revise this PR — for example, gate the remap behind an
opt-out flag, or expose a `--reset-labels` switch instead. Otherwise it
looks like a simple miss when #822 was applied and this PR just mirrors
the existing pattern.

## Refs
- Issue: #1027
- Stability work that introduced `remap_communities_to_previous`: #822