### PR TITLE
feat: support ANTHROPIC_BASE_URL for custom API endpoints

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -119,6 +119,20 @@ BACKENDS: dict[str, dict] = {
 }
 
 
+_ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
+
+
+def _anthropic_base_url() -> str:
+    """Return the Anthropic API base URL, respecting ANTHROPIC_BASE_URL env var.
+
+    Falls back to the default (https://api.anthropic.com) when the env var is
+    unset or empty.  This allows routing requests through corporate API gateways,
+    LiteLLM proxies, or other Anthropic-compatible endpoints.
+    """
+    url = os.environ.get("ANTHROPIC_BASE_URL", "").strip()
+    return url if url else _ANTHROPIC_DEFAULT_BASE_URL
+
+
 def _custom_providers_path(global_: bool = True) -> Path:
     if global_:
         return Path.home() / ".graphify" / "providers.json"
@@ -484,7 +498,10 @@ def _call_claude(api_key: str, model: str, user_message: str, max_tokens: int = 
             "Run: pip install anthropic"
         ) from exc
 
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.Anthropic(
+        api_key=api_key,
+        base_url=_anthropic_base_url(),
+    )
     resp = client.messages.create(
         model=model,
         max_tokens=max_tokens,
@@ -1116,7 +1133,10 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
             import anthropic
         except ImportError as exc:
             raise ImportError("anthropic package required for claude backend") from exc
-        client = anthropic.Anthropic(api_key=key)
+        client = anthropic.Anthropic(
+            api_key=key,
+            base_url=_anthropic_base_url(),
+        )
         resp = client.messages.create(
             model=mdl,
             max_tokens=max_tokens,


### PR DESCRIPTION
## Problem

The Claude backend hardcodes `base_url` to `https://api.anthropic.com`, making it impossible to route requests through Anthropic-compatible API gateways or proxies.

This breaks usage behind:
- Corporate API gateways (our use case — a centralized gateway that routes to Bedrock)
- LiteLLM / other proxy servers
- Self-hosted Anthropic-compatible endpoints

## Fix

Read `ANTHROPIC_BASE_URL` from the environment and pass it to the `anthropic.Anthropic()` constructor. Falls back to `https://api.anthropic.com` when unset — fully backwards-compatible.

This matches the convention used by the [official Anthropic Python SDK](https://github.com/anthropics/anthropic-sdk-python#usage) itself, which respects this env var.

## Changes

`graphify/llm.py`: Two call sites patched:
1. `_call_claude()` — used for semantic extraction
2. `_call_llm()` claude backend — used for query/cluster

## Testing

Verified with a corporate API gateway (Anthropic Messages API compatible, JWT auth):
```bash
export ANTHROPIC_API_KEY=$JWT_TOKEN
export ANTHROPIC_BASE_URL=https://gateway.example.com
graphify . --update --backend claude --model claude-haiku-4-5-20251001
# → Successfully extracts via gateway
```

Without the env var set, behavior is identical to before (hits api.anthropic.com).