### PR TITLE
feat(hooks): close the Read-tool graph bypass (Read/Glob + multi-file reads)

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -192,6 +192,8 @@ def _print_project_git_add_hint(paths: list[Path]) -> None:
 _SETTINGS_HOOK = {
     # Claude Code v2.1.117+ removed dedicated Grep/Glob tools; searches now go through Bash.
     # We match on Bash and inspect the command string to avoid firing on every shell call.
+    # The search arm nudges grep/rg/find/etc.; the content-read arm nudges multi-file
+    # cat/head/tail/sed/awk (single-file reads stay silent so the nudge does not become spam).
     "matcher": "Bash",
     "hooks": [
         {
@@ -200,12 +202,60 @@ _SETTINGS_HOOK = {
                 "CMD=$(python3 -c \""
                 "import json,sys; d=json.load(sys.stdin); "
                 "print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); "
+                "REST=\"${CMD#* }\"; "
                 "case \"$CMD\" in "
+                # --- search commands (existing set, unchanged payload) ---
                 r"*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *) "
                 "  [ -f graphify-out/graph.json ] && "
                 r"""  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: knowledge graph at graphify-out/. For focused questions, run `graphify query \"<question>\"` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context."}}' """
                 "  || true ;; "
+                # --- multi-file content reads (new) ---
+                r"cat\ *|head\ *|tail\ *|sed\ *|awk\ *) "
+                "  case \"$CMD\" in "
+                r"    *\>*|*\<\<*|*\|*|*graphify-out/*) ;; "
+                r"    *\**|*\?*|*\[*) "
+                "      [ -f graphify-out/graph.json ] && "
+                r"""      echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: knowledge graph at graphify-out/. Before reading multiple source files, run `graphify query \"<question>\"` / `graphify explain \"<concept>\"` (scoped subgraph) or `graphify path \"<A>\" \"<B>\"` for relationships. Read raw files only to modify/debug specific code or when the graph lacks the detail."}}' """
+                "      || true ;; "
+                "    *) case \"$REST\" in "
+                r"        */*\ */*|*/*\ *.[A-Za-z0-9]*|*.[A-Za-z0-9]*\ */*|*.[A-Za-z0-9]*\ *.[A-Za-z0-9]*) "
+                "          [ -f graphify-out/graph.json ] && "
+                r"""          echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: knowledge graph at graphify-out/. Before reading multiple source files, run `graphify query \"<question>\"` / `graphify explain \"<concept>\"` (scoped subgraph) or `graphify path \"<A>\" \"<B>\"` for relationships. Read raw files only to modify/debug specific code or when the graph lacks the detail."}}' """
+                "          || true ;; "
+                "      esac ;; "
+                "  esac ;; "
                 "esac"
+            ),
+        }
+    ],
+}
+
+_READ_SETTINGS_HOOK = {
+    # Claude Code routes file reads through the Read tool and globbing through Glob.
+    # A query-first nudge on Bash search alone misses the agent that answers a question
+    # by Read-ing many source files. We match Read|Glob, inspect the target path, and
+    # nudge only for source/doc files outside graphify-out/. Never blocks.
+    "matcher": "Read|Glob",
+    "hooks": [
+        {
+            "type": "command",
+            "command": (
+                "HIT=$(python3 -c \""
+                "import json,sys,os;"
+                "d=json.load(sys.stdin);"
+                "t=d.get('tool_input',d);"
+                "p=t.get('file_path') or t.get('pattern') or '';"
+                "b=t.get('path') or '';"
+                "s=(p+' '+b).lower();"
+                # never nudge on the graph's own outputs
+                "ok='graphify-out/' not in s and 'graphify-out\\\\\\\\' not in s;"
+                # source/doc suffix allowlist (closed set: unknown ext stays silent)
+                "exts=('.py','.js','.ts','.tsx','.jsx','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.sh','.md','.rst','.txt','.mdx');"
+                "hit=ok and any(e in s for e in exts);"
+                "sys.stdout.write('HIT' if hit else '')\" 2>/dev/null || true); "
+                "if [ \"$HIT\" = HIT ] && [ -f graphify-out/graph.json ]; then "
+                r"""  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"graphify: knowledge graph at graphify-out/. For focused questions, run `graphify query \"<question>\"` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of reading raw source files. Read GRAPH_REPORT.md only for broad architecture context."}}'; """
+                "fi || true"
             ),
         }
     ],
@@ -447,7 +497,7 @@ _CLAUDE_MD_SECTION = """\
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
@@ -465,7 +515,7 @@ This project has a knowledge graph at graphify-out/ with god nodes, community st
 When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
 
 Rules:
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
@@ -480,7 +530,7 @@ _GEMINI_MD_SECTION = """\
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
-- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
@@ -706,7 +756,7 @@ description: Consult the graphify knowledge graph at graphify-out/ for codebase 
 This project has a graphify knowledge graph at graphify-out/.
 
 Rules:
-- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (CLI) or `query_graph` (MCP). Use `graphify path "<A>" "<B>"` / `shortest_path` for relationships and `graphify explain "<concept>"` / `get_node` for focused concepts. These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output.
+- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (CLI) or `query_graph` (MCP). Use `graphify path "<A>" "<B>"` / `shortest_path` for relationships and `graphify explain "<concept>"` / `get_node` for focused concepts. These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
@@ -734,7 +784,7 @@ inclusion: always
 graphify: A knowledge graph of this project lives in `graphify-out/`. \
 For codebase, architecture, or dependency questions, when `graphify-out/graph.json` exists, \
 first run `graphify query "<question>"` (or `graphify path "<A>" "<B>"` / `graphify explain "<concept>"`). \
-These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output. \
+These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output. Prefer these over grepping or reading source files directly. \
 Read `GRAPH_REPORT.md` only for broad architecture review or when those commands do not surface enough context.
 """
 
@@ -893,7 +943,7 @@ alwaysApply: true
 
 This project has a graphify knowledge graph at graphify-out/.
 
-- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (or `graphify path "<A>" "<B>"` / `graphify explain "<concept>"`). These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output.
+- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (or `graphify path "<A>" "<B>"` / `graphify explain "<concept>"`). These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
@@ -936,7 +986,7 @@ _DEVIN_RULES = """\
 This project has a graphify knowledge graph at graphify-out/.
 
 Rules:
-- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (or `graphify path "<A>" "<B>"` / `graphify explain "<concept>"`). These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output.
+- For codebase or architecture questions, when `graphify-out/graph.json` exists, first run `graphify query "<question>"` (or `graphify path "<A>" "<B>"` / `graphify explain "<concept>"`). These return a scoped subgraph, usually much smaller than `GRAPH_REPORT.md` or raw grep output. Prefer them over grepping or reading source files directly to answer a question.
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
@@ -1547,8 +1597,9 @@ def _install_claude_hook(project_dir: Path) -> None:
     hooks = settings.setdefault("hooks", {})
     pre_tool = hooks.setdefault("PreToolUse", [])
 
-    hooks["PreToolUse"] = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash") and "graphify" in str(h))]
+    hooks["PreToolUse"] = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash", "Read|Glob") and "graphify" in str(h))]
     hooks["PreToolUse"].append(_SETTINGS_HOOK)
+    hooks["PreToolUse"].append(_READ_SETTINGS_HOOK)
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     print(f"  .claude/settings.json  ->  PreToolUse hook registered")
 
@@ -1563,7 +1614,7 @@ def _uninstall_claude_hook(project_dir: Path) -> None:
     except json.JSONDecodeError:
         return
     pre_tool = settings.get("hooks", {}).get("PreToolUse", [])
-    filtered = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash") and "graphify" in str(h))]
+    filtered = [h for h in pre_tool if not (h.get("matcher") in ("Glob|Grep", "Bash", "Read|Glob") and "graphify" in str(h))]
     if len(filtered) == len(pre_tool):
         return
     settings["hooks"]["PreToolUse"] = filtered

--- a/tests/test_claude_md.py
+++ b/tests/test_claude_md.py
@@ -134,3 +134,68 @@ def test_uninstall_removes_settings_hook(tmp_path):
         settings = json.loads(settings_path.read_text())
         hooks = settings.get("hooks", {}).get("PreToolUse", [])
         assert not any(h.get("matcher") == "Bash" and "graphify" in str(h) for h in hooks)
+
+
+# ---------------------------------------------------------------------------
+# settings.json Read|Glob PreToolUse hook (issue #1114)
+# ---------------------------------------------------------------------------
+
+def test_install_settings_json_has_read_matcher(tmp_path):
+    """claude_install also registers a Read-tool PreToolUse hook so a query-first
+    nudge fires when the agent answers a question by Read-ing source files, not
+    just by grepping through Bash."""
+    import json
+    claude_install(tmp_path)
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    hooks = settings["hooks"]["PreToolUse"]
+    read_hooks = [h for h in hooks if "Read" in (h.get("matcher") or "") and "graphify" in str(h)]
+    assert len(read_hooks) == 1
+
+
+def test_install_settings_json_has_glob_matcher(tmp_path):
+    """The same hook (or a sibling) covers the Glob tool too."""
+    import json
+    claude_install(tmp_path)
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    hooks = settings["hooks"]["PreToolUse"]
+    assert any("Glob" in (h.get("matcher") or "") and "graphify" in str(h) for h in hooks)
+
+
+def test_install_settings_json_idempotent_read_hook(tmp_path):
+    """Reinstall must not accumulate duplicate Read hooks. This is the regression
+    that fails unless the matcher-keyed dedup filter is extended to cover the new
+    Read|Glob matcher."""
+    import json
+    claude_install(tmp_path)
+    claude_install(tmp_path)
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    hooks = settings["hooks"]["PreToolUse"]
+    read_hooks = [h for h in hooks if "Read" in (h.get("matcher") or "") and "graphify" in str(h)]
+    assert len(read_hooks) == 1
+
+
+def test_uninstall_removes_read_hook(tmp_path):
+    """claude_uninstall drops the Read|Glob graphify hook too (symmetric filter)."""
+    import json
+    claude_install(tmp_path)
+    claude_uninstall(tmp_path)
+    settings_path = tmp_path / ".claude" / "settings.json"
+    if settings_path.exists():
+        settings = json.loads(settings_path.read_text())
+        hooks = settings.get("hooks", {}).get("PreToolUse", [])
+        assert not any("Read" in (h.get("matcher") or "") and "graphify" in str(h) for h in hooks)
+
+
+def test_bash_hook_command_covers_multi_file_reads(tmp_path):
+    """The broadened Bash hook command also matches multi-file content reads
+    (cat/head/tail/sed/awk), not only the search tools."""
+    import json
+    claude_install(tmp_path)
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    hooks = settings["hooks"]["PreToolUse"]
+    bash_hooks = [h for h in hooks if h.get("matcher") == "Bash" and "graphify" in str(h)]
+    assert len(bash_hooks) == 1
+    cmd = bash_hooks[0]["hooks"][0]["command"]
+    assert r"cat\ *|head\ *|tail\ *|sed\ *|awk\ *" in cmd
+    # the original search arm must remain byte-identical
+    assert r"*grep*|*rg\ *|*ripgrep*|*find\ *|*fd\ *|*ack\ *|*ag\ *" in cmd

--- a/tests/test_install_strings.py
+++ b/tests/test_install_strings.py
@@ -13,6 +13,7 @@ import json
 
 from graphify.__main__ import (
     _SETTINGS_HOOK,
+    _READ_SETTINGS_HOOK,
     _CLAUDE_MD_SECTION,
     _AGENTS_MD_SECTION,
     _GEMINI_MD_SECTION,
@@ -31,6 +32,7 @@ from graphify.__main__ import (
 # against the actual payload text the assistant will receive.
 _INSTALL_TEXTS: dict[str, str] = {
     "_SETTINGS_HOOK": json.dumps(_SETTINGS_HOOK),
+    "_READ_SETTINGS_HOOK": json.dumps(_READ_SETTINGS_HOOK),
     "_CLAUDE_MD_SECTION": _CLAUDE_MD_SECTION,
     "_AGENTS_MD_SECTION": _AGENTS_MD_SECTION,
     "_GEMINI_MD_SECTION": _GEMINI_MD_SECTION,
@@ -45,11 +47,12 @@ _INSTALL_TEXTS: dict[str, str] = {
 
 
 def test_every_install_surface_recommends_graphify_query():
-    """All ten install surfaces must point the assistant at `graphify query`
-    as the first action for codebase questions. This is the load-bearing
-    fix for issue #580 — the alternative (reading GRAPH_REPORT.md) costs
-    ~10x more tokens per question and made the project worse-than-baseline
-    in real Claude Code sessions."""
+    """Every install surface (including the Read|Glob hook payload added for
+    issue #1114) must point the assistant at `graphify query` as the first
+    action for codebase questions. This is the load-bearing fix for issue
+    #580 — the alternative (reading GRAPH_REPORT.md) costs ~10x more tokens
+    per question and made the project worse-than-baseline in real Claude
+    Code sessions."""
     missing: list[str] = []
     for name, text in _INSTALL_TEXTS.items():
         if "graphify query" not in text:
@@ -91,6 +94,45 @@ def test_no_install_surface_demands_reading_the_full_report_first():
         f"banned report-first phrasing reappeared: {hits}. "
         f"This regresses issue #580."
     )
+
+
+def test_query_first_surfaces_also_cover_reading_files():
+    """Issue #1114: the query-first guidance must name reading source files (not
+    only grepping) as the action graphify displaces. The Read-tool bypass — an
+    agent answering a question by Read-ing many files one at a time — is invisible
+    to a grep-only nudge, so the always-on prose has to say it in words too."""
+    read_cover = {
+        "_CLAUDE_MD_SECTION": _CLAUDE_MD_SECTION,
+        "_AGENTS_MD_SECTION": _AGENTS_MD_SECTION,
+        "_GEMINI_MD_SECTION": _GEMINI_MD_SECTION,
+        "_VSCODE_INSTRUCTIONS_SECTION": _VSCODE_INSTRUCTIONS_SECTION,
+        "_ANTIGRAVITY_RULES": _ANTIGRAVITY_RULES,
+        "_KIRO_STEERING": _KIRO_STEERING,
+        "_CURSOR_RULE": _CURSOR_RULE,
+        "_DEVIN_RULES": _DEVIN_RULES,
+    }
+    # Accept any of the read-covering phrasings: the D1 clause ("reading source
+    # files"), the wiki bullets ("reading raw files"), or the VSCode template
+    # ("read source files when ..."). Whitespace is normalized so the assertion
+    # survives line wrapping in the multi-line constants.
+    accepted = ("reading source files", "reading raw files", "read source files when")
+    missing = [
+        name
+        for name, text in read_cover.items()
+        if not any(phrase in " ".join(text.lower().split()) for phrase in accepted)
+    ]
+    assert not missing, (
+        f"these surfaces still only displace grep, not reading: {missing}. "
+        f"This regresses issue #1114."
+    )
+
+
+def test_read_hook_payload_recommends_query():
+    """The new Read|Glob hook payload steers to `graphify query` like every other
+    surface, and frames reading raw source files as the displaced action."""
+    payload = json.dumps(_READ_SETTINGS_HOOK)
+    assert "graphify query" in payload
+    assert "reading raw source files" in payload
 
 
 def test_report_is_still_referenced_as_fallback():

--- a/tests/test_read_hook.py
+++ b/tests/test_read_hook.py
@@ -1,0 +1,207 @@
+"""Behavioral tests for the query-first PreToolUse hooks (issue #1114).
+
+The other tests assert the hooks are *present* in settings.json. These run the
+hook's shell command the way Claude Code will: pipe a crafted tool_input JSON to
+`sh -c "<command>"` in a tmp_path cwd with or without graphify-out/graph.json,
+then assert on stdout. This is the only layer that proves the nudge/silence
+behavior of the Read|Glob hook and the multi-file vs single-file discrimination
+in the broadened Bash hook.
+"""
+from __future__ import annotations
+import json
+import subprocess
+
+import pytest
+
+from graphify.__main__ import _SETTINGS_HOOK, _READ_SETTINGS_HOOK
+
+
+def _run(hook, tool_input, cwd):
+    cmd = hook["hooks"][0]["command"]
+    payload = json.dumps({"tool_input": tool_input})
+    p = subprocess.run(
+        ["sh", "-c", cmd], input=payload, capture_output=True, text=True, cwd=str(cwd)
+    )
+    return p.stdout
+
+
+def _has_graph(tmp_path):
+    out = tmp_path / "graphify-out"
+    out.mkdir()
+    (out / "graph.json").write_text("{}")
+
+
+def _nudges(out):
+    return "graphify query" in out or "Before reading multiple source files" in out
+
+
+# ---------------------------------------------------------------------------
+# Read|Glob hook — gate on graph.json
+# ---------------------------------------------------------------------------
+
+def test_read_hook_silent_without_graph(tmp_path):
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": "src/app.py"}, tmp_path)
+    assert "graphify" not in out
+
+
+def test_read_hook_nudges_with_graph(tmp_path):
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": "src/app.py"}, tmp_path)
+    assert "graphify query" in out
+    # emitted text must be valid PreToolUse JSON, not just a substring match
+    parsed = json.loads(out)
+    ctx = parsed["hookSpecificOutput"]["additionalContext"]
+    assert "graphify query" in ctx
+    assert "reading raw source files" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Read|Glob hook — source/doc targeting vs graph-output silence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path", ["src/app.py", "lib/foo.ts", "main.go", "Server.java", "mod.rs"])
+def test_read_hook_nudges_on_source_file(tmp_path, path):
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": path}, tmp_path)
+    assert _nudges(out)
+
+
+@pytest.mark.parametrize("path", ["README.md", "docs/guide.rst", "notes.txt", "page.mdx"])
+def test_read_hook_nudges_on_doc_file(tmp_path, path):
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": path}, tmp_path)
+    assert _nudges(out)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "graphify-out/GRAPH_REPORT.md",
+        "graphify-out/wiki/index.md",
+        "graphify-out/graph.json",
+    ],
+)
+def test_read_hook_silent_on_graphify_out_file(tmp_path, path):
+    """Never nudge a Read that is already inside graphify-out/, even though the
+    target is a .md/.json the allowlist would otherwise match. Otherwise the agent
+    gets told to go read the graph while it is reading the graph."""
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": path}, tmp_path)
+    assert "graphify" not in out
+
+
+def test_read_hook_silent_on_unknown_extension(tmp_path):
+    """The suffix allowlist is closed: an extension that is not source/doc and
+    carries no allowlisted substring stays silent."""
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": "config.yaml"}, tmp_path)
+    assert "graphify" not in out
+
+
+def test_read_hook_silent_on_extensionless_file(tmp_path):
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"file_path": "Makefile"}, tmp_path)
+    assert "graphify" not in out
+
+
+# ---------------------------------------------------------------------------
+# Glob coverage (rides the same Read|Glob matcher)
+# ---------------------------------------------------------------------------
+
+def test_glob_hook_nudges_with_graph(tmp_path):
+    _has_graph(tmp_path)
+    out = _run(_READ_SETTINGS_HOOK, {"pattern": "src/**/*.py"}, tmp_path)
+    assert "graphify query" in out
+
+
+def test_glob_hook_silent_without_graph(tmp_path):
+    out = _run(_READ_SETTINGS_HOOK, {"pattern": "src/**/*.py"}, tmp_path)
+    assert "graphify" not in out
+
+
+# ---------------------------------------------------------------------------
+# Broadened Bash hook — single-file silent vs multi-file/glob nudge
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat src/app.py",
+        "head -n 50 README.md",
+        "tail -n 50 server.log",
+        "sed -n '1,20p' a.py",
+        "cat /etc/hosts",
+    ],
+)
+def test_bash_single_file_read_silent(tmp_path, command):
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": command}, tmp_path)
+    assert "graphify" not in out
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat src/a.py src/b.py src/c.py",
+        "cat a.py b.py",
+        "tail -n 20 one.log two.log",
+        "sed -n '1,20p' a.py b.py",
+    ],
+)
+def test_bash_multi_file_read_nudges(tmp_path, command):
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": command}, tmp_path)
+    assert "Before reading multiple source files" in out
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cat src/*.py", "head -n 5 *.md", "cat src/**/*.ts"],
+)
+def test_bash_glob_read_nudges(tmp_path, command):
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": command}, tmp_path)
+    assert "Before reading multiple source files" in out
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat a.py b.py > merged.txt",
+        "cat > out.txt",
+        "cat >> log.txt",
+        "cat <<EOF",
+        "cat a.py | head",
+        "cat graphify-out/GRAPH_REPORT.md",
+        "cat graphify-out/a.json graphify-out/b.json",
+    ],
+)
+def test_bash_read_excluded_cases_silent(tmp_path, command):
+    """Redirects, heredocs, pipes and graphify-out/ reads never nudge."""
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": command}, tmp_path)
+    assert "graphify" not in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: the original grep/search behavior must survive the broadening
+# ---------------------------------------------------------------------------
+
+def test_bash_grep_still_nudges(tmp_path):
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": "grep -r foo src/"}, tmp_path)
+    assert "graphify query" in out
+    assert "instead of grepping raw files" in out
+
+
+def test_bash_search_silent_without_graph(tmp_path):
+    out = _run(_SETTINGS_HOOK, {"command": "grep -r foo src/"}, tmp_path)
+    assert "graphify" not in out
+
+
+def test_bash_pipe_into_grep_routes_to_search(tmp_path):
+    """`cat foo.py | grep bar` is a search (the pipe feeds grep), so it gets the
+    search nudge, not suppressed by the content-read pipe exclusion."""
+    _has_graph(tmp_path)
+    out = _run(_SETTINGS_HOOK, {"command": "cat foo.py | grep bar"}, tmp_path)
+    assert "instead of grepping raw files" in out


### PR DESCRIPTION
## What this does

graphify's whole point is that once `graphify-out/graph.json` exists, the agent should answer codebase questions with `graphify query` / `path` / `explain` instead of grepping or reading raw files. Today the `PreToolUse` nudge (`_SETTINGS_HOOK`) only fires on Bash search (`grep`, `rg`, `find`, ...). The most common way an agent actually skips the graph slips right past it: reading 20 files one at a time with the `Read` tool, globbing, or `cat`-ing several files at once. So a graph can exist and still be ignored on exactly the questions it is built to answer.

This closes that gap on the Claude path and extends the always-on prose for the other platforms.

## How

- **New `Read|Glob` PreToolUse hook** (`_READ_SETTINGS_HOOK`). It fires only when `graphify-out/graph.json` exists, and only for a source or doc file (suffix allowlist); anything under `graphify-out/` is suppressed so reading the graph's own report never starts a "go read the graph" loop. It injects the same query-first `additionalContext` and never blocks. The parser is `python3` only (already a graphify dependency, no `jq`), the shell is POSIX, and every branch fails open.
- **Broadened the Bash matcher** to also cover multi-file content reads (`cat`, `head`, `tail`, `sed`, `awk`), but only when multiple paths or a glob are involved, so a single-file read stays silent and the nudge does not become spam. Redirects, heredocs, pipes, and reads under `graphify-out/` are excluded. The existing grep/search arm and its payload are byte-for-byte unchanged.
- **Idempotency:** both the install and uninstall dedup filters now recognize the new matcher, so reinstalling or upgrading does not stack duplicate Read hooks.
- **Non-Claude paths:** the always-on sections (CLAUDE.md, AGENTS.md, GEMINI.md, Cursor, Kiro, Antigravity, Devin) now name reading files alongside grep as the thing `graphify query` replaces. Codex stays prose-only, since Codex Desktop rejects `additionalContext` on `PreToolUse`, so its coverage comes from the AGENTS.md text.

## Testing

- New `tests/test_read_hook.py` runs the hook commands the way Claude Code does, via subprocess with crafted stdin JSON: silent without a graph, nudges with one, source/doc vs config vs `graphify-out/` targets, glob coverage, single-file-silent vs multi-file/glob-nudge, and a regression that grep still nudges after the broadening.
- `tests/test_claude_md.py` gains the settings.json shape checks, an idempotency-across-double-install assertion, and clean uninstall. The new hook is added to the issue-#580 install-string contract so it is held to the same "recommends `graphify query`" guarantee as every other surface.
- Full suite green (47 new tests). `ruff check` clean on the changed files.

## Scope / why it's low-risk

This is hook configuration in `graphify/__main__.py` plus tests and the always-on prose. It touches no skill-file content, so it cannot affect the extraction pipeline. It never blocks a tool call: every branch is a pure `additionalContext` nudge that fails open, so legitimate reads always go through.

## Related

Closes #1114.
