### PR TITLE
feat: add Azure OpenAI Service backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Install only what you need:
 | `leiden` | Leiden community detection (Python < 3.13 only) | `uv tool install "graphifyy[leiden]"` |
 | `ollama` | Ollama local inference | `uv tool install "graphifyy[ollama]"` |
 | `openai` | OpenAI / OpenAI-compatible APIs | `uv tool install "graphifyy[openai]"` |
+| `azure` | Azure OpenAI Service (uses openai package) | `uv tool install "graphifyy[openai]"` |
 | `gemini` | Google Gemini API | `uv tool install "graphifyy[gemini]"` |
 | `bedrock` | AWS Bedrock (uses IAM, no API key) | `uv tool install "graphifyy[bedrock]"` |
 | `sql` | SQL schema extraction | `uv tool install "graphifyy[sql]"` |
@@ -354,6 +355,10 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 | `OPENAI_API_KEY` | OpenAI or OpenAI-compatible APIs | `--backend openai` |
 | `DEEPSEEK_API_KEY` | DeepSeek backend | `--backend deepseek` |
 | `MOONSHOT_API_KEY` | Kimi Code backend | `--backend kimi` |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI Service backend | `--backend azure` |
+| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI resource endpoint URL | `--backend azure` (e.g. `https://my-resource.openai.azure.com/`) |
+| `AZURE_OPENAI_DEPLOYMENT` | Azure deployment name | `--backend azure` (default: `gpt-4o`) |
+| `AZURE_OPENAI_API_VERSION` | Azure API version | `--backend azure` (default: `2024-12-01-preview`) |
 | `OLLAMA_BASE_URL` | Ollama local inference URL | `--backend ollama` (default: `http://localhost:11434`) |
 | `OLLAMA_MODEL` | Ollama model name | `--backend ollama` (default: auto-detect) |
 | `GRAPHIFY_OLLAMA_NUM_CTX` | Override Ollama KV-cache window size | optional — auto-sized by default |
@@ -373,8 +378,8 @@ These are only needed for **headless / CI extraction** (`graphify extract`). Whe
 
 - **Code files** — processed locally via tree-sitter. Nothing leaves your machine.
 - **Video / audio** — transcribed locally with faster-whisper. Nothing leaves your machine.
-- **Docs, PDFs, images** — sent to your AI assistant for semantic extraction (via the `/graphify` skill, using whatever model your IDE session runs). Headless `graphify extract` requires `GEMINI_API_KEY` / `GOOGLE_API_KEY` (Gemini), `MOONSHOT_API_KEY` (Kimi), `ANTHROPIC_API_KEY` (Claude), `OPENAI_API_KEY` (OpenAI), `DEEPSEEK_API_KEY` (DeepSeek), a running Ollama instance (`OLLAMA_BASE_URL`), AWS credentials via the standard provider chain (Bedrock - no API key needed, uses IAM), or the `claude` CLI binary (Claude Code - no API key needed, uses your Claude subscription). The `--dedup-llm` flag uses the same key.
-- **Data residency** — `graphify extract` auto-detects which provider to use based on which API key is set (priority: Gemini → Kimi → Claude → OpenAI → DeepSeek → Bedrock → Ollama). For code with data-residency requirements, use `--backend ollama` (fully local) or pass an explicit `--backend` flag. Kimi (`MOONSHOT_API_KEY`) routes to Moonshot AI servers in China.
+- **Docs, PDFs, images** — sent to your AI assistant for semantic extraction (via the `/graphify` skill, using whatever model your IDE session runs). Headless `graphify extract` requires `GEMINI_API_KEY` / `GOOGLE_API_KEY` (Gemini), `MOONSHOT_API_KEY` (Kimi), `ANTHROPIC_API_KEY` (Claude), `OPENAI_API_KEY` (OpenAI), `DEEPSEEK_API_KEY` (DeepSeek), `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` (Azure OpenAI), a running Ollama instance (`OLLAMA_BASE_URL`), AWS credentials via the standard provider chain (Bedrock - no API key needed, uses IAM), or the `claude` CLI binary (Claude Code - no API key needed, uses your Claude subscription). The `--dedup-llm` flag uses the same key.
+- **Data residency** — `graphify extract` auto-detects which provider to use based on which API key is set (priority: Gemini → Kimi → Claude → OpenAI → DeepSeek → Azure → Bedrock → Ollama). For code with data-residency requirements, use `--backend ollama` (fully local), `--backend azure` (data stays in your Azure region), or pass an explicit `--backend` flag. Kimi (`MOONSHOT_API_KEY`) routes to Moonshot AI servers in China.
 - No telemetry, no usage tracking, no analytics.
 
 ---
@@ -506,11 +511,12 @@ graphify antigravity install       # .agents/rules + .agents/workflows (Google A
 graphify antigravity uninstall
 
 graphify extract ./docs                        # headless LLM extraction for CI (no IDE needed)
-graphify extract ./docs --backend gemini       # explicit backend: gemini, kimi, claude, openai, deepseek, ollama, bedrock, or claude-cli
+graphify extract ./docs --backend gemini       # explicit backend: gemini, kimi, claude, openai, deepseek, azure, ollama, bedrock, or claude-cli
 graphify extract ./docs --backend gemini --model gemini-3.1-pro-preview
 graphify extract ./docs --backend ollama       # local Ollama (set OLLAMA_BASE_URL / OLLAMA_MODEL) - no API key needed for loopback
 GRAPHIFY_OLLAMA_NUM_CTX=32768 graphify extract ./docs --backend ollama   # override KV-cache window (auto-sized by default)
 GRAPHIFY_OLLAMA_KEEP_ALIVE=0 graphify extract ./docs --backend ollama    # unload model after each chunk (saves VRAM on small GPUs)
+graphify extract ./docs --backend azure        # Azure OpenAI Service (set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT)
 graphify extract ./docs --backend bedrock      # AWS Bedrock via IAM - no API key, uses AWS credential chain
 graphify extract ./docs --backend claude-cli   # route through Claude Code CLI - no API key, uses your Claude subscription
 graphify extract ./docs --max-workers 16       # AST parallelism (also GRAPHIFY_MAX_WORKERS)

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -3567,6 +3567,7 @@ def main() -> None:
                     "error: no LLM API key found. Set GEMINI_API_KEY or GOOGLE_API_KEY "
                     "(gemini), MOONSHOT_API_KEY (kimi), ANTHROPIC_API_KEY (claude), "
                     "OPENAI_API_KEY (openai), DEEPSEEK_API_KEY (deepseek), "
+                    "AZURE_OPENAI_API_KEY+AZURE_OPENAI_ENDPOINT (azure), "
                     "or pass --backend.",
                     file=sys.stderr,
                 )

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -99,6 +99,19 @@ BACKENDS: dict[str, dict] = {
         "temperature": 0,
         "max_tokens": 16384,
     },
+    "azure": {
+        # Azure OpenAI Service — uses AzureOpenAI SDK client, not the standard
+        # OpenAI client, so it has its own call path (_call_azure).
+        # Required env vars: AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT.
+        # Optional: AZURE_OPENAI_API_VERSION (defaults to 2024-12-01-preview),
+        #           AZURE_OPENAI_DEPLOYMENT or GRAPHIFY_AZURE_MODEL (deployment name).
+        "default_model": os.environ.get("AZURE_OPENAI_DEPLOYMENT", os.environ.get("GRAPHIFY_AZURE_MODEL", "gpt-4o")),
+        "env_key": "AZURE_OPENAI_API_KEY",
+        "model_env_key": "GRAPHIFY_AZURE_MODEL",
+        "pricing": {"input": 2.50, "output": 10.00},  # USD per 1M tokens (gpt-4o)
+        "temperature": 0,
+        "max_tokens": 16384,
+    },
     "bedrock": {
         "default_model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
         "model_env_key": "GRAPHIFY_BEDROCK_MODEL",
@@ -610,6 +623,72 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
     return result
 
 
+def _call_azure(
+    api_key: str,
+    endpoint: str,
+    model: str,
+    user_message: str,
+    temperature: float | None = 0,
+    max_tokens: int = 8192,
+    *,
+    deep_mode: bool = False,
+) -> dict:
+    """Call Azure OpenAI Service via the AzureOpenAI SDK client."""
+    try:
+        from openai import AzureOpenAI
+    except ImportError as exc:
+        raise ImportError(
+            "Azure OpenAI extraction requires the openai package. "
+            "Run: pip install openai"
+        ) from exc
+
+    api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview").strip()
+    timeout_raw = os.environ.get("GRAPHIFY_API_TIMEOUT", "").strip()
+    timeout_s: float = 600.0
+    if timeout_raw:
+        try:
+            v = float(timeout_raw)
+            if v > 0:
+                timeout_s = v
+        except ValueError:
+            pass
+
+    client = AzureOpenAI(
+        api_key=api_key,
+        azure_endpoint=endpoint,
+        api_version=api_version,
+        timeout=timeout_s,
+    )
+    kwargs: dict = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _extraction_system(deep=deep_mode)},
+            {"role": "user", "content": user_message},
+        ],
+        "max_tokens": max_tokens,
+    }
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+
+    resp = client.chat.completions.create(**kwargs)
+    if not resp.choices or resp.choices[0].message is None:
+        raise ValueError("Azure OpenAI returned empty or filtered response")
+    raw_content = resp.choices[0].message.content
+    result = _parse_llm_json(raw_content or "{}")
+    result["input_tokens"] = resp.usage.prompt_tokens if resp.usage else 0
+    result["output_tokens"] = resp.usage.completion_tokens if resp.usage else 0
+    result["model"] = model
+    result["finish_reason"] = resp.choices[0].finish_reason
+    if _response_is_hollow(raw_content, result) and result["finish_reason"] != "length":
+        print(
+            "[graphify] azure returned a hollow response; treating as "
+            "truncation so adaptive retry can bisect the chunk.",
+            file=sys.stderr,
+        )
+        result["finish_reason"] = "length"
+    return result
+
+
 def _call_bedrock(model: str, user_message: str, max_tokens: int = 8192, *, deep_mode: bool = False) -> dict:
     """Call AWS Bedrock via boto3 Converse API using the standard AWS credential chain."""
     try:
@@ -674,7 +753,8 @@ def extract_files_direct(
         if backend is None:
             raise ValueError(
                 "No LLM backend configured. Set one of: GEMINI_API_KEY, ANTHROPIC_API_KEY, "
-                "OPENAI_API_KEY, DEEPSEEK_API_KEY, MOONSHOT_API_KEY, OLLAMA_BASE_URL, "
+                "OPENAI_API_KEY, DEEPSEEK_API_KEY, MOONSHOT_API_KEY, "
+                "AZURE_OPENAI_API_KEY+AZURE_OPENAI_ENDPOINT, OLLAMA_BASE_URL, "
                 "or AWS credentials. Pass backend= explicitly to select a provider."
             )
     if backend not in BACKENDS:
@@ -710,6 +790,22 @@ def extract_files_direct(
         return _call_claude_cli(user_msg, max_tokens=max_out, deep_mode=deep_mode)
     if backend == "bedrock":
         return _call_bedrock(mdl, user_msg, max_tokens=max_out, deep_mode=deep_mode)
+    if backend == "azure":
+        endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+        if not endpoint:
+            raise ValueError(
+                "Azure OpenAI backend requires AZURE_OPENAI_ENDPOINT to be set "
+                "(e.g. https://my-resource.openai.azure.com/)."
+            )
+        return _call_azure(
+            key,
+            endpoint,
+            mdl,
+            user_msg,
+            temperature=cfg.get("temperature", 0),
+            max_tokens=max_out,
+            deep_mode=deep_mode,
+        )
     return _call_openai_compat(
         cfg["base_url"],
         key,
@@ -1161,6 +1257,28 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
         )
         return resp.get("output", {}).get("message", {}).get("content", [{}])[0].get("text", "")
 
+    if backend == "azure":
+        endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+        if not endpoint:
+            raise ValueError(
+                "Azure OpenAI backend requires AZURE_OPENAI_ENDPOINT to be set."
+            )
+        try:
+            from openai import AzureOpenAI
+        except ImportError as exc:
+            raise ImportError("openai package required for azure backend") from exc
+        api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview").strip()
+        azure_client = AzureOpenAI(api_key=key, azure_endpoint=endpoint, api_version=api_version)
+        resp = azure_client.chat.completions.create(
+            model=mdl,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+            temperature=cfg.get("temperature", 0),
+        )
+        if not resp.choices or resp.choices[0].message is None:
+            raise ValueError("Azure OpenAI returned empty or filtered response")
+        return resp.choices[0].message.content or ""
+
     # OpenAI-compatible (kimi, openai, gemini, ollama)
     try:
         from openai import OpenAI
@@ -1231,7 +1349,7 @@ def _validate_ollama_base_url(url: str) -> None:
 def detect_backend() -> str | None:
     """Return the name of whichever backend has an API key set, or None.
 
-    Priority: gemini → kimi → claude → openai → bedrock → ollama (last, opt-in).
+    Priority: gemini → kimi → claude → openai → deepseek → azure → bedrock → ollama (last, opt-in).
 
     Ollama is intentionally checked LAST so a paid API key (Anthropic/OpenAI/etc.)
     is never silently shadowed by an incidental OLLAMA_BASE_URL in the environment
@@ -1242,6 +1360,8 @@ def detect_backend() -> str | None:
     for backend in ("gemini", "kimi", "claude", "openai", "deepseek"):
         if _get_backend_api_key(backend):
             return backend
+    if _get_backend_api_key("azure") and os.environ.get("AZURE_OPENAI_ENDPOINT"):
+        return "azure"
     if os.environ.get("AWS_PROFILE") or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"):
         return "bedrock"
     ollama_url = os.environ.get("OLLAMA_BASE_URL")
@@ -1249,7 +1369,7 @@ def detect_backend() -> str | None:
         _validate_ollama_base_url(ollama_url)
         return "ollama"
     for name in BACKENDS:
-        if name not in ("gemini", "kimi", "claude", "openai", "deepseek", "bedrock", "ollama", "claude-cli"):
+        if name not in ("gemini", "kimi", "claude", "openai", "deepseek", "azure", "bedrock", "ollama", "claude-cli"):
             if _get_backend_api_key(name):
                 return name
     return None

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -105,10 +105,12 @@ BACKENDS: dict[str, dict] = {
         # Required env vars: AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT.
         # Optional: AZURE_OPENAI_API_VERSION (defaults to 2024-12-01-preview),
         #           AZURE_OPENAI_DEPLOYMENT or GRAPHIFY_AZURE_MODEL (deployment name).
+        # base_url is intentionally absent — prevents accidental routing through
+        # _call_openai_compat, which requires it and uses the wrong SDK client class.
         "default_model": os.environ.get("AZURE_OPENAI_DEPLOYMENT", os.environ.get("GRAPHIFY_AZURE_MODEL", "gpt-4o")),
         "env_key": "AZURE_OPENAI_API_KEY",
         "model_env_key": "GRAPHIFY_AZURE_MODEL",
-        "pricing": {"input": 2.50, "output": 10.00},  # USD per 1M tokens (gpt-4o)
+        "pricing": {"input": 2.50, "output": 10.00},  # USD per 1M tokens (gpt-4o; may mis-estimate other deployments)
         "temperature": 0,
         "max_tokens": 16384,
     },
@@ -623,6 +625,31 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
     return result
 
 
+def _azure_client(api_key: str, endpoint: str):
+    """Construct an AzureOpenAI client with env-driven api_version and timeout.
+
+    Single construction point so _call_azure and _call_llm can't diverge on
+    api_version or timeout handling.
+    """
+    try:
+        from openai import AzureOpenAI
+    except ImportError as exc:
+        raise ImportError(
+            "Azure OpenAI requires the openai package. Run: pip install openai"
+        ) from exc
+    api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview").strip()
+    timeout_raw = os.environ.get("GRAPHIFY_API_TIMEOUT", "").strip()
+    timeout_s: float = 600.0
+    if timeout_raw:
+        try:
+            v = float(timeout_raw)
+            if v > 0:
+                timeout_s = v
+        except ValueError:
+            pass
+    return AzureOpenAI(api_key=api_key, azure_endpoint=endpoint, api_version=api_version, timeout=timeout_s)
+
+
 def _call_azure(
     api_key: str,
     endpoint: str,
@@ -634,38 +661,14 @@ def _call_azure(
     deep_mode: bool = False,
 ) -> dict:
     """Call Azure OpenAI Service via the AzureOpenAI SDK client."""
-    try:
-        from openai import AzureOpenAI
-    except ImportError as exc:
-        raise ImportError(
-            "Azure OpenAI extraction requires the openai package. "
-            "Run: pip install openai"
-        ) from exc
-
-    api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview").strip()
-    timeout_raw = os.environ.get("GRAPHIFY_API_TIMEOUT", "").strip()
-    timeout_s: float = 600.0
-    if timeout_raw:
-        try:
-            v = float(timeout_raw)
-            if v > 0:
-                timeout_s = v
-        except ValueError:
-            pass
-
-    client = AzureOpenAI(
-        api_key=api_key,
-        azure_endpoint=endpoint,
-        api_version=api_version,
-        timeout=timeout_s,
-    )
+    client = _azure_client(api_key, endpoint)
     kwargs: dict = {
         "model": model,
         "messages": [
             {"role": "system", "content": _extraction_system(deep=deep_mode)},
             {"role": "user", "content": user_message},
         ],
-        "max_tokens": max_tokens,
+        "max_completion_tokens": max_tokens,
     }
     if temperature is not None:
         kwargs["temperature"] = temperature
@@ -1263,16 +1266,11 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
             raise ValueError(
                 "Azure OpenAI backend requires AZURE_OPENAI_ENDPOINT to be set."
             )
-        try:
-            from openai import AzureOpenAI
-        except ImportError as exc:
-            raise ImportError("openai package required for azure backend") from exc
-        api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview").strip()
-        azure_client = AzureOpenAI(api_key=key, azure_endpoint=endpoint, api_version=api_version)
+        azure_client = _azure_client(key, endpoint)
         resp = azure_client.chat.completions.create(
             model=mdl,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=max_tokens,
+            max_completion_tokens=max_tokens,
             temperature=cfg.get("temperature", 0),
         )
         if not resp.choices or resp.choices[0].message is None:

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -15,6 +15,9 @@ def _clear_backend_env(monkeypatch):
         "MOONSHOT_API_KEY",
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
     ):
         monkeypatch.delenv(env_key, raising=False)
 
@@ -513,3 +516,80 @@ def test_adaptive_retry_bisects_on_hollow_ollama_response(tmp_path):
         "full chunk came back hollow"
     )
     assert calls["n"] == 3  # 1 hollow + 2 successful halves
+
+
+# ---------------------------------------------------------------------------
+# Azure backend
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_azure_openai(monkeypatch, fake_resp):
+    """Inject a stub openai module with AzureOpenAI so _call_azure and
+    _azure_client can run without the real SDK installed."""
+    import sys
+    import types
+
+    captured: dict = {}
+
+    class _FakeAzureOpenAI:
+        def __init__(self, *_, **kwargs):
+            captured["init_kwargs"] = kwargs
+            self.chat = self
+            self.completions = self
+
+        def create(self, **kwargs):
+            captured["create_kwargs"] = kwargs
+            return fake_resp
+
+    fake_module = types.ModuleType("openai")
+    fake_module.AzureOpenAI = _FakeAzureOpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+    return captured
+
+
+def test_call_azure_uses_correct_client_params_and_max_completion_tokens(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview")
+    monkeypatch.delenv("GRAPHIFY_API_TIMEOUT", raising=False)
+
+    fake_resp = _fake_openai_response(
+        '{"nodes":[{"id":"a"}],"edges":[],"hyperedges":[]}',
+        finish_reason="stop",
+        prompt_tokens=100,
+        completion_tokens=50,
+    )
+    captured = _install_fake_azure_openai(monkeypatch, fake_resp)
+
+    result = llm._call_azure(
+        api_key="test-key",
+        endpoint="https://my-resource.openai.azure.com/",
+        model="gpt-4o",
+        user_message="test",
+    )
+
+    assert captured["init_kwargs"].get("azure_endpoint") == "https://my-resource.openai.azure.com/"
+    assert captured["init_kwargs"].get("api_version") == "2024-08-01-preview"
+    assert "max_completion_tokens" in captured["create_kwargs"], "must use max_completion_tokens not max_tokens"
+    assert "max_tokens" not in captured["create_kwargs"], "deprecated max_tokens must not be sent"
+    assert result["nodes"] == [{"id": "a"}]
+
+
+def test_detect_backend_returns_azure_when_both_vars_set(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-key")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://my-resource.openai.azure.com/")
+
+    assert llm.detect_backend() == "azure"
+    assert llm._get_backend_api_key("azure") == "azure-key"
+
+
+def test_detect_backend_azure_requires_endpoint_not_just_key(monkeypatch):
+    _clear_backend_env(monkeypatch)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-key")
+    # AZURE_OPENAI_ENDPOINT already cleared by _clear_backend_env
+
+    assert llm.detect_backend() != "azure"
+
+
+def test_estimate_cost_azure_no_keyerror():
+    cost = llm.estimate_cost("azure", 1_000_000, 500_000)
+    assert cost == pytest.approx(2.50 + 5.00)  # 1M in * $2.50/M + 0.5M out * $10.00/M


### PR DESCRIPTION
Adds full support for Azure OpenAI as a new LLM backend alongside the existing OpenAI, Anthropic, Gemini, Kimi, DeepSeek, Bedrock, and Ollama backends.

- `_call_azure()` — dedicated Azure dispatch using `AzureOpenAI` SDK client (requires `azure_endpoint` + `api_version`, distinct from the shared `_call_openai_compat()` path)
- `BACKENDS["azure"]` — config entry with env-driven deployment name, GPT-4o pricing defaults, and `api_version` fallback
- `detect_backend()` — auto-detects Azure when both `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set
- `extract_files_direct()` and `_call_llm()` — both dispatch sites updated with Azure branches
- README — documents env vars, optional extras, privacy/data-residency note, and CLI cheat-sheet example