### PR TITLE
fix: evict stale nodes in _rebuild_code for graphify update (#1007)

### DIFF
--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -138,7 +138,7 @@ def _relativize_source_files(payload: dict, root: Path) -> None:
             if not source_path.is_absolute():
                 continue
             try:
-                item["source_file"] = str(source_path.resolve().relative_to(root))
+                item["source_file"] = source_path.resolve().relative_to(root).as_posix()
             except ValueError:
                 continue
 
@@ -376,7 +376,7 @@ def _rebuild_code(
                     # (e.g. .gitignore, vendored). Either way, evict any
                     # preserved nodes that still claim this source path.
                     try:
-                        deleted_paths.add(str(cand.relative_to(project_root)))
+                        deleted_paths.add(cand.relative_to(project_root).as_posix())
                     except ValueError:
                         deleted_paths.add(str(cand))
             if not wanted and not deleted_paths:
@@ -412,9 +412,29 @@ def _rebuild_code(
                 if changed_paths is not None:
                     for p in extract_targets:
                         try:
-                            evict_sources.add(str(p.relative_to(project_root)))
+                            evict_sources.add(p.relative_to(project_root).as_posix())
                         except ValueError:
                             evict_sources.add(str(p))
+                else:
+                    # Full re-extraction: reconcile against current code files to
+                    # evict nodes from files deleted since the last run (#1007).
+                    from graphify.build import _norm_source_file as _nsf
+                    _root_str = str(project_root)
+                    current_sources = {
+                        p.relative_to(project_root).as_posix()
+                        for p in code_files
+                        if p.is_relative_to(project_root)
+                    }
+                    for n in existing.get("nodes", []):
+                        sf = n.get("source_file")
+                        if not sf:
+                            continue
+                        if Path(sf).suffix.lower() not in _CODE_EXTENSIONS:
+                            continue
+                        norm = _nsf(sf, _root_str)
+                        if norm not in current_sources:
+                            evict_sources.add(sf)
+                            evict_sources.add(norm)
                 preserved_nodes = [
                     n for n in existing.get("nodes", [])
                     if n["id"] not in new_ast_ids

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -340,7 +340,7 @@ def _rebuild_code(
     try:
         from graphify.extract import extract, _get_extractor
         from graphify.detect import detect
-        from graphify.build import build_from_json
+        from graphify.build import build_from_json, _norm_source_file as _nsf
         from graphify.cluster import cluster, remap_communities_to_previous, score_all
         from graphify.analyze import god_nodes, surprising_connections, suggest_questions
         from graphify.report import generate
@@ -375,10 +375,7 @@ def _rebuild_code(
                     # File was deleted, renamed away, or filtered out by detect
                     # (e.g. .gitignore, vendored). Either way, evict any
                     # preserved nodes that still claim this source path.
-                    try:
-                        deleted_paths.add(cand.relative_to(project_root).as_posix())
-                    except ValueError:
-                        deleted_paths.add(str(cand))
+                    deleted_paths.add(_nsf(str(cand), str(project_root)) or str(cand))
             if not wanted and not deleted_paths:
                 print("[graphify watch] No tracked code files in change set - skipping rebuild.")
                 return True
@@ -411,16 +408,12 @@ def _rebuild_code(
                 evict_sources: set[str] = set(deleted_paths)
                 if changed_paths is not None:
                     for p in extract_targets:
-                        try:
-                            evict_sources.add(p.relative_to(project_root).as_posix())
-                        except ValueError:
-                            evict_sources.add(str(p))
+                        evict_sources.add(_nsf(str(p), str(project_root)) or str(p))
                 else:
                     # Full re-extraction: reconcile against current code files to
                     # evict nodes from files deleted since the last run (#1007).
                     # Use _norm_source_file on both sides so prune keys and node
                     # source_file attrs are normalised identically (mirrors build_merge).
-                    from graphify.build import _norm_source_file as _nsf
                     _root_str = str(project_root)
                     current_sources = {
                         _nsf(str(p.relative_to(project_root)), _root_str)

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -435,6 +435,7 @@ def _rebuild_code(
                         if norm not in current_sources:
                             evict_sources.add(sf)
                             evict_sources.add(norm)
+                            deleted_paths.add(norm)  # allow shrink-guard to pass
                 preserved_nodes = [
                     n for n in existing.get("nodes", [])
                     if n["id"] not in new_ast_ids

--- a/graphify/watch.py
+++ b/graphify/watch.py
@@ -418,10 +418,12 @@ def _rebuild_code(
                 else:
                     # Full re-extraction: reconcile against current code files to
                     # evict nodes from files deleted since the last run (#1007).
+                    # Use _norm_source_file on both sides so prune keys and node
+                    # source_file attrs are normalised identically (mirrors build_merge).
                     from graphify.build import _norm_source_file as _nsf
                     _root_str = str(project_root)
                     current_sources = {
-                        p.relative_to(project_root).as_posix()
+                        _nsf(str(p.relative_to(project_root)), _root_str)
                         for p in code_files
                         if p.is_relative_to(project_root)
                     }

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -168,11 +168,13 @@ def test_rebuild_code_evicts_nodes_from_deleted_files(tmp_path):
     # Delete utils.py
     (corpus / "utils.py").unlink()
 
-    # Full re-extraction via update — must evict stale nodes
-    assert _rebuild_code(corpus, acquire_lock=False, force=True) is True
+    # Full re-extraction via update — must evict stale nodes without --force
+    # (deleted_paths must be populated so shrink-guard passes on its own)
+    assert _rebuild_code(corpus, acquire_lock=False) is True
     data = json.loads(graph_path.read_text(encoding="utf-8"))
     node_labels_after = {n["label"] for n in data.get("nodes", [])}
-    assert "format_date()" not in node_labels_after, "stale node from deleted file must be evicted"
+    assert "format_date()" not in node_labels_after, "stale function node from deleted file must be evicted"
+    assert "utils.py" not in node_labels_after, "stale file node from deleted file must be evicted"
     assert "login()" in node_labels_after, "nodes from surviving file must be kept"
 
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -141,6 +141,41 @@ def test_rebuild_lock_does_not_accumulate_pids_across_runs(tmp_path):
         assert not lock_path.exists()
 
 
+def test_rebuild_code_evicts_nodes_from_deleted_files(tmp_path):
+    """#1007: graphify update (_rebuild_code with no changed_paths) must remove
+    nodes and edges from files deleted since the last run."""
+    import json
+    from graphify.watch import _rebuild_code
+
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+
+    # Two Python files
+    (corpus / "auth.py").write_text(
+        "def login(): pass\ndef logout(): pass\n", encoding="utf-8"
+    )
+    (corpus / "utils.py").write_text(
+        "def format_date(): pass\n", encoding="utf-8"
+    )
+
+    # Build initial graph with both files
+    assert _rebuild_code(corpus, acquire_lock=False) is True
+    graph_path = corpus / "graphify-out" / "graph.json"
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    node_labels_before = {n["label"] for n in data.get("nodes", [])}
+    assert "format_date()" in node_labels_before
+
+    # Delete utils.py
+    (corpus / "utils.py").unlink()
+
+    # Full re-extraction via update — must evict stale nodes
+    assert _rebuild_code(corpus, acquire_lock=False, force=True) is True
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    node_labels_after = {n["label"] for n in data.get("nodes", [])}
+    assert "format_date()" not in node_labels_after, "stale node from deleted file must be evicted"
+    assert "login()" in node_labels_after, "nodes from surviving file must be kept"
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="fcntl-only (POSIX)")
 def test_rebuild_lock_non_blocking_does_not_clobber_holder(tmp_path):
     """GH-858: a non-blocking caller that fails to acquire the lock must not


### PR DESCRIPTION
## Fix `graphify update` failing to evict stale nodes from deleted files (#1007)

### Problem

`graphify update` (`_rebuild_code` with no `changed_paths`) silently preserved nodes
from deleted files. The fix in `build_merge` (eef623a) covered `graphify extract`
but `_rebuild_code` has its own eviction logic that was not touched.

Reproduction with v8 branch after eef623a:

```
graphify extract corpus        # → 7 nodes (module-a + module-b)
rm -r corpus/module-b
graphify update corpus         # → "No code-graph topology changes detected" ✗
                               #    graph.json still has 7 nodes
```

### Root cause

When `changed_paths is None` (plain `graphify update`), `evict_sources` is never
populated — deleted files are simply absent from the new extraction and end up in
`preserved_nodes` unchanged:

```python
# watch.py — before this fix
evict_sources: set[str] = set(deleted_paths)   # always empty when changed_paths is None
if changed_paths is not None:
    ...                                         # evict_sources never filled for plain update
preserved_nodes = [
    n for n in existing.get("nodes", [])
    if n["id"] not in new_ast_ids
    and (not evict_sources or n.get("source_file") not in evict_sources)  # guard is no-op
]
```

Additionally, `str(cand.relative_to(project_root))` produces backslash paths on
Windows (`module-b\utils.py`) while `graph.json` stores forward-slash paths
(`module-b/utils.py`) — causing eviction to silently fail even when
`changed_paths` is provided.

### Fix

**watch.py — three changes:**

1. `_relativize_source_files` (line 141): `str(...)` → `.as_posix()` —
   fixes forward-slash normalization for absolute-path conversion.

2. `deleted_paths` / `evict_sources` (lines 379, 415): `str(...)` →
   `_norm_source_file(str(p), root)` — same function used in `build_merge`,
   so prune keys are normalized identically to node `source_file` attrs.

3. `_rebuild_code` reconciliation: when `changed_paths is None`, iterate
   existing graph nodes and build `current_sources` — both sides normalized
   via `_norm_source_file` so prune keys and node `source_file` attrs are
   compared identically (mirrors `build_merge` fix in eef623a).
   Any code node whose normalized source is absent from disk is added to
   `evict_sources` and `deleted_paths` (to pass the shrink-guard).

### Test

`tests/test_watch.py::test_rebuild_code_evicts_nodes_from_deleted_files` —
builds a two-file corpus, deletes one file, calls `_rebuild_code` directly,
asserts the deleted file's nodes are gone and the surviving file's nodes remain.

Full test run: 47 passed, 7 skipped across `test_build.py` and `test_watch.py`
(skipped: POSIX fcntl + watchdog — not applicable on Windows).
