### PR TITLE
add inheritance edges to the dart extractor

### DIFF
--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4089,8 +4089,51 @@ def extract_blade(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+def _strip_generics(text: str) -> str:
+    """Drop balanced `<...>` generic spans, including nested ones, so that
+    `Foo<A, Bar<B, C>>` collapses to `Foo`. A plain regex can't track nesting."""
+    out, depth = [], 0
+    for ch in text:
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(ch)
+    return "".join(out)
+
+
+# Dart class header, e.g. `Dog extends Animal with A, B implements C`. Clauses
+# are optional and always appear in this order; each captures a comma-separated
+# type list that `_dart_inheritance` splits.
+_DART_HEADER_RE = re.compile(
+    r"\bextends\s+(?P<extends>[\w, .]+?)\s*(?=\bwith\b|\bimplements\b|$)"
+    r"|\bwith\s+(?P<mixes_in>[\w, .]+?)\s*(?=\bimplements\b|$)"
+    r"|\bimplements\s+(?P<implements>[\w, .]+)$"
+)
+_DART_RELATIONS = {"extends": "inherits", "mixes_in": "mixes_in", "implements": "implements"}
+
+
+def _dart_inheritance(header: str):
+    """Yield (relation, base_type) pairs from a class declaration header.
+
+    `extends` -> inherits, `with` -> mixes_in, `implements` -> implements.
+    Generic arguments are removed first so commas inside them don't split a
+    base type. Targets are bare type names (cross-file resolution is out of
+    scope for the regex extractor, like how imports target a raw package path).
+    """
+    for m in _DART_HEADER_RE.finditer(_strip_generics(header)):
+        group = m.lastgroup
+        relation = _DART_RELATIONS[group]
+        for base in m.group(group).split(","):
+            base = base.strip()
+            if base:
+                yield relation, base
+
+
 def extract_dart(path: Path) -> dict:
-    """Extract classes, mixins, functions, imports, and calls from a .dart file using regex."""
+    """Extract classes, mixins, functions, imports, and inheritance
+    (extends/implements/with) from a .dart file using regex."""
     try:
         src = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
@@ -4104,16 +4147,35 @@ def extract_dart(path: Path) -> dict:
     edges = []
     defined: set[str] = set()
 
-    # Classes and mixins
-    for m in re.finditer(r"^\s*(?:abstract\s+)?(?:class|mixin)\s+(\w+)", src, re.MULTILINE):
-        nid = _make_id(stem, m.group(1))
-        if nid not in defined:
-            nodes.append({"id": nid, "label": m.group(1), "file_type": "code",
+    def add_node(node_id, label):
+        """Register a child node once; `defined` guards against duplicates."""
+        if node_id not in defined:
+            nodes.append({"id": node_id, "label": label, "file_type": "code",
                           "source_file": str(path), "source_location": None})
-            edges.append({"source": file_nid, "target": nid, "relation": "defines",
-                          "confidence": "EXTRACTED", "confidence_score": 1.0,
-                          "source_file": str(path), "source_location": None, "weight": 1.0})
-            defined.add(nid)
+            defined.add(node_id)
+
+    def add_edge(source, target, relation):
+        edges.append({"source": source, "target": target, "relation": relation,
+                      "confidence": "EXTRACTED", "confidence_score": 1.0,
+                      "source_file": str(path), "source_location": None, "weight": 1.0})
+
+    # Classes and mixins. Capture the declaration header (everything up to the
+    # opening brace, the `=` of a `class X = A with B;` alias, or `;`) so the
+    # extends/with/implements clauses can be parsed by `_dart_inheritance`.
+    for m in re.finditer(
+        r"^\s*(?:abstract\s+)?(?:class|mixin)\s+(\w+)(?:\s*<[^{=;]*>)?([^{=;]*)",
+        src, re.MULTILINE,
+    ):
+        cls = m.group(1)
+        nid = _make_id(stem, cls)
+        if nid not in defined:
+            add_node(nid, cls)
+            add_edge(file_nid, nid, "defines")
+
+        for relation, base in _dart_inheritance(m.group(2) or ""):
+            tgt_nid = _make_id(base)
+            add_node(tgt_nid, base)
+            add_edge(nid, tgt_nid, relation)
 
     # Top-level and member functions/methods
     for m in re.finditer(r"^\s*(?:static\s+|async\s+)?(?:\w+\s+)+(\w+)\s*\(", src, re.MULTILINE):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1060,3 +1060,91 @@ def test_dart_child_node_ids_are_stem_based(tmp_path):
         )
 
 
+def test_dart_extracts_inheritance_edges(tmp_path):
+    """extends -> inherits, with -> mixes_in, implements -> implements."""
+    from graphify.extract import extract_dart, _file_stem, _make_id
+
+    src_file = tmp_path / "sample.dart"
+    src_file.write_text(
+        "class Animal {}\n"
+        "mixin Walks {}\n"
+        "abstract class Pet {}\n"
+        "class Dog extends Animal with Walks implements Pet {}\n"
+    )
+
+    result = extract_dart(src_file)
+
+    stem = _file_stem(src_file)
+    dog_nid = _make_id(stem, "Dog")
+    edges = {
+        (e["source"], e["relation"], e["target"])
+        for e in result["edges"]
+    }
+
+    assert (dog_nid, "inherits", _make_id("Animal")) in edges, (
+        "extract_dart should emit an 'inherits' edge for `extends`."
+    )
+    assert (dog_nid, "mixes_in", _make_id("Walks")) in edges, (
+        "extract_dart should emit a 'mixes_in' edge for `with`."
+    )
+    assert (dog_nid, "implements", _make_id("Pet")) in edges, (
+        "extract_dart should emit an 'implements' edge for `implements`."
+    )
+
+
+def test_dart_inheritance_handles_multiple_bases_and_generics(tmp_path):
+    """Comma-separated `implements`/`with` lists each become an edge; generics are stripped."""
+    from graphify.extract import extract_dart, _file_stem, _make_id
+
+    src_file = tmp_path / "sample.dart"
+    src_file.write_text(
+        "class Cat extends Animal implements Pet, Comparable<Cat> {}\n"
+        "class Robot with Walks, Talks {}\n"
+    )
+
+    result = extract_dart(src_file)
+
+    stem = _file_stem(src_file)
+    cat_nid = _make_id(stem, "Cat")
+    robot_nid = _make_id(stem, "Robot")
+    edges = {
+        (e["source"], e["relation"], e["target"])
+        for e in result["edges"]
+    }
+
+    assert (cat_nid, "inherits", _make_id("Animal")) in edges
+    assert (cat_nid, "implements", _make_id("Pet")) in edges
+    # Generic argument `<Cat>` must be stripped from the base name.
+    assert (cat_nid, "implements", _make_id("Comparable")) in edges
+    assert (robot_nid, "mixes_in", _make_id("Walks")) in edges
+    assert (robot_nid, "mixes_in", _make_id("Talks")) in edges
+
+
+def test_dart_inheritance_strips_multi_arg_and_nested_generics(tmp_path):
+    """Commas inside generic args must not split a base type into fragments."""
+    from graphify.extract import extract_dart, _file_stem, _make_id
+
+    src_file = tmp_path / "sample.dart"
+    # The generic `<GFooItem, FooModelItem>` contains a comma; a naive split
+    # would wrongly produce `BaseMapper<GFooItem` and `FooModelItem>` targets.
+    src_file.write_text(
+        "class FooMapper extends BaseMapper<GFooItem, FooModelItem> {}\n"
+        "class Tree extends Node<Tree<int>> {}\n"
+    )
+
+    result = extract_dart(src_file)
+
+    stem = _file_stem(src_file)
+    foo_nid = _make_id(stem, "FooMapper")
+    tree_nid = _make_id(stem, "Tree")
+    labels = {n["id"]: n["label"] for n in result["nodes"]}
+    inherits = {}
+    for e in result["edges"]:
+        if e["relation"] == "inherits":
+            inherits.setdefault(e["source"], []).append(labels[e["target"]])
+
+    assert inherits.get(foo_nid) == ["BaseMapper"], inherits.get(foo_nid)
+    assert inherits.get(tree_nid) == ["Node"], inherits.get(tree_nid)
+    # No target label should retain angle brackets from a generic.
+    for label in labels.values():
+        assert "<" not in label and ">" not in label, label


### PR DESCRIPTION
## What

`extract_dart` only emitted `defines` (file→symbol) and `imports` (file→package) edges, so Dart graphs had **no symbol-to-symbol structure** — every class/mixin was a leaf hanging off its file. This parses the `extends` / `with` / `implements` clauses of class and mixin declarations and emits the corresponding edges, reusing relation names already in `SEMANTIC_RELATIONS`:

| Dart | edge relation |
|------|---------------|
| `extends Base` | `inherits` |
| `with Mixin` | `mixes_in` |
| `implements Iface` | `implements` |

Targets are the bare base-type name (cross-file class resolution is out of scope for the regex extractor, the same way `imports` targets a package by its raw string).

## Also

Fixed the docstring, which claimed it extracted **"calls"** — it never did.

## Design

- Clause parsing lives in a small `_dart_inheritance(header)` generator that yields `(relation, base_type)` pairs, so the call site stays a readable two-liner.
- Generic arguments are removed first by `_strip_generics`, which depth-counts `<...>` so nested generics like `BaseMapper<GFooItem, FooModelItem>` and `Node<Tree<int>>` collapse to the bare base type instead of leaving stray fragments — a plain `re.sub` can't track nesting.
- Node/edge creation uses local `add_node` / `add_edge` closures, matching the pattern the other extractors in this file already use.

## Verification

On the `material_3_demo` app from [`flutter/samples`](https://github.com/flutter/samples) (23 Dart files), inheritance edges originating from `.dart` files:

| | inheritance edges from Dart | malformed targets |
|---|---|---|
| before | 0 | 0 |
| after | 110 | 0 |

(The few inheritance edges the baseline already had came from non-Dart files via the existing extractors, not Dart.)

## Tests

Three new tests in `tests/test_extract.py` (synthetic sources, matching the existing Dart test style): basic `extends`/`with`/`implements`, multiple bases + generics, and a nested/multi-arg generic regression guard. Full `tests/test_extract.py` passes (79 tests).
