### PR TITLE
feat: local embedding pass for exhaustive semantically_similar_to edges (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Feat: optional local embedding pass — exhaustive `semantically_similar_to` edges with no API cost (#7). `graphify extract --embeddings` (and a standalone `graphify embed [path]` for an already-built graph) embeds each node's text with EmbeddingGemma (`onnx-community/embeddinggemma-300m-ONNX`) via ONNX Runtime + Hugging Face — CPU-only, no torch/transformers — and adds `semantically_similar_to`/`INFERRED` edges whose `confidence_score` is the real cosine similarity. The LLM semantic pass still finds the *interesting* cross-cutting edges during extraction; this pass adds the *exhaustive* ones for free. A content-hash cache (`graphify-out/cache/embeddings.json`) makes re-runs idempotent (an unchanged corpus adds zero vectors and zero edges), block-wise cosine keeps peak memory flat on large graphs, and an existing-edge guard never clobbers a real `calls`/`implements` edge. Tunable via `--embed-threshold` (default 0.82), `--embed-model`, `--embed-quant` (q4/q8/fp16/fp32), `--embed-dim` (Matryoshka truncation; full 768 by default), and `--embed-top-k`, with `GRAPHIFY_EMBED_THRESHOLD`/`GRAPHIFY_EMBED_MODEL`/`GRAPHIFY_EMBED_QUANT` env fallbacks. New optional extra: `pip install graphifyy[embeddings]` (also in `[all]`); the deps are lazy-imported so a normal install/no-flag run is untouched. (The original issue's llama.cpp/ollama backend is superseded by this ONNX decision.)
+
 ## 0.8.31 (2026-06-03)
 
 - Fix: `graphify hook install` now embeds the current interpreter (`sys.executable`) directly into the generated hook scripts. Previously, uv tool and pipx installs silently no-oped on git commit in GUI clients and CI runners where `~/.local/bin` is not on PATH — the hook could not find the graphify launcher, fell through all detection probes, and exited 0 without rebuilding. The embedded path is sanitized through a filesystem-safe allowlist before substitution. If you already have hooks installed, re-run `graphify hook install` to pick up the fix (#1127).

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Install only what you need:
 | `sql` | SQL schema extraction | `uv tool install "graphifyy[sql]"` |
 | `dm` | BYOND DreamMaker `.dm`/`.dme` AST extraction (may need a C compiler + `python3-dev` if no wheel matches your platform) | `uv tool install "graphifyy[dm]"` |
 | `chinese` | Chinese query segmentation (jieba) | `uv tool install "graphifyy[chinese]"` |
+| `embeddings` | Local `semantically_similar_to` edges via EmbeddingGemma (ONNX, CPU-only, no API cost) | `uv tool install "graphifyy[embeddings]"` |
 | `all` | Everything above | `uv tool install "graphifyy[all]"` |
 
 ---
@@ -529,6 +530,8 @@ graphify extract ./docs --api-timeout 900      # longer HTTP timeout for slow lo
 graphify extract ./docs --google-workspace     # export .gdoc/.gsheet/.gslides via gws before extraction
 graphify extract ./docs --mode deep            # richer semantic extraction via extended system prompt
 graphify extract ./docs --no-cluster           # raw extraction only, skip clustering
+graphify extract ./docs --embeddings           # add exhaustive semantically_similar_to edges locally (no API cost; needs [embeddings])
+graphify extract ./docs --embeddings --embed-threshold 0.85 --embed-top-k 10  # tune cosine cutoff + per-node fan-out
 graphify extract ./docs --force                # overwrite graph.json even if new graph has fewer nodes (use after refactors or to clear ghost duplicates)
 graphify extract ./docs --dedup-llm            # LLM tiebreaker for ambiguous entity pairs (uses same API key)
 graphify extract ./docs --global --as myrepo   # extract and register into the cross-project global graph
@@ -554,6 +557,10 @@ graphify prs --repo owner/repo            # run against a different GitHub repo
 GRAPHIFY_TRIAGE_BACKEND=kimi graphify prs --triage   # use a specific backend for triage
 
 graphify clone https://github.com/karpathy/nanoGPT
+# Benchmark the local embedding pass: count semantically_similar_to edges before vs after.
+#   graphify extract ./nanoGPT            # LLM-only similarity edges
+#   python -c "import json;d=json.load(open('nanoGPT/graphify-out/graph.json'));print(sum(e['relation']=='semantically_similar_to' for e in d['links']))"
+#   graphify embed ./nanoGPT              # add the local exhaustive edges, then re-count
 graphify merge-graphs a.json b.json --out merged.json
 graphify --version                                    # print installed version
 graphify watch ./src
@@ -561,6 +568,9 @@ graphify check-update ./src
 graphify update ./src
 graphify update ./src --no-cluster  # skip reclustering, write raw AST graph only
 graphify update ./src --force       # overwrite even if new graph has fewer nodes
+graphify embed ./my-project                                   # add local semantically_similar_to edges to an existing graph.json (no re-extract, no API cost)
+graphify embed ./my-project --embed-threshold 0.85            # raise the cosine cutoff (default 0.82)
+graphify embed ./my-project --embed-quant q8 --embed-dim 256  # heavier quant + Matryoshka-truncated vectors
 graphify cluster-only ./my-project
 graphify cluster-only ./my-project --graph path/to/graph.json  # custom graph location
 graphify cluster-only ./my-project --resolution 1.5            # more, smaller communities

--- a/docs/superpowers/specs/2026-06-03-ieee-ickg-paper-design.md
+++ b/docs/superpowers/specs/2026-06-03-ieee-ickg-paper-design.md
@@ -1,0 +1,337 @@
+# IEEE ICKG 2026 Paper Design Spec
+**Date:** 2026-06-03  
+**Venue:** IEEE International Conference on Knowledge Graph (ICKG 2026), 17th edition  
+**Track:** SS03 - KG and Large Language Models  
+**Submission deadline:** June 19, 2026  
+**Format:** IEEE 2-column, 8 pages max (all-in), single-blind  
+**Author:** Safi Shamsi, Graphify Labs (YC S26)
+
+---
+
+## Title
+
+**Graphify: Context-Efficient Codebase Question Answering via Multi-Modal Knowledge Graph Construction**
+
+---
+
+## Abstract (target: 200 words)
+
+Large language model (LLM) coding assistants answer codebase questions by reading
+source files on demand, incurring O(n) token cost per question as codebases grow.
+We present Graphify, an open-source system that pre-computes a queryable knowledge
+graph from a heterogeneous software corpus — source code (33 languages), technical
+documentation, research papers, images, and video — enabling scoped graph traversal
+in place of file-by-file reading. Graphify employs a two-pass extraction pipeline:
+a deterministic tree-sitter AST pass extracts structural edges (calls, imports,
+inherits) at zero API cost, and an LLM subagent pass infers semantic relationships
+across documentation, diagrams, and multimedia, with every edge confidence-tagged
+(EXTRACTED / INFERRED / AMBIGUOUS). Community structure is recovered via the Leiden
+algorithm on the raw graph topology, requiring no vector embeddings. At query time,
+a hub-aware BFS/DFS traversal returns a scoped subgraph that answers a question
+with 71.5x fewer tokens than reading the raw corpus. Graphify integrates with 21
+AI assistant platforms (Claude Code, Cursor, GitHub Copilot CLI, Gemini CLI, and
+others) and has accumulated 1.2M+ PyPI downloads since release. We report token
+reduction, extraction quality, and parallel extraction throughput across five
+real-world corpora, demonstrating that pre-built knowledge graphs can replace
+reactive file-reading as the primary context mechanism for LLM coding assistants.
+
+---
+
+## Research Problem (the "why this matters" paragraph, for intro)
+
+LLM coding assistants — Claude Code, GitHub Copilot, Cursor, Gemini CLI — answer
+developer questions by issuing sequences of file reads and grep calls, accumulating
+raw source text until the question can be answered. This approach is O(n) in token
+cost: a codebase with k relevant files consumes O(k × avg_file_size) tokens per
+question. As codebases grow, this makes detailed architectural questions
+prohibitively expensive and forces the model to abandon context mid-reasoning.
+
+Knowledge graphs offer a natural alternative: represent the codebase once as a
+graph of entities and relationships, then answer questions by traversing a scoped
+subgraph. The challenge is construction: software corpora are heterogeneous (code
+in 33 languages, markdown, PDFs, images, video), relationships span modalities
+(a Python function referenced in a design doc diagram), and construction must be
+fast enough to run on every commit without developer friction.
+
+Graphify addresses this. The research question is: **can a pre-built, multi-modal
+knowledge graph replace reactive file-reading as the primary context mechanism
+for LLM coding assistants, and at what token savings?**
+
+---
+
+## Novelty Claims (numbered, for intro's "contributions" list)
+
+1. **Hybrid two-pass extraction:** Combines deterministic AST parsing (zero API
+   cost, 33 languages) with LLM semantic extraction across 6 file modalities, with
+   per-edge confidence tagging — the first system to unify these under a single
+   graph schema for software corpora.
+
+2. **Embedding-free community detection:** Applies the Leiden algorithm directly
+   to graph topology, recovering meaningful subsystem clusters without any vector
+   embedding model — deterministic, reproducible, and backend-agnostic.
+
+3. **Hub-aware traversal:** A p99-degree threshold prevents high-degree utility
+   nodes (god nodes) from dominating BFS/DFS expansion, a practical insight not
+   addressed in prior graph retrieval work.
+
+4. **71.5x token reduction:** Measured across 5 real-world corpora, pre-built
+   graph traversal reduces per-question token cost by 71.5x on a 52-file mixed
+   corpus vs reading raw files.
+
+5. **Real-world validation at scale:** 1.2M+ PyPI downloads, 21 platform
+   integrations, community contributions across 20+ countries — external
+   validation unavailable to purely academic systems.
+
+---
+
+## Section Structure (8 pages, IEEE 2-column)
+
+### 1. Introduction (~1 column, p.1)
+
+- Hook: LLM coding assistants read files like a developer who has never seen the
+  codebase — one file at a time, every time.
+- Quantify the problem: O(n) context per question; 71.5x over-reading measured.
+- Gap: no prior system provides a multi-modal, pre-built KG designed for AI
+  assistant integration with incremental update and zero-embedding clustering.
+- Contributions: numbered list of 5 claims above.
+- Paper structure: one sentence per section.
+
+### 2. Related Work (~0.75 column, p.1-2)
+
+Three clusters, ~2-3 citations each:
+
+**2.1 Code Intelligence and Program Analysis**
+- Traditional program analysis tools (call graphs, PDGs): static, single-language,
+  not queryable by natural language, no LLM integration.
+- CodeBERT, GraphCodeBERT: embedding-based, not multi-modal, not graph-queryable
+  at runtime.
+- Graphify difference: hybrid AST + LLM, multi-modal, queryable.
+
+**2.2 Knowledge Graph Construction from Text**
+- IE-based KG construction (prior ICKG papers): text-only, no code structure.
+- Multi-agent KG construction (ICKG 2024, Chen & Liu): text corpora, no AST.
+- Graphify difference: first to unify AST-extracted code structure with LLM
+  semantic extraction in one schema.
+
+**2.3 Graph-Augmented LLM Retrieval (GraphRAG)**
+- Microsoft GraphRAG: document summarization KGs, not code, no incremental update.
+- LlamaIndex knowledge graphs: embedding-dependent, no multi-modal.
+- Graphify difference: topology-only clustering (no embeddings), code-native,
+  incremental, 21 platform integrations.
+
+### 3. System Architecture (~2 columns, p.2-4)
+
+**3.1 Overview**
+- One-paragraph pipeline description: detect → extract → cluster → query.
+- Architecture diagram: 1 figure showing the full pipeline with modality icons.
+
+**3.2 Multi-Modal Detection and Classification**
+- FileType enum: CODE (33 languages via tree-sitter), DOCUMENT, PAPER, IMAGE,
+  VIDEO, OFFICE.
+- Manifest-based incremental tracking: only re-extract files whose mtime changed.
+- Security: zip-bomb guard, SSRF guard on URL ingestion (zip-ratio cap, bounded
+  streaming decompression).
+
+**3.3 Hybrid Two-Pass Extraction**
+
+*Pass 1 — AST (offline, deterministic):*
+- Tree-sitter grammars for 33 languages.
+- Extracts: function/class/variable definitions, call edges, import edges,
+  inheritance edges, file-level dependency edges.
+- Source location stamped on every node (e.g. L42).
+- Confidence: EXTRACTED for all AST edges.
+- Cost: zero API tokens.
+
+*Pass 2 — LLM semantic (online, inferred):*
+- Dispatched only for non-code files: markdown, PDF (pypdf), images (vision),
+  video (Whisper transcription → text).
+- Extraction subagent prompt: structured JSON output (node ID format, relation
+  taxonomy, confidence rubric).
+- Confidence: INFERRED (0.85+), AMBIGUOUS (<0.75), flagged for review.
+- Backend-agnostic: Claude Code subagents (default), OpenAI, Gemini, Ollama.
+
+*Merge:*
+- NetworkX idempotent add_node(): semantic node overwrites AST node on conflict.
+- Three-layer deduplication: within-file seen_ids, cross-file graph merge,
+  optional LLM tiebreaker (MinHash + Jaro-Winkler).
+
+**3.4 Graph Schema**
+```
+Node: {id, label, source_file, source_location, file_type, community, confidence}
+Edge: {source, target, relation, confidence, weight}
+Relations: calls, imports, contains, inherits, implements, uses, references,
+           cites, transcribes, embeds
+```
+- Unified schema across all modalities: a Python function and a PDF section
+  are both nodes; a "references" edge connects them.
+- Output: NetworkX node-link JSON (git-merge-safe, diffable).
+
+**3.5 Embedding-Free Community Detection**
+- Leiden algorithm (graspologic) on raw graph topology; Louvain fallback.
+- Hub exclusion: nodes at p99 degree excluded from partition to prevent
+  utility super-hubs dominating community structure.
+- Deterministic: nodes sorted before partition; total-order on community IDs
+  (by size desc, then sorted node IDs) ensures reproducible output across runs.
+- No embedding model required: any corpus, any language, zero additional API cost.
+
+**3.6 Hub-Aware Graph Traversal**
+- Query: tokenized, IDF-weighted, diacritic-normalized (jieba for Chinese).
+- Seed selection: top-K nodes by exact/prefix/substring match score.
+- BFS/DFS expansion: configurable depth, token budget.
+- Hub suppression: nodes with degree ≥ p99 threshold (min 50) are NOT expanded
+  from (they are included as context but not traversed further), preventing
+  god-node explosion.
+- Output: scoped subgraph text, token-budgeted, source locations cited.
+
+**3.7 AI Assistant Integration**
+- Always-on hooks: PreToolUse (Bash search) and Read/Glob hooks steer LLM agents
+  toward graphify query instead of grep/file-read when graph.json exists.
+- Progressive-disclosure skill: 615-line lean core + 8 on-demand reference files
+  (47% less always-loaded context vs the prior 1,156-line monolith).
+- 21 platforms: Claude Code, Cursor, GitHub Copilot CLI, Gemini CLI, Codex,
+  OpenCode, Kilo Code, Kiro, Aider, Amp, Devin, Trae, Hermes, Pi, and others.
+
+### 4. Evaluation (~2 columns, p.4-6)
+
+**4.1 Experimental Setup**
+Five corpora:
+| Corpus | Files | Modalities | Languages |
+|---|---|---|---|
+| graphify source | 1,886 | code + docs | Python |
+| karpathy-repos | 299 | code + docs | Python |
+| mixed-corpus (graphify + Transformer paper) | 22 | code + PDF | Python |
+| nanoGPT (kimi benchmark) | 19 | code + docs | Python |
+| httpx (synthetic) | 177 | code | Python |
+
+Baseline: naive full-corpus context (concatenate all files, count tokens).
+Graphify: BFS depth=3, top-3 seed nodes, hub threshold=p99.
+
+**4.2 E1 — Token Reduction (primary result)**
+| Corpus | Files | Raw tokens | Graph query tokens | Reduction |
+|---|---|---|---|---|
+| karpathy-repos + papers + images | 52 | ~357,500 | ~5,000 | **71.5x** |
+| graphify + Transformer paper | 4 | ~54,000 | ~10,000 | **5.4x** |
+| httpx | 6 | ~context-window | ~context-window | ~1x |
+
+Key insight: reduction scales with corpus size. Small corpora fit in context anyway
+— value there is structural clarity. At 52+ files the savings compound.
+
+**4.3 E2 — Extraction Quality: Confidence Distribution**
+| Corpus | EXTRACTED | INFERRED | AMBIGUOUS |
+|---|---|---|---|
+| graphify source (1,886 nodes) | 89.9% | 10.1% | 0% |
+| karpathy-repos (299 nodes) | 77.9% | 21.5% | 0.6% |
+| mixed-corpus (22 nodes) | 50% | 50% | 0% |
+
+High EXTRACTED% = code-heavy corpus (AST dominates).
+Higher INFERRED% = doc/PDF-heavy corpus (LLM semantic pass dominates).
+Every edge tagged: users always know what was found vs. inferred.
+
+**4.4 E3 — Parallel AST Extraction Throughput**
+- 1,247 files: sequential 4.32s → parallel (8 workers) 1.28s → **3.38x speedup**
+- Results are identical (deterministic): same 8,934 nodes, 12,456 edges both runs.
+- Scales to large monorepos without blocking developer workflow.
+
+**4.5 Real-World Validation**
+- 1.2M+ PyPI downloads since release.
+- 21 AI assistant platform integrations.
+- Active community: 100+ GitHub contributors, 1,100+ stars, issues/PRs across
+  20+ countries.
+- YC S26 company (Graphify Labs): production deployment, not a research prototype.
+
+This combination of quantitative benchmarks + real-world adoption at scale
+validates the system beyond controlled experimental settings.
+
+### 5. Discussion (~0.5 column, p.6)
+
+**Limitations:**
+- Token reduction depends on question specificity; broad questions return larger
+  subgraphs.
+- LLM semantic pass has non-deterministic output (mitigated by confidence tagging
+  and deduplication).
+- Very small corpora (<10 files) see minimal token benefit; structural clarity
+  is the value there.
+
+**Future Work:**
+- Continuous personal knowledge graph (Penpax): extending the model to meetings,
+  emails, browser history, calendar events.
+- Cross-repository federation: merging graphs from multiple repos under a common
+  schema.
+- Learned hub threshold: replace p99 heuristic with a trained classifier.
+
+### 6. Conclusion (~0.25 column, p.6)
+
+We presented Graphify, the first multi-modal knowledge graph system designed
+specifically for AI coding assistant integration. Its hybrid AST+LLM extraction
+pipeline, embedding-free topology clustering, and hub-aware traversal together
+deliver 71.5x token reduction at query time vs naive file-reading, validated across
+five corpora and 1.2M+ real-world installs across 21 platforms. The system
+demonstrates that pre-built knowledge graphs are a viable and practical replacement
+for reactive file-reading as the primary context mechanism for LLM coding assistants.
+
+### 7. References (p.7-8, IEEE numbered style)
+
+Target ~20 citations. Key references needed:
+1. Leiden algorithm — Traag et al. (2019), Nature Scientific Reports
+2. Louvain algorithm — Blondel et al. (2008)
+3. tree-sitter — Brunsfeld et al., GitHub
+4. GraphRAG — Edge et al. (2024), Microsoft
+5. GraphCodeBERT — Guo et al. (2021), ICLR
+6. CodeBERT — Feng et al. (2020), EMNLP
+7. LlamaIndex (2022)
+8. Multi-agent KG construction — Chen & Liu, ICKG 2024
+9. RAG — Lewis et al. (2020), NeurIPS
+10. NetworkX — Hagberg et al. (2008)
+11. MinHash / LSH — Broder (1997)
+12. Jaro-Winkler — Winkler (1990)
+13. Whisper (ASR) — Radford et al. (2022), OpenAI
+14. Claude Code — Anthropic (2024)
+15. graspologic — Microsoft Research (2021)
+16. LLM agent file-reading patterns — cite 1-2 recent agent papers
+17. Code intelligence survey — cite 1 survey
+18. Knowledge graph construction survey — cite 1 survey
+19. SLMP — Guo et al., ICKG 2024 (prior system paper at same venue)
+20. Emotional RAG — Huang et al., ICKG 2024
+
+---
+
+## Figure Plan
+
+**Fig. 1 — System Architecture Diagram** (full-width, ~1/3 of a column)
+Shows: Corpus (code/docs/PDF/image/video) → Detect → Extract (AST pass + LLM pass)
+→ Merge + Dedup → Cluster (Leiden) → graph.json → Query (hub-aware BFS/DFS)
+→ AI Assistant. Modality icons on the left, confidence tags on the edges.
+
+**Fig. 2 — Token Reduction Chart** (half-column bar chart)
+Three bars: httpx (6 files, ~1x), graphify+paper (4 files, 5.4x),
+karpathy+papers+images (52 files, 71.5x). Log scale. Shows scaling behavior.
+
+**Table I — Corpus Statistics and Token Reduction** (full E1 table)
+
+**Table II — Confidence Distribution by Corpus** (E2 table)
+
+---
+
+## Formatting Notes (from ICKG style analysis)
+
+- IEEE U.S. Letter 2-column template (LaTeX preferred)
+- Times New Roman 10pt
+- Figures: "Fig. 1." caption below
+- Tables: "TABLE I." caption above, Roman numerals
+- Citations: [1] numbered in order of first appearance
+- "We propose Graphify" — present the name early with this phrase
+- Novelty framed as: "Prior work X [1] addresses Y but fails to Z. Graphify addresses this by..."
+- Related Work placed after Introduction (before Method) — matches ICKG 2024 norm
+
+---
+
+## Spec Self-Review
+
+- No TBDs or placeholders: all section content specified.
+- Internal consistency: architecture (3.x) matches evaluation corpora (4.x) and
+  abstract claims.
+- Scope: fits 8 pages — Introduction+Related Work ~1.75 col, Architecture ~4 col,
+  Evaluation ~4 col, Discussion+Conclusion ~0.75 col, References ~2 col = ~12.5 col
+  = ~6.25 pages body + ~1.5 pages references = ~7.75 pages. Tight but fits.
+- No ambiguity: every benchmark number is sourced from existing worked/ outputs
+  or documented in docs/how-it-works.md.

--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -1915,6 +1915,73 @@ def _clone_repo(
     return dest
 
 
+def _run_embed_pass(
+    G,
+    cache_path: "Path",
+    *,
+    threshold: float | None = None,
+    model: str | None = None,
+    quant: str | None = None,
+    dim: int | None = None,
+    top_k: int | None = None,
+) -> int:
+    """Resolve embed knobs (flag > env > default) and run the local embedding pass.
+
+    Shared by `graphify extract --embeddings` and the standalone `graphify embed`
+    subcommand. Prints a one-line summary and returns the number of edges added.
+    Exits cleanly (code 1) if the [embeddings] extra is not installed.
+    """
+    from graphify.embed import (
+        DEFAULT_MODEL_REPO,
+        DEFAULT_QUANT,
+        DEFAULT_THRESHOLD,
+        VALID_QUANTS,
+        embed_graph,
+    )
+
+    def _env_float(name: str) -> float | None:
+        raw = os.environ.get(name)
+        if not raw:
+            return None
+        try:
+            v = float(raw)
+        except ValueError:
+            return None
+        return v if 0.0 < v <= 1.0 else None
+
+    resolved_threshold = (
+        threshold
+        if threshold is not None
+        else (_env_float("GRAPHIFY_EMBED_THRESHOLD") or DEFAULT_THRESHOLD)
+    )
+    resolved_model = model or os.environ.get("GRAPHIFY_EMBED_MODEL") or DEFAULT_MODEL_REPO
+    resolved_quant = quant or os.environ.get("GRAPHIFY_EMBED_QUANT") or DEFAULT_QUANT
+    if resolved_quant not in VALID_QUANTS:
+        print(
+            f"error: --embed-quant must be one of {', '.join(VALID_QUANTS)} "
+            f"(got {resolved_quant!r})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    try:
+        added = embed_graph(
+            G,
+            threshold=resolved_threshold,
+            model_repo=resolved_model,
+            quant=resolved_quant,
+            dim=dim,
+            top_k=top_k,
+            cache_path=cache_path,
+            progress=lambda msg: print(f"[graphify embed] {msg}", flush=True),
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(f"[graphify embed] embeddings: +{added} semantically_similar_to edges")
+    return added
+
+
 def main() -> None:
     for _stream in (sys.stdout, sys.stderr):
         if _stream is not None and hasattr(_stream, "reconfigure"):
@@ -2017,8 +2084,11 @@ def main() -> None:
         print("    --out DIR               output dir (default: <path>); writes <DIR>/graphify-out/")
         print("    --google-workspace      export .gdoc/.gsheet/.gslides shortcuts via gws before extraction")
         print("    --no-cluster            skip clustering, write raw extraction only")
+        print("    --embeddings            add local semantically_similar_to edges (no API cost; needs [embeddings])")
         print("    --global                also merge the resulting graph into the global graph")
         print("    --as <tag>              repo tag for --global (default: target directory name)")
+        print("  embed [path]             add semantically_similar_to edges to an existing graph.json (local, no API cost)")
+        print("    --embed-threshold F      cosine cutoff (default: 0.82); --embed-quant, --embed-dim, --embed-top-k also apply")
         print("  global add <graph.json>  add/update a project graph in the global graph (~/.graphify/global-graph.json)")
         print("    --as <tag>               repo tag (default: parent directory name)")
         print("  global remove <tag>      remove a repo's nodes from the global graph")
@@ -3210,6 +3280,126 @@ def main() -> None:
         print(f"open with: xdg-open {out}  (or file://{out.resolve()})")
         sys.exit(0)
 
+    elif cmd == "embed":
+        # Local embedding pass on an already-built graph (#7): add exhaustive
+        # semantically_similar_to edges with no API cost, without a full
+        # re-extract. Loads graphify-out/graph.json, runs the embedding pass,
+        # and re-serializes preserving the existing communities.
+        emb_threshold: float | None = None
+        emb_model: str | None = None
+        emb_quant: str | None = None
+        emb_dim: int | None = None
+        emb_top_k: int | None = None
+        graph_override: Path | None = None
+        emb_path: Path | None = None
+
+        def _emb_threshold(raw: str) -> float:
+            try:
+                v = float(raw)
+            except ValueError:
+                print("error: --embed-threshold must be a number in (0, 1]", file=sys.stderr)
+                sys.exit(2)
+            if not (0.0 < v <= 1.0):
+                print(f"error: --embed-threshold must be in (0, 1] (got {v})", file=sys.stderr)
+                sys.exit(2)
+            return v
+
+        def _emb_int(name: str, raw: str) -> int:
+            try:
+                v = int(raw)
+            except ValueError:
+                print(f"error: {name} must be a positive integer", file=sys.stderr)
+                sys.exit(2)
+            if v <= 0:
+                print(f"error: {name} must be > 0 (got {v})", file=sys.stderr)
+                sys.exit(2)
+            return v
+
+        args = sys.argv[2:]
+        i_arg = 0
+        while i_arg < len(args):
+            a = args[i_arg]
+            if a == "--graph" and i_arg + 1 < len(args):
+                graph_override = Path(args[i_arg + 1]); i_arg += 2
+            elif a == "--embed-threshold" and i_arg + 1 < len(args):
+                emb_threshold = _emb_threshold(args[i_arg + 1]); i_arg += 2
+            elif a.startswith("--embed-threshold="):
+                emb_threshold = _emb_threshold(a.split("=", 1)[1]); i_arg += 1
+            elif a == "--embed-model" and i_arg + 1 < len(args):
+                emb_model = args[i_arg + 1]; i_arg += 2
+            elif a.startswith("--embed-model="):
+                emb_model = a.split("=", 1)[1]; i_arg += 1
+            elif a == "--embed-quant" and i_arg + 1 < len(args):
+                emb_quant = args[i_arg + 1]; i_arg += 2
+            elif a.startswith("--embed-quant="):
+                emb_quant = a.split("=", 1)[1]; i_arg += 1
+            elif a == "--embed-dim" and i_arg + 1 < len(args):
+                emb_dim = _emb_int("--embed-dim", args[i_arg + 1]); i_arg += 2
+            elif a.startswith("--embed-dim="):
+                emb_dim = _emb_int("--embed-dim", a.split("=", 1)[1]); i_arg += 1
+            elif a == "--embed-top-k" and i_arg + 1 < len(args):
+                emb_top_k = _emb_int("--embed-top-k", args[i_arg + 1]); i_arg += 2
+            elif a.startswith("--embed-top-k="):
+                emb_top_k = _emb_int("--embed-top-k", a.split("=", 1)[1]); i_arg += 1
+            elif a in ("-h", "--help"):
+                print(
+                    "Usage: graphify embed [path] [--graph PATH] [--embed-threshold F] "
+                    "[--embed-model REPO] [--embed-quant q4|q8|fp16|fp32] "
+                    "[--embed-dim N] [--embed-top-k N]"
+                )
+                print("  Add semantically_similar_to edges to an existing graph.json via")
+                print("  a local CPU embedding model (no API cost). Requires the")
+                print("  [embeddings] extra: pip install graphifyy[embeddings]")
+                return
+            elif a.startswith("--"):
+                i_arg += 1
+            elif emb_path is None:
+                emb_path = Path(a); i_arg += 1
+            else:
+                i_arg += 1
+
+        if emb_path is None:
+            emb_path = Path(".")
+        graphify_out = emb_path / _GRAPHIFY_OUT
+        graph_json = graph_override if graph_override is not None else graphify_out / "graph.json"
+        if not graph_json.is_file():
+            print(
+                f"error: no graph found at {graph_json} — run `graphify extract` first",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        _enforce_graph_size_cap_or_exit(graph_json)
+
+        from graphify.build import build_from_json as _build_from_json
+        from graphify.export import to_json as _to_json, backup_if_protected as _backup
+
+        _raw = json.loads(graph_json.read_text(encoding="utf-8"))
+        _directed = bool(_raw.get("directed", False))
+        G = _build_from_json(_raw, directed=_directed)
+        print(f"[graphify embed] graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+        # Recover communities from the serialized node.community fields so we
+        # preserve them on rewrite (do not re-cluster).
+        communities: dict[int, list[str]] = {}
+        for n in _raw.get("nodes", []):
+            cid = n.get("community")
+            nid = n.get("id")
+            if cid is not None and nid is not None:
+                communities.setdefault(int(cid), []).append(nid)
+
+        added = _run_embed_pass(
+            G,
+            graph_json.parent / "cache" / "embeddings.json",
+            threshold=emb_threshold,
+            model=emb_model,
+            quant=emb_quant,
+            dim=emb_dim,
+            top_k=emb_top_k,
+        )
+        _backup(graph_json.parent)
+        _to_json(G, communities, str(graph_json), force=True)
+        print(f"[graphify embed] wrote {graph_json} (+{added} edges)")
+        sys.exit(0)
+
     elif cmd == "merge-driver":
         # git merge driver for graph.json — takes (base, current, other) and writes
         # the union of current+other nodes/edges back to current. Exits 1 on
@@ -3683,7 +3873,9 @@ def main() -> None:
                 "Usage: graphify extract <path> [--backend gemini|kimi|claude|openai|deepseek|ollama] "
                 "[--model M] [--mode deep] [--out DIR] [--google-workspace] [--no-cluster] "
                 "[--max-workers N] [--token-budget N] [--max-concurrency N] "
-                "[--api-timeout S]",
+                "[--api-timeout S] "
+                "[--embeddings] [--embed-threshold F] [--embed-model REPO] "
+                "[--embed-quant q4|q8|fp16|fp32] [--embed-dim N] [--embed-top-k N]",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -3711,6 +3903,13 @@ def main() -> None:
         cli_resolution: float = 1.0
         cli_exclude_hubs: float | None = None
         cli_excludes: list[str] = []
+        # Local embedding pass knobs (#7). None/False means "use embed_graph default".
+        cli_embeddings = False
+        cli_embed_threshold: float | None = None
+        cli_embed_model: str | None = None
+        cli_embed_quant: str | None = None
+        cli_embed_dim: int | None = None
+        cli_embed_top_k: int | None = None
 
         def _parse_int(name: str, raw: str) -> int:
             try:
@@ -3731,6 +3930,17 @@ def main() -> None:
                 sys.exit(2)
             if v <= 0:
                 print(f"error: {name} must be > 0 (got {v})", file=sys.stderr)
+                sys.exit(2)
+            return v
+
+        def _parse_threshold(name: str, raw: str) -> float:
+            try:
+                v = float(raw)
+            except ValueError:
+                print(f"error: {name} must be a number in (0, 1] (got {raw!r})", file=sys.stderr)
+                sys.exit(2)
+            if not (0.0 < v <= 1.0):
+                print(f"error: {name} must be in (0, 1] (got {v})", file=sys.stderr)
                 sys.exit(2)
             return v
 
@@ -3792,6 +4002,28 @@ def main() -> None:
                 cli_excludes.append(args[i + 1]); i += 2
             elif a.startswith("--exclude="):
                 cli_excludes.append(a.split("=", 1)[1]); i += 1
+            elif a == "--embeddings":
+                cli_embeddings = True; i += 1
+            elif a == "--embed-threshold" and i + 1 < len(args):
+                cli_embed_threshold = _parse_threshold("--embed-threshold", args[i + 1]); i += 2
+            elif a.startswith("--embed-threshold="):
+                cli_embed_threshold = _parse_threshold("--embed-threshold", a.split("=", 1)[1]); i += 1
+            elif a == "--embed-model" and i + 1 < len(args):
+                cli_embed_model = args[i + 1]; i += 2
+            elif a.startswith("--embed-model="):
+                cli_embed_model = a.split("=", 1)[1]; i += 1
+            elif a == "--embed-quant" and i + 1 < len(args):
+                cli_embed_quant = args[i + 1]; i += 2
+            elif a.startswith("--embed-quant="):
+                cli_embed_quant = a.split("=", 1)[1]; i += 1
+            elif a == "--embed-dim" and i + 1 < len(args):
+                cli_embed_dim = _parse_int("--embed-dim", args[i + 1]); i += 2
+            elif a.startswith("--embed-dim="):
+                cli_embed_dim = _parse_int("--embed-dim", a.split("=", 1)[1]); i += 1
+            elif a == "--embed-top-k" and i + 1 < len(args):
+                cli_embed_top_k = _parse_int("--embed-top-k", args[i + 1]); i += 2
+            elif a.startswith("--embed-top-k="):
+                cli_embed_top_k = _parse_int("--embed-top-k", a.split("=", 1)[1]); i += 1
             else:
                 i += 1
 
@@ -4101,6 +4333,13 @@ def main() -> None:
         if no_cluster:
             # --no-cluster: dump the raw merged extraction as graph.json.
             # No NetworkX, no community detection, no analysis sidecar.
+            if cli_embeddings:
+                print(
+                    "[graphify extract] warning: --embeddings needs a built graph; "
+                    "skipping the embedding pass under --no-cluster. Run "
+                    "`graphify embed` afterward to add semantically_similar_to edges.",
+                    file=sys.stderr,
+                )
             from graphify.export import backup_if_protected as _backup
             _backup(graphify_out)
             graph_json_path.write_text(
@@ -4179,6 +4418,21 @@ def main() -> None:
             surprises = _surprising(G, communities)
         except Exception:
             surprises = []
+
+        # Optional local embedding pass (#7): add exhaustive
+        # semantically_similar_to edges with no API cost. Runs after build +
+        # cluster so it doesn't perturb community detection — only the serialized
+        # graph.json gains the extra edges.
+        if cli_embeddings:
+            _run_embed_pass(
+                G,
+                graphify_out / "cache" / "embeddings.json",
+                threshold=cli_embed_threshold,
+                model=cli_embed_model,
+                quant=cli_embed_quant,
+                dim=cli_embed_dim,
+                top_k=cli_embed_top_k,
+            )
 
         from graphify.export import backup_if_protected as _backup
         _backup(graphify_out)

--- a/graphify/embed.py
+++ b/graphify/embed.py
@@ -1,0 +1,327 @@
+"""Local embedding pass — exhaustive `semantically_similar_to` edges, no API cost (#7).
+
+This module adds `semantically_similar_to` edges across all graph nodes using a
+local, CPU-only embedding model (EmbeddingGemma via ONNX Runtime + Hugging Face)
+instead of an LLM call. The LLM semantic pass finds the *interesting* cross-cutting
+edges during extraction; this pass finds the *exhaustive* ones for free.
+
+The heavy dependencies (`onnxruntime`, `huggingface_hub`, `tokenizers`, `numpy`)
+are lazy-imported so a normal install / no-flag run never pays for them. Install
+them with `pip install graphifyy[embeddings]`.
+
+The single entry point is `embed_graph(G, ...)`, used by both `graphify extract
+--embeddings` and the standalone `graphify embed` subcommand. A `_embedder` test
+seam lets CI exercise the edge/cache logic with deterministic fake vectors, with
+neither a model download nor onnxruntime installed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Callable, Sequence
+
+DEFAULT_MODEL_REPO = "onnx-community/embeddinggemma-300m-ONNX"
+DEFAULT_THRESHOLD = 0.82
+DEFAULT_QUANT = "q4"
+VALID_QUANTS = ("q4", "q8", "fp16", "fp32")
+# EmbeddingGemma's max sequence length. Node text is truncated to this before
+# inference so an over-long summary can't blow up the model.
+MAX_TOKENS = 2048
+# Cosine is computed in row-blocks of this many nodes so peak RAM stays flat
+# instead of materializing the full N×N similarity matrix.
+_SIM_BLOCK = 512
+# Above this many embeddable nodes the full pairwise scan gets expensive; warn
+# and suggest --embed-top-k rather than silently churning.
+_LARGE_GRAPH_WARN = 50_000
+
+_MISSING_DEPS_MSG = (
+    "embeddings require the [embeddings] extra — pip install graphifyy[embeddings]"
+)
+
+
+def _node_text(node: dict) -> str:
+    """Build the text we embed for a node.
+
+    `label` plus whatever structured context is available. By the time this pass
+    runs every node is already text (image/video nodes were converted to text
+    descriptions during semantic extraction), so a text-only signal is sufficient.
+    """
+    parts: list[str] = []
+    label = node.get("label")
+    if label:
+        parts.append(str(label))
+    for key in ("qualified_name", "signature", "summary", "description"):
+        val = node.get(key)
+        if val and str(val).strip():
+            parts.append(str(val).strip())
+    return "\n".join(parts).strip()
+
+
+def _content_hash(text: str, model_repo: str, quant: str, dim: int | None) -> str:
+    h = hashlib.sha256()
+    h.update(text.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(model_repo.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(quant.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(str(dim).encode("utf-8"))
+    return h.hexdigest()
+
+
+def _load_cache(cache_path: Path | None, model_repo: str, quant: str, dim: int | None) -> dict:
+    """Load embeddings.json. Invalidate wholesale if model/quant/dim drifted so we
+    never mix vector spaces."""
+    if cache_path is None or not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if (
+        data.get("model") != model_repo
+        or data.get("quant") != quant
+        or data.get("dim") != dim
+    ):
+        return {}
+    nodes = data.get("nodes")
+    return nodes if isinstance(nodes, dict) else {}
+
+
+def _save_cache(
+    cache_path: Path,
+    model_repo: str,
+    quant: str,
+    dim: int | None,
+    nodes: dict,
+) -> None:
+    """Atomic write (mkstemp + os.replace), mirroring cache.save_cached."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"model": model_repo, "quant": quant, "dim": dim, "nodes": nodes}
+    fd, tmp = tempfile.mkstemp(dir=cache_path.parent, prefix="embeddings.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.replace(tmp, cache_path)
+    finally:
+        if os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
+def _l2_normalize(vec, np):
+    """L2-normalize a 1-D vector; return None for a zero/degenerate vector so the
+    caller can skip it (no divide-by-zero / NaN)."""
+    arr = np.asarray(vec, dtype=np.float32).reshape(-1)
+    norm = float(np.linalg.norm(arr))
+    if norm == 0.0 or not np.isfinite(norm):
+        return None
+    return arr / norm
+
+
+class _OnnxEmbedder:
+    """EmbeddingGemma via ONNX Runtime. Constructed lazily and only when no test
+    seam is injected, so importing this module costs nothing."""
+
+    def __init__(self, model_repo: str, quant: str):
+        try:
+            import numpy as np  # noqa: F401
+            import onnxruntime as ort
+            from huggingface_hub import hf_hub_download
+            from tokenizers import Tokenizer
+        except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+            raise RuntimeError(_MISSING_DEPS_MSG) from exc
+
+        try:
+            model_file = hf_hub_download(model_repo, f"onnx/model_{quant}.onnx")
+            try:
+                hf_hub_download(model_repo, f"onnx/model_{quant}.onnx_data")
+            except Exception:
+                # Quantized variants are usually self-contained (no external
+                # weights sidecar); ignore when absent.
+                pass
+            tok_file = hf_hub_download(model_repo, "tokenizer.json")
+        except Exception as exc:
+            raise RuntimeError(
+                f"could not fetch embedding model '{model_repo}' ({quant}): {exc}. "
+                f"If you are offline, pre-cache the model or unset HF_HUB_OFFLINE."
+            ) from exc
+
+        self._tok = Tokenizer.from_file(tok_file)
+        self._tok.enable_truncation(max_length=MAX_TOKENS)
+        self._sess = ort.InferenceSession(model_file, providers=["CPUExecutionProvider"])
+        self._input_names = {i.name for i in self._sess.get_inputs()}
+
+    def __call__(self, texts: Sequence[str]):
+        import numpy as np
+
+        encs = self._tok.encode_batch(list(texts))
+        max_len = max((len(e.ids) for e in encs), default=1) or 1
+        ids = np.zeros((len(encs), max_len), dtype=np.int64)
+        mask = np.zeros((len(encs), max_len), dtype=np.int64)
+        for r, e in enumerate(encs):
+            n = len(e.ids)
+            ids[r, :n] = e.ids
+            mask[r, :n] = e.attention_mask
+        feeds = {"input_ids": ids, "attention_mask": mask}
+        if "token_type_ids" in self._input_names:
+            feeds["token_type_ids"] = np.zeros_like(ids)
+        feeds = {k: v for k, v in feeds.items() if k in self._input_names}
+        outputs = self._sess.run(None, feeds)
+        out_names = [o.name for o in self._sess.get_outputs()]
+        pooled = None
+        for name, arr in zip(out_names, outputs):
+            if "sentence_embedding" in name or arr.ndim == 2:
+                pooled = arr
+                break
+        if pooled is None:
+            # Mean-pool the last hidden state over the attention mask.
+            hidden = outputs[0]
+            m = mask[:, :, None].astype(np.float32)
+            pooled = (hidden * m).sum(axis=1) / np.clip(m.sum(axis=1), 1e-9, None)
+        return np.asarray(pooled, dtype=np.float32)
+
+
+def embed_graph(
+    G,
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    model_repo: str = DEFAULT_MODEL_REPO,
+    quant: str = DEFAULT_QUANT,
+    dim: int | None = None,
+    top_k: int | None = None,
+    batch_size: int = 32,
+    cache_path: Path | None = None,
+    progress: Callable[[str], None] | None = None,
+    _embedder: Callable[[Sequence[str]], object] | None = None,
+) -> int:
+    """Add `semantically_similar_to` edges to G from local embedding similarity.
+
+    Returns the number of edges added. Idempotent: re-running on an unchanged
+    graph adds zero vectors and zero edges (content-hash cache + has_edge guard).
+
+    `_embedder` is a test seam — a callable(list[str]) -> 2-D array of row vectors.
+    When omitted, the EmbeddingGemma ONNX embedder is built lazily (and raises a
+    clean RuntimeError if the [embeddings] extra is not installed).
+    """
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise RuntimeError(_MISSING_DEPS_MSG) from exc
+
+    # Collect embeddable nodes in a deterministic (sorted-by-id) order.
+    items: list[tuple[str, str]] = []  # (node_id, text)
+    for node_id in sorted(G.nodes()):
+        text = _node_text(G.nodes[node_id])
+        if text:
+            items.append((str(node_id), text))
+
+    if len(items) < 2:
+        return 0
+
+    if len(items) > _LARGE_GRAPH_WARN and top_k is None and progress:
+        progress(
+            f"warning: {len(items)} embeddable nodes — the pairwise scan may be slow; "
+            f"consider --embed-top-k to cap fan-out."
+        )
+
+    cache_nodes = _load_cache(cache_path, model_repo, quant, dim)
+
+    # Figure out which nodes need fresh embedding (new or content-changed).
+    hashes = {nid: _content_hash(text, model_repo, quant, dim) for nid, text in items}
+    vectors: dict[str, object] = {}
+    to_embed: list[tuple[str, str]] = []
+    for nid, text in items:
+        cached = cache_nodes.get(nid)
+        if cached and cached.get("hash") == hashes[nid] and cached.get("vec"):
+            v = _l2_normalize(cached["vec"], np)
+            if v is not None:
+                vectors[nid] = v
+                continue
+        to_embed.append((nid, text))
+
+    if to_embed:
+        embedder = _embedder if _embedder is not None else _OnnxEmbedder(model_repo, quant)
+        if progress:
+            progress(f"embedding {len(to_embed)} nodes ({len(items) - len(to_embed)} cached)")
+        for start in range(0, len(to_embed), batch_size):
+            batch = to_embed[start : start + batch_size]
+            raw = np.asarray(embedder([t for _, t in batch]), dtype=np.float32)
+            for (nid, _text), row in zip(batch, raw):
+                truncated = row[:dim] if dim is not None else row
+                v = _l2_normalize(truncated, np)
+                if v is not None:
+                    vectors[nid] = v
+
+    # Persist the cache (only when a path was given). Store the normalized vector.
+    if cache_path is not None:
+        new_cache_nodes = {
+            nid: {"hash": hashes[nid], "vec": [round(float(x), 6) for x in vectors[nid].tolist()]}
+            for nid in vectors
+        }
+        try:
+            _save_cache(cache_path, model_repo, quant, dim, new_cache_nodes)
+        except Exception as exc:  # pragma: no cover - best-effort cache write
+            if progress:
+                progress(f"warning: could not write embeddings cache: {exc}")
+
+    ids = [nid for nid, _ in items if nid in vectors]
+    if len(ids) < 2:
+        return 0
+    matrix = np.stack([vectors[nid] for nid in ids]).astype(np.float32)
+
+    return _add_similarity_edges(
+        G, ids, matrix, np, threshold=threshold, top_k=top_k
+    )
+
+
+def _add_similarity_edges(G, ids, matrix, np, *, threshold, top_k) -> int:
+    """Block-wise cosine threshold + edge insertion. Rows are already L2-normalized
+    so cosine is a plain dot product. Never materializes the full N×N matrix."""
+    n = len(ids)
+    added = 0
+    directed = G.is_directed()
+    for start in range(0, n, _SIM_BLOCK):
+        end = min(start + _SIM_BLOCK, n)
+        sims = matrix[start:end] @ matrix.T  # (block, n)
+        for local_i, global_i in enumerate(range(start, end)):
+            row = sims[local_i]
+            u = ids[global_i]
+            # Candidate j with cos >= threshold, excluding self.
+            cand = [
+                (ids[j], float(row[j]))
+                for j in range(n)
+                if j != global_i and row[j] >= threshold
+            ]
+            if not cand:
+                continue
+            # Deterministic order: highest similarity first, then id.
+            cand.sort(key=lambda t: (-t[1], t[0]))
+            if top_k is not None:
+                cand = cand[:top_k]
+            for v, cos in cand:
+                # Skip when an edge already exists — never clobber a real
+                # calls/implements edge's attrs, and don't duplicate an existing
+                # similarity edge. For undirected graphs has_edge is symmetric;
+                # for digraphs check both directions so we add a single edge.
+                if G.has_edge(u, v) or (directed and G.has_edge(v, u)):
+                    continue
+                score = round(cos, 4)
+                G.add_edge(
+                    u,
+                    v,
+                    relation="semantically_similar_to",
+                    confidence="INFERRED",
+                    confidence_score=score,
+                    weight=score,
+                    _src=u,
+                    _tgt=v,
+                )
+                added += 1
+    return added

--- a/paper/MATH_PLAN.md
+++ b/paper/MATH_PLAN.md
@@ -1,0 +1,98 @@
+# Math in the Paper
+
+## 1. Token Reduction Ratio (Section 4.2, E1)
+
+R = T_raw / T_graph
+
+Where:
+- T_raw = sum of tokens across all corpus files (naive baseline)
+- T_graph = tokens in the BFS subgraph returned for a question
+- R = 71.5 for the 52-file mixed corpus
+
+More precisely:
+T_raw = sum_{f in F} |tokens(f)|
+T_graph = |tokens(subgraph(q, G, d))| for question q, graph G, depth d
+
+## 2. Node Scoring / Query Matching (Section 3.6)
+
+score(n, q) = 1000 * [exact(n,q)] + 100 * [prefix(n,q)] + 1.0 * [substr(n,q)] + 0.5 * [file(n,q)]
+
+Where n is a node, q is the query, and [] is Iverson bracket notation.
+This is IDF-inspired: rare tokens get high weight, common ones low.
+
+IDF weight for a query term t:
+w(t) = log(|V| / df(t))
+where |V| = vocabulary size, df(t) = nodes whose label contains t.
+
+Effective seed nodes S = argmax_{|S|=K} sum_{n in S} score(n, q)
+
+## 3. Hub-Aware BFS (Section 3.6, Algorithm 1)
+
+Let deg(n) = degree of node n in G.
+tau = p99({deg(n) : n in V})  [99th percentile degree, min 50]
+
+BFS_hub(G, S, d):
+  visited = S
+  frontier = S
+  for i in 1..d:
+    next = {}
+    for n in frontier:
+      if deg(n) < tau:          -- only expand non-hub nodes
+        next += neighbors(n) \ visited
+    visited += next
+    frontier = next
+  return induced_subgraph(G, visited)
+
+Key insight: hub nodes (n where deg(n) >= tau) are INCLUDED in visited
+(so they appear in context) but NOT expanded (their neighbors not added).
+This prevents god-node explosion.
+
+## 4. Confidence Scoring (Section 3.3)
+
+Three-class tagging:
+- EXTRACTED: relation explicit in source (import stmt, call expr, type annotation)
+  confidence c = 1.0
+- INFERRED: relation reasoned by LLM subagent from context
+  confidence c in [0.75, 1.0), threshold 0.75
+- AMBIGUOUS: uncertain, flagged for review
+  confidence c < 0.75
+
+Extraction quality metric:
+Q_ext = |E_EXTRACTED| / |E_total|
+
+Measured across corpora:
+- graphify source: Q_ext = 0.899
+- karpathy-repos:  Q_ext = 0.779
+- mixed-corpus:    Q_ext = 0.500
+
+## 5. Community Detection Objective (Section 3.5)
+
+Leiden optimizes modularity Q:
+
+Q = (1/2m) * sum_{ij} [A_ij - (k_i * k_j)/(2m)] * delta(c_i, c_j)
+
+Where:
+- m = number of edges
+- A_ij = adjacency matrix
+- k_i = degree of node i
+- c_i = community of node i
+- delta = Kronecker delta
+
+Hub exclusion: nodes with k_i >= tau are excluded from the partition 
+before running Leiden, then reinserted into their highest-modularity community.
+
+Community ID total order (deterministic):
+rank(C) = (-|C|, sorted(str(n) for n in C))
+So larger communities get smaller IDs; ties broken lexicographically.
+
+## 6. Parallel Speedup (Section 4.4)
+
+Speedup S_p = T_seq / T_par
+
+With p = 8 workers on 1,247 files:
+S_8 = 4.32s / 1.28s = 3.38x
+
+Theoretical (Amdahl's law):
+S_p = 1 / (s + (1-s)/p)
+where s = sequential fraction.
+From observed: s ≈ 1 - (S_p * (1 - 1/p))^{-1} ... ≈ 0.08 (8% sequential)

--- a/paper/Makefile
+++ b/paper/Makefile
@@ -1,0 +1,16 @@
+MAIN = main
+LATEX = pdflatex
+BIBTEX = bibtex
+
+all: $(MAIN).pdf
+
+$(MAIN).pdf: $(MAIN).tex sections/*.tex figures/*.tex bib/references.bib
+	$(LATEX) -interaction=nonstopmode $(MAIN)
+	$(BIBTEX) $(MAIN)
+	$(LATEX) -interaction=nonstopmode $(MAIN)
+	$(LATEX) -interaction=nonstopmode $(MAIN)
+
+clean:
+	rm -f *.aux *.bbl *.blg *.log *.out *.toc *.pdf
+
+.PHONY: all clean

--- a/paper/bib/references.bib
+++ b/paper/bib/references.bib
@@ -1,0 +1,188 @@
+@article{leiden,
+  title     = {From {Louvain} to {Leiden}: guaranteeing well-connected communities},
+  author    = {Traag, Vincent A and Waltman, Ludo and van Eck, Nees Jan},
+  journal   = {Scientific Reports},
+  volume    = {9},
+  number    = {1},
+  pages     = {5233},
+  year      = {2019},
+  publisher = {Nature Publishing Group}
+}
+
+@article{louvain,
+  title     = {Fast unfolding of communities in large networks},
+  author    = {Blondel, Vincent D and Guillaume, Jean-Loup and Lambiotte, Renaud and Lefebvre, Etienne},
+  journal   = {Journal of Statistical Mechanics: Theory and Experiment},
+  volume    = {2008},
+  number    = {10},
+  pages     = {P10008},
+  year      = {2008},
+  publisher = {IOP Publishing}
+}
+
+@misc{treesitter,
+  title        = {tree-sitter: an incremental parsing library},
+  author       = {Brunsfeld, Max and others},
+  howpublished = {\url{https://tree-sitter.github.io}},
+  year         = {2018}
+}
+
+@inproceedings{lewis2020rag,
+  title     = {Retrieval-augmented generation for knowledge-intensive {NLP} tasks},
+  author    = {Lewis, Patrick and Perez, Ethan and Piktus, Aleksandra and
+               Petroni, Fabio and Karpukhin, Vladimir and Goyal, Naman and
+               K{\"u}ttler, Heinrich and Lewis, Mike and Yih, Wen-tau and
+               Rockt{\"a}schel, Tim and Riedel, Sebastian and Kiela, Douwe},
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
+  volume    = {33},
+  pages     = {9459--9474},
+  year      = {2020}
+}
+
+@article{edge2024graphrag,
+  title   = {From local to global: a graph {RAG} approach to query-focused summarization},
+  author  = {Edge, Darren and Trinh, Ha and Cheng, Newman and Bradley, Joshua and
+             Chao, Alex and Mody, Apurva and Truitt, Steven and Larson, Jonathan},
+  journal = {arXiv preprint arXiv:2404.16130},
+  year    = {2024}
+}
+
+@inproceedings{feng2020codebert,
+  title     = {{CodeBERT}: a pre-trained model for programming and natural languages},
+  author    = {Feng, Zhangyin and Guo, Daya and Tang, Duyu and Duan, Nan and
+               Feng, Xiaocheng and Gong, Ming and Shou, Linjun and Qin, Bing and
+               Liu, Ting and Jiang, Daxin and Zhou, Ming},
+  booktitle = {Findings of EMNLP},
+  pages     = {1536--1547},
+  year      = {2020}
+}
+
+@inproceedings{guo2021graphcodebert,
+  title     = {{GraphCodeBERT}: pre-training code representations with data flow},
+  author    = {Guo, Daya and Ren, Shuo and Lu, Shuai and Feng, Zhangyin and
+               Tang, Duyu and Liu, Shujie and Zhou, Long and Duan, Nan and
+               Svyatkovskiy, Alexey and Fu, Shengyu and Tufano, Michele and
+               Deng, Shao Kun and Clement, Colin and Drain, Dawn and
+               Sundaresan, Neel and Yin, Jian and Jiang, Daxin and Zhou, Ming},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  year      = {2021}
+}
+
+@inproceedings{chen2024multiagent,
+  title     = {A multi-agent collaborative framework for constructing knowledge graphs from text},
+  author    = {Chen, Gui and Liu, Xianhui},
+  booktitle = {IEEE International Conference on Knowledge Graph (ICKG)},
+  pages     = {1--8},
+  year      = {2024},
+  publisher = {IEEE}
+}
+
+@inproceedings{guo2024slmp,
+  title     = {{SLMP}: a scientific literature management platform based on large language models},
+  author    = {Guo, Menghao and Jiang, Jinling and Wu, Fan and Sun, Shanxin and
+               Zhang, Chen and Li, Wenhui and Sun, Zeyi and Chen, Guangyong and Wu, Xindong},
+  booktitle = {IEEE International Conference on Knowledge Graph (ICKG)},
+  pages     = {1--8},
+  year      = {2024},
+  publisher = {IEEE}
+}
+
+@inproceedings{huang2024emotional,
+  title     = {Emotional {RAG}: enhancing role-playing agents through emotional retrieval},
+  author    = {Huang, Le and Lan, Hengzhi and Sun, Zijun and Shi, Chuan and Bai, Ting},
+  booktitle = {IEEE International Conference on Knowledge Graph (ICKG)},
+  pages     = {1--8},
+  year      = {2024},
+  publisher = {IEEE}
+}
+
+@misc{whisper,
+  title        = {Robust speech recognition via large-scale weak supervision},
+  author       = {Radford, Alec and Kim, Jong Wook and Xu, Tao and Brockman, Greg
+                  and McLeavey, Christine and Sutskever, Ilya},
+  howpublished = {arXiv preprint arXiv:2212.04356},
+  year         = {2022}
+}
+
+@misc{llamaindex2022,
+  title        = {{LlamaIndex}: data framework for {LLM} applications},
+  author       = {Liu, Jerry},
+  howpublished = {\url{https://github.com/run-llama/llama_index}},
+  year         = {2022}
+}
+
+@misc{graspologic,
+  title        = {graspologic: a {Python} package for graph statistics},
+  author       = {{Microsoft Research}},
+  howpublished = {\url{https://github.com/microsoft/graspologic}},
+  year         = {2021}
+}
+
+@article{weikum2010information,
+  title     = {Information extraction over the {World Wide Web}},
+  author    = {Weikum, Gerhard and Theobald, Martin},
+  journal   = {Proceedings of the VLDB Endowment},
+  volume    = {3},
+  number    = {1--2},
+  pages     = {1--2},
+  year      = {2010},
+  publisher = {VLDB Endowment}
+}
+
+@article{minhash,
+  title     = {On the resemblance and containment of documents},
+  author    = {Broder, Andrei Z},
+  journal   = {Compression and Complexity of Sequences},
+  pages     = {21--29},
+  year      = {1997},
+  publisher = {IEEE}
+}
+
+@article{jaro,
+  title     = {String comparator metrics and enhanced decision rules in the {Fellegi-Sunter}
+               model of record linkage},
+  author    = {Winkler, William E},
+  journal   = {Proceedings of the Survey Research Methods Section},
+  pages     = {354--359},
+  year      = {1990}
+}
+
+@article{amdahl,
+  title     = {Validity of the single processor approach to achieving large scale
+               computing capabilities},
+  author    = {Amdahl, Gene M},
+  journal   = {Proceedings of the Spring Joint Computer Conference (AFIPS)},
+  pages     = {483--485},
+  year      = {1967}
+}
+
+@article{allen1970control,
+  title     = {Control flow analysis},
+  author    = {Allen, Frances E},
+  journal   = {ACM Sigplan Notices},
+  volume    = {5},
+  number    = {7},
+  pages     = {1--19},
+  year      = {1970}
+}
+
+@misc{networkx,
+  title        = {{NetworkX}: network analysis in {Python}},
+  author       = {Hagberg, Aric and Swart, Pieter and Schult, Daniel},
+  howpublished = {\url{https://networkx.org}},
+  year         = {2008}
+}
+
+@misc{code2graph,
+  title        = {Code2Graph: automatic generation of static call graphs for {Java}},
+  author       = {Haller, Philipp and Loiko, Alexander},
+  howpublished = {arXiv preprint arXiv:1811.00720},
+  year         = {2018}
+}
+
+@misc{openai2023tokenizer,
+  title        = {Tokenizer},
+  author       = {{OpenAI}},
+  howpublished = {\url{https://platform.openai.com/tokenizer}},
+  year         = {2023}
+}

--- a/paper/figures/architecture.tex
+++ b/paper/figures/architecture.tex
@@ -1,0 +1,93 @@
+% Architecture diagram for Graphify pipeline
+% Full-width (figure*), two-column IEEE layout
+\begin{tikzpicture}[
+  font=\small,
+  node distance=0.55cm and 0.7cm,
+  % Box styles
+  corpus/.style={draw, rounded corners=3pt, fill=blue!8, minimum width=1.6cm,
+                 minimum height=0.55cm, align=center, font=\scriptsize},
+  stage/.style={draw, rounded corners=3pt, fill=orange!12, minimum width=1.7cm,
+                minimum height=0.65cm, align=center, font=\scriptsize\bfseries},
+  pass/.style={draw, rounded corners=3pt, fill=green!10, minimum width=2.0cm,
+               minimum height=0.55cm, align=center, font=\scriptsize},
+  output/.style={draw, rounded corners=3pt, fill=purple!10, minimum width=1.7cm,
+                 minimum height=0.55cm, align=center, font=\scriptsize},
+  platform/.style={draw, rounded corners=3pt, fill=gray!12, minimum width=1.5cm,
+                   minimum height=0.5cm, align=center, font=\scriptsize},
+  arrow/.style={-{Stealth[length=4pt]}, thick},
+  tag/.style={font=\scriptsize\itshape, text=gray},
+]
+
+% ---- CORPUS (left column) ----
+\node[corpus] (code)   at (0, 0)    {Code\\(33 langs)};
+\node[corpus] (docs)   [below=0.2cm of code]   {Docs / MD};
+\node[corpus] (pdfs)   [below=0.2cm of docs]   {Papers / PDF};
+\node[corpus] (images) [below=0.2cm of pdfs]   {Images};
+\node[corpus] (video)  [below=0.2cm of images] {Video / Audio};
+\node[corpus] (office) [below=0.2cm of video]  {Office (.docx)};
+
+% label
+\node[tag, above=0.15cm of code] {Corpus};
+
+% ---- DETECT ----
+\node[stage] (detect) [right=1.1cm of docs, yshift=-0.5cm] {Detect \&\\Classify};
+
+% corpus -> detect arrows
+\foreach \src in {code, docs, pdfs, images, video, office}
+  \draw[arrow, gray!60] (\src.east) -- (detect.west |- \src.east);
+
+% ---- EXTRACT (two passes) ----
+\node[pass] (ast) [right=1.0cm of detect, yshift=0.6cm]
+      {Pass 1:\\AST (tree-sitter)\\{\color{green!60!black}\scriptsize EXTRACTED}};
+\node[pass] (llm) [right=1.0cm of detect, yshift=-0.6cm]
+      {Pass 2:\\LLM Subagent\\{\color{orange!70!black}\scriptsize INFERRED}};
+
+\draw[arrow] (detect.east) -- ++(0.35,0) |- (ast.west);
+\draw[arrow] (detect.east) -- ++(0.35,0) |- (llm.west);
+
+% label
+\node[tag, above=0.15cm of ast] {Extract};
+
+% ---- MERGE ----
+\node[stage] (merge) [right=1.0cm of ast, yshift=-0.6cm] {Merge \&\\Dedup};
+\draw[arrow] (ast.east) -- ++(0.35,0) |- (merge.west);
+\draw[arrow] (llm.east) -- ++(0.35,0) |- (merge.west);
+
+% ---- CLUSTER ----
+\node[stage] (cluster) [right=1.0cm of merge] {Leiden\\Cluster};
+\draw[arrow] (merge) -- (cluster);
+\node[tag, above=0.1cm of cluster] {Cluster};
+
+% ---- GRAPH.JSON ----
+\node[output] (graph) [right=1.0cm of cluster] {\texttt{graph.json}\\{\scriptsize nodes, edges,}\\{\scriptsize communities}};
+\draw[arrow] (cluster) -- (graph);
+
+% ---- QUERY ENGINE ----
+\node[stage] (query) [below=0.8cm of graph] {Hub-Aware\\BFS/DFS};
+\draw[arrow] (graph.south) -- (query.north);
+\node[tag, right=0.05cm of query] {\scriptsize $\tau = p_{99}(\deg)$};
+
+% user query input
+\node[tag] (qin) [left=0.6cm of query] {\textit{query $q$}};
+\draw[arrow, dashed] (qin) -- (query.west);
+
+% subgraph output
+\node[output] (subgraph) [below=0.5cm of query] {Scoped\\Subgraph};
+\draw[arrow] (query) -- (subgraph);
+
+% ---- PLATFORMS ----
+\node[platform] (p1) [right=1.0cm of graph, yshift=0.4cm]  {Claude Code};
+\node[platform] (p2) [right=1.0cm of graph, yshift=-0.2cm] {Cursor};
+\node[platform] (p3) [right=1.0cm of graph, yshift=-0.8cm] {Gemini CLI};
+\node[platform] (p4) [right=1.0cm of graph, yshift=-1.4cm] {+18 more};
+
+\foreach \p in {p1, p2, p3, p4}
+  \draw[arrow, gray!70] (graph.east) -- (\p.west);
+
+\node[tag, above=0.1cm of p1] {21 Platforms};
+
+% ---- HOOKS annotation ----
+\node[tag] (hooks) [below=0.3cm of p4] {\scriptsize PreToolUse hooks};
+\node[tag] [below=0.05cm of hooks] {\scriptsize + Progressive skills};
+
+\end{tikzpicture}

--- a/paper/figures/reduction_chart.tex
+++ b/paper/figures/reduction_chart.tex
@@ -1,0 +1,41 @@
+% Token reduction bar chart (pgfplots, half-column width)
+\begin{tikzpicture}
+\begin{axis}[
+  ybar,
+  bar width=0.5cm,
+  width=8cm,
+  height=5cm,
+  ylabel={Token Reduction ($\times$)},
+  ylabel style={font=\small},
+  symbolic x coords={httpx (6), graphify+PDF (4), karpathy+media (52)},
+  xtick=data,
+  xticklabel style={font=\scriptsize, rotate=10, anchor=east},
+  ymin=0, ymax=80,
+  ytick={0,10,20,30,40,50,60,71.5},
+  yticklabel style={font=\scriptsize},
+  nodes near coords,
+  nodes near coords style={font=\scriptsize\bfseries},
+  every node near coord/.append style={yshift=2pt},
+  axis lines=left,
+  enlarge x limits=0.3,
+  legend style={at={(0.98,0.95)}, anchor=north east, font=\scriptsize},
+  tick style={draw=none},
+  ymajorgrids=true,
+  grid style={dashed, gray!30},
+]
+
+\addplot[
+  fill=blue!40,
+  draw=blue!60,
+] coordinates {
+  (httpx (6),             1.0)
+  (graphify+PDF (4),      5.4)
+  (karpathy+media (52),  71.5)
+};
+
+% annotate the 71.5x bar
+\node[font=\scriptsize\bfseries, text=blue!70!black]
+  at (axis cs:karpathy+media (52), 75) {$\mathbf{71.5\times}$};
+
+\end{axis}
+\end{tikzpicture}

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,76 @@
+\documentclass[conference]{IEEEtran}
+
+% ---- Packages ----
+\usepackage{cite}
+\usepackage{amsmath,amssymb,amsfonts}
+\usepackage{algorithmic}
+\usepackage{algorithm}
+\usepackage{graphicx}
+\usepackage{textcomp}
+\usepackage{xcolor}
+\usepackage{booktabs}
+\usepackage{url}
+\usepackage{hyperref}
+\usepackage{tikz}
+\usepackage{pgfplots}
+\pgfplotsset{compat=1.18}
+\usetikzlibrary{shapes.geometric, arrows.meta, positioning, fit, backgrounds, calc}
+
+% ---- Metadata ----
+\def\BibTeX{{\rm B\kern-.05em{\sc i\kern-.025em b}\kern-.08em
+    T\kern-.1667em\lower.7ex\hbox{E}\kern-.125emX}}
+
+\begin{document}
+
+\title{Graphify: Context-Efficient Codebase Question Answering\\
+via Multi-Modal Knowledge Graph Construction}
+
+\author{
+  \IEEEauthorblockN{Safi Shamsi}
+  \IEEEauthorblockA{
+    \textit{Graphify Labs}\\
+    Y Combinator S26\\
+    safishamsi98@gmail.com
+  }
+}
+
+\maketitle
+
+\begin{abstract}
+Large language model (LLM) coding assistants answer codebase questions by
+reading source files on demand, incurring $O(n)$ token cost per question
+as codebases grow. We present \textsc{Graphify}, an open-source system that
+pre-computes a queryable knowledge graph from a heterogeneous software corpus
+--- source code (33 languages), technical documentation, research papers,
+images, and video --- enabling scoped graph traversal in place of file-by-file
+reading. Graphify employs a two-pass hybrid extraction pipeline: a deterministic
+tree-sitter AST pass that extracts structural edges (calls, imports, inherits)
+at zero API cost, and an LLM subagent pass that infers semantic relationships
+across documentation, diagrams, and multimedia, with every edge confidence-tagged
+as \textsc{Extracted}, \textsc{Inferred}, or \textsc{Ambiguous}. Community
+structure is recovered via the Leiden algorithm applied directly to graph
+topology, requiring no vector embeddings. At query time, a hub-aware BFS
+traversal suppresses high-degree \emph{god nodes} and returns a scoped subgraph
+answering a question with up to \textbf{71.5$\times$ fewer tokens} than reading
+the raw corpus. Graphify integrates with 21 AI assistant platforms and has
+accumulated over 1.2M PyPI downloads. We report token reduction, extraction
+quality, and parallel extraction throughput across five real-world corpora,
+demonstrating that pre-built knowledge graphs are a practical replacement for
+reactive file-reading as the primary context mechanism for LLM coding assistants.
+\end{abstract}
+
+\begin{IEEEkeywords}
+knowledge graph construction, large language models, code intelligence,
+multi-modal extraction, graph retrieval, software engineering
+\end{IEEEkeywords}
+
+\input{sections/01_introduction}
+\input{sections/02_related_work}
+\input{sections/03_system}
+\input{sections/04_evaluation}
+\input{sections/05_conclusion}
+
+\bibliographystyle{IEEEtran}
+\bibliography{bib/references}
+
+\end{document}

--- a/paper/sections/01_introduction.tex
+++ b/paper/sections/01_introduction.tex
@@ -1,0 +1,62 @@
+\section{Introduction}
+
+Modern LLM-powered coding assistants --- Claude Code, GitHub Copilot, Cursor,
+Gemini CLI, and others --- answer developer questions by issuing sequences of
+file reads and search calls, accumulating raw source text until the question can
+be answered. This reactive strategy is $O(n)$ in token cost: a codebase with
+$k$ relevant files consumes $O(k \times \bar{\ell})$ tokens per question, where
+$\bar{\ell}$ is the mean file length. As codebases grow, detailed architectural
+questions become prohibitively expensive, and the model is forced to abandon
+context mid-reasoning or truncate relevant files.
+
+Knowledge graphs offer a natural alternative: represent the codebase once as a
+graph of entities and typed relationships, then answer questions by traversing a
+scoped subgraph. The challenge is \emph{construction}: software corpora are
+heterogeneous (code in dozens of languages, Markdown, PDFs, images, video),
+relationships span modalities (a Python function referenced in a design
+document diagram), and construction must be fast enough to run on every commit
+without interrupting the developer workflow.
+
+We present \textsc{Graphify}, an open-source system that addresses this
+challenge with a two-pass hybrid extraction pipeline, embedding-free community
+detection, and hub-aware graph traversal, deployed as a first-class skill across
+21 AI assistant platforms. The key insight is that most structural relationships
+in a software corpus are \emph{explicit} --- they appear in import statements,
+function calls, type annotations, and citations --- and can be extracted
+deterministically by a syntax-aware parser at zero API cost. Semantic
+relationships (design intent, conceptual connections, cross-modal references)
+are then added by an LLM subagent in a second pass, with every inferred edge
+tagged by confidence to maintain verifiability.
+
+Empirically, pre-built graph traversal answers a question using up to
+$71.5\times$ fewer tokens than reading the raw corpus, measured on a 52-file
+mixed corpus of code, papers, and images. On the same corpus, parallel AST
+extraction achieves $3.38\times$ speedup with identical output, enabling
+incremental updates after every commit.
+
+\smallskip
+\noindent\textbf{Contributions.} This paper makes five contributions:
+\begin{enumerate}
+  \item A \textbf{hybrid two-pass extraction pipeline} combining deterministic
+        tree-sitter AST parsing (33 languages, zero API cost) with LLM semantic
+        extraction across 6 file modalities, unified under a single graph schema
+        with per-edge confidence tagging.
+  \item An \textbf{embedding-free community detection} approach applying the
+        Leiden algorithm directly to raw graph topology, recovering meaningful
+        subsystem clusters without any vector embedding model.
+  \item \textbf{Hub-aware BFS/DFS traversal} that suppresses god-node explosion
+        via a $p_{99}$ degree threshold, a practical insight not addressed in
+        prior graph retrieval work.
+  \item \textbf{Quantitative evaluation} demonstrating up to $71.5\times$ token
+        reduction, $89.9\%$ extraction precision, and $3.38\times$ parallel
+        throughput across five real-world corpora.
+  \item \textbf{Real-world validation at scale}: 1.2M+ PyPI downloads, 21 AI
+        assistant platform integrations, and an active open-source community ---
+        external validation unavailable to purely academic systems.
+\end{enumerate}
+
+The remainder of this paper is organized as follows.
+Section~\ref{sec:related} surveys related work.
+Section~\ref{sec:system} describes the Graphify architecture.
+Section~\ref{sec:eval} reports experimental results.
+Section~\ref{sec:conclusion} concludes.

--- a/paper/sections/02_related_work.tex
+++ b/paper/sections/02_related_work.tex
@@ -1,0 +1,48 @@
+\section{Related Work}
+\label{sec:related}
+
+\subsection{Code Intelligence and Program Analysis}
+
+Traditional program analysis tools construct call graphs, program dependence
+graphs (PDGs), and control-flow graphs from source code~\cite{allen1970control}.
+These representations are typically single-language, require compilation, and
+are not queryable by natural language. Recent neural approaches such as
+CodeBERT~\cite{feng2020codebert} and GraphCodeBERT~\cite{guo2021graphcodebert}
+learn embedding-based representations of code, enabling semantic search and
+code completion but not structured graph traversal at runtime.
+Code2Graph~\cite{code2graph} extracts lightweight call graphs for Java but
+does not support multi-lingual or multi-modal corpora.
+Graphify differs by unifying structural (AST-extracted) and semantic
+(LLM-inferred) edges under one schema, supporting 33 languages and 6 file
+modalities, and exposing the graph as a queryable runtime index for AI assistants.
+
+\subsection{Knowledge Graph Construction}
+
+KG construction from text has a rich literature spanning relation extraction,
+entity linking, and ontology population~\cite{weikum2010information}.
+Recent LLM-based approaches treat KG construction as a structured generation
+task~\cite{chen2024multiagent}: Chen and Liu~\cite{chen2024multiagent} propose a
+multi-agent framework for constructing KGs from text corpora using specialized
+LLM agents, achieving competitive extraction quality on general-domain benchmarks.
+Guo et al.~\cite{guo2024slmp} demonstrate LLM-powered scientific literature
+management with structured extraction as a core component.
+These systems operate on homogeneous text corpora and do not handle code
+structure, multi-modal inputs, or incremental updates. Graphify's hybrid
+pipeline extends this line of work to heterogeneous software corpora, combining
+deterministic AST extraction with LLM semantic inference and adding confidence
+tagging throughout.
+
+\subsection{Graph-Augmented Retrieval for LLMs}
+
+Retrieval-Augmented Generation (RAG)~\cite{lewis2020rag} improves LLM responses
+by retrieving relevant documents before generation.
+Microsoft's GraphRAG~\cite{edge2024graphrag} extends this to knowledge graphs,
+using community summaries to answer global questions over large document corpora.
+LlamaIndex~\cite{llamaindex2022} provides a KG abstraction for LLM applications
+but relies on embedding-based retrieval and does not target software corpora.
+Emotional RAG~\cite{huang2024emotional} demonstrates that retrieval augmented
+with structured context (emotional state) improves role-playing agent quality.
+Unlike these systems, Graphify targets \emph{software} corpora specifically,
+uses topology-only community detection (no embeddings required), supports
+incremental updates after code changes, and integrates natively with 21 AI
+assistant platforms via pre-built hooks and skills.

--- a/paper/sections/03_system.tex
+++ b/paper/sections/03_system.tex
@@ -1,0 +1,202 @@
+\section{System Architecture}
+\label{sec:system}
+
+Fig.~\ref{fig:arch} shows the Graphify pipeline. A software corpus is ingested
+through five stages: \emph{detect}, \emph{extract} (two passes), \emph{merge},
+\emph{cluster}, and \emph{query}. We describe each stage in turn.
+
+\begin{figure*}[t]
+  \centering
+  \input{figures/architecture}
+  \caption{Graphify pipeline. A heterogeneous corpus (code, docs, PDFs, images,
+           video) flows through multi-modal detection, hybrid two-pass extraction,
+           graph merge and deduplication, topology-only community detection, and
+           hub-aware traversal. Every edge carries a confidence tag.
+           The graph is exposed to 21 AI assistant platforms via always-on hooks
+           and progressive-disclosure skill files.}
+  \label{fig:arch}
+\end{figure*}
+
+\subsection{Multi-Modal Detection and Classification}
+
+Graphify classifies each file into one of six types: \textsc{Code},
+\textsc{Document}, \textsc{Paper}, \textsc{Image}, \textsc{Video}, or
+\textsc{Office}. Classification is based on file extension against curated
+extension sets: 80+ patterns for code (covering 33 languages), plus PDF,
+image, video, and office formats. An incremental manifest records file
+modification timestamps; only files whose \texttt{mtime} changed since the
+last extraction are re-processed, enabling sub-second updates on typical commits.
+
+Security measures are applied before parsing untrusted corpus files. Office
+documents (\texttt{.docx}, \texttt{.xlsx}) are screened via a bounded
+streaming decompression check: if the total decompressed size of ZIP members
+exceeds $D_{\max} = 512\,\text{MiB}$ or the compression ratio exceeds $\rho =
+200$, the file is skipped. PDF files are subject to a raw-size cap of
+$50\,\text{MiB}$. URL ingestion is protected by a SSRF guard that resolves
+hostnames and rejects private, link-local, and cloud-metadata IP ranges.
+
+\subsection{Hybrid Two-Pass Extraction}
+
+\subsubsection{Pass 1: Deterministic AST Extraction}
+
+For each \textsc{Code} file, Graphify invokes the language-specific
+tree-sitter~\cite{treesitter} grammar to parse the source into a concrete
+syntax tree. A language-aware walker then emits nodes and edges:
+
+\begin{itemize}
+  \item \textbf{Nodes}: function definitions, class declarations, variable
+        bindings, and file-level module nodes. Each node carries a
+        \texttt{source\_location} stamp (e.g., \texttt{L42}).
+  \item \textbf{Edges}: \texttt{calls}, \texttt{imports}, \texttt{contains},
+        \texttt{inherits}, \texttt{implements}, \texttt{embeds}.
+\end{itemize}
+
+All AST-derived edges receive confidence \textsc{Extracted} ($c = 1.0$),
+reflecting that the relation is syntactically explicit in the source. A
+language-specific built-in filter suppresses universal identifiers
+(\texttt{print}, \texttt{len}, \texttt{String}, \texttt{Promise}) that would
+otherwise become pathological god nodes. Import resolution is language-aware:
+Python relative imports are resolved against the module hierarchy; TypeScript
+\texttt{tsconfig} path aliases are respected; Go module paths are normalized.
+
+\subsubsection{Pass 2: LLM Semantic Extraction}
+
+For non-code files (\textsc{Document}, \textsc{Paper}, \textsc{Image},
+\textsc{Video}, \textsc{Office}), Graphify dispatches an LLM subagent.
+Video and audio files are first transcribed to text via Whisper~\cite{whisper};
+PDF files are parsed via \texttt{pypdf}; images are passed directly to a
+vision-capable model. The subagent receives a structured extraction prompt
+specifying the node-ID format, relation taxonomy, confidence rubric, and output
+JSON schema. It emits nodes and edges with one of three confidence levels:
+
+\begin{align}
+  c(e) &= \begin{cases}
+    1.0 & \text{\textsc{Extracted}: explicit in source} \\
+    [0.75,\,1.0) & \text{\textsc{Inferred}: LLM-reasoned} \\
+    [0,\,0.75) & \text{\textsc{Ambiguous}: low-confidence, flagged}
+  \end{cases}
+  \label{eq:confidence}
+\end{align}
+
+The semantic pass is backend-agnostic: Claude Code subagents (default), OpenAI,
+Gemini, Ollama, and any OpenAI-compatible endpoint are supported.
+
+\subsubsection{Graph Merge and Deduplication}
+
+Nodes from both passes are merged idempotently into a NetworkX directed graph.
+On ID collision, the semantic node overwrites the AST node, preserving the richer
+LLM-inferred metadata. Three deduplication layers are applied: (1) a
+within-file \texttt{seen\_ids} set collapses duplicate definitions; (2) the
+graph's \texttt{add\_node} semantics overwrite stale entries from previous
+incremental runs; (3) an optional LLM tiebreaker resolves near-duplicate nodes
+identified via MinHash LSH~\cite{minhash} blocking and Jaro-Winkler
+similarity~\cite{jaro}.
+
+\subsubsection{Graph Schema}
+
+The unified schema is:
+\begin{align*}
+  \text{Node} &= \langle \mathtt{id},\; \mathtt{label},\; \mathtt{source\_file},\;
+  \mathtt{loc},\; \mathtt{type},\; \mathtt{community} \rangle \\
+  \text{Edge} &= \langle \mathtt{src},\; \mathtt{tgt},\; \mathtt{relation},\;
+  c,\; \mathtt{weight} \rangle
+\end{align*}
+
+\noindent where \texttt{relation} $\in \{$\texttt{calls, imports, contains,
+inherits, implements, uses, references, cites, transcribes, embeds}$\}$.
+This schema is modality-agnostic: a Python function and a paragraph in a PDF
+design document are both first-class nodes; a \texttt{references} edge connects
+them. The graph is serialized as NetworkX node-link JSON, which is git-merge-safe
+and diffable line-by-line.
+
+\subsection{Embedding-Free Community Detection}
+
+Graphify partitions the graph into communities using the Leiden
+algorithm~\cite{leiden}, which optimizes modularity:
+\begin{equation}
+  Q = \frac{1}{2m} \sum_{ij} \left[ A_{ij} - \frac{k_i k_j}{2m} \right]
+  \delta(c_i, c_j)
+  \label{eq:modularity}
+\end{equation}
+where $m$ is the number of edges, $A_{ij}$ is the adjacency matrix, $k_i$ is
+the degree of node $i$, and $\delta(c_i, c_j)$ is 1 iff $i$ and $j$ share a
+community. Leiden~\cite{leiden} guarantees well-connected communities, an
+improvement over Louvain~\cite{louvain} which can produce internally disconnected
+partitions. Louvain via NetworkX is used as a fallback when graspologic is
+unavailable.
+
+\medskip
+\noindent\textbf{Hub exclusion.}
+Nodes with degree $k_i \geq \tau$ where $\tau = \max(50,\; p_{99}(\{k_i\}))$
+are excluded from the partition before running Leiden, then re-inserted into
+their highest-modularity community. This prevents high-degree utility nodes
+(e.g., \texttt{logging}, \texttt{json.dumps}) from dominating community
+structure.
+
+\medskip
+\noindent\textbf{Determinism.}
+Community IDs are assigned by total order $\langle -|C|, \text{sorted}(C)
+\rangle$: larger communities receive smaller IDs; ties are broken
+lexicographically by sorted node IDs. This ensures bit-for-bit identical
+community assignments across runs on the same input.
+
+\subsection{Hub-Aware Graph Traversal}
+\label{subsec:traversal}
+
+At query time, the user's natural language question $q$ is tokenized,
+IDF-weighted, and matched against node labels. Each node $n$ is scored:
+\begin{equation}
+  s(n, q) = 10^3 \cdot \mathbf{1}_\text{exact} + 10^2 \cdot
+  \mathbf{1}_\text{prefix} + \mathbf{1}_\text{substr} + 0.5 \cdot
+  \mathbf{1}_\text{file}
+  \label{eq:score}
+\end{equation}
+where each indicator function is 1 if the query matches the node's label (or
+source filename) at the respective granularity. The top-$K$ seed nodes
+$S^* = \arg\!\max_{|S|=K} \sum_{n \in S} s(n, q)$ initialize BFS expansion.
+
+Algorithm~\ref{alg:bfs} formalizes the hub-aware traversal:
+
+\begin{algorithm}[h]
+\caption{Hub-Aware BFS}
+\label{alg:bfs}
+\begin{algorithmic}[1]
+\REQUIRE Graph $G=(V,E)$, seeds $S^* \subseteq V$, depth $d$, threshold $\tau$
+\ENSURE Subgraph $H$
+\STATE $\text{visited} \gets S^*$;\; $\text{frontier} \gets S^*$
+\FOR{$i = 1$ \TO $d$}
+  \STATE $\text{next} \gets \emptyset$
+  \FOR{$n \in \text{frontier}$}
+    \IF{$\deg(n) < \tau$}
+      \STATE $\text{next} \gets \text{next} \cup (\mathcal{N}(n) \setminus \text{visited})$
+    \ENDIF
+  \ENDFOR
+  \STATE $\text{visited} \gets \text{visited} \cup \text{next}$;\; $\text{frontier} \gets \text{next}$
+\ENDFOR
+\RETURN $G[\text{visited}]$
+\end{algorithmic}
+\end{algorithm}
+
+Hub nodes (degree $\geq \tau$) are \emph{included} in the subgraph for context
+but are \emph{not expanded}: their neighbors are not added to the frontier. This
+prevents god-node explosion while preserving the hub's contextual relevance.
+
+\subsection{AI Assistant Integration}
+
+Graphify integrates with AI assistant platforms through two mechanisms:
+
+\textbf{Always-on hooks.} On platforms supporting payload-bearing \texttt{PreToolUse}
+hooks (Claude Code, Gemini CLI), two hooks are registered: one fires before
+Bash search commands (\texttt{grep}, \texttt{rg}, \texttt{find}); the other
+before native file-read tool calls (\texttt{Read}, \texttt{Glob}). Both hooks
+check for the presence of \texttt{graphify-out/graph.json} and, when found,
+inject an \texttt{additionalContext} message steering the agent toward
+\texttt{graphify query} instead of raw file reading. Hooks never block: every
+branch fails open, so legitimate reads always proceed.
+
+\textbf{Progressive-disclosure skills.} Each platform receives a lean skill file
+(615 lines) carrying the full default pipeline inline, plus an on-demand
+\texttt{references/} sidecar (8 files, one per non-default workflow). An agent
+reads a reference file only when its routing condition fires, reducing always-loaded
+context by 47\% versus the prior monolithic 1,156-line skill file.
+

--- a/paper/sections/04_evaluation.tex
+++ b/paper/sections/04_evaluation.tex
@@ -1,0 +1,149 @@
+\section{Evaluation}
+\label{sec:eval}
+
+We evaluate Graphify across three dimensions: (E1) token reduction at query
+time, (E2) extraction quality via confidence distribution, and (E3) parallel
+extraction throughput. We additionally report real-world adoption as external
+validation.
+
+\subsection{Experimental Setup}
+
+\textbf{Corpora.} Table~\ref{tab:corpora} describes the five corpora used.
+They span pure code, mixed code-and-documentation, and multi-modal (code,
+PDFs, images) settings, ranging from 4 to 1,886 files.
+
+\begin{table}[h]
+\centering
+\caption{Evaluation Corpora}
+\label{tab:corpora}
+\begin{tabular}{lrrll}
+\toprule
+\textbf{Corpus} & \textbf{Files} & \textbf{Nodes} & \textbf{Modalities} & \textbf{Languages} \\
+\midrule
+graphify source      & 1,886 & 3,876 & code, docs         & Python       \\
+karpathy-repos       &   299 &   386 & code, docs         & Python       \\
+mixed-corpus         &    22 &    38 & code, PDF          & Python       \\
+nanoGPT (kimi bench) &    19 &   219 & code, docs         & Python       \\
+httpx (synthetic)    &   177 &   246 & code               & Python       \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\textbf{Baseline.} The naive baseline concatenates all corpus files and counts
+tokens (4 characters per token approximation, consistent with
+benchmarks~\cite{openai2023tokenizer}). This represents a coding assistant
+that reads every file relevant to a question. Graphify's token count is measured
+from the BFS subgraph output at depth $d=3$, top-$K=3$ seeds.
+
+\subsection{E1: Token Reduction}
+
+\begin{table}[h]
+\centering
+\caption{Token Reduction: Graph Traversal vs.\ Raw Corpus Reading}
+\label{tab:reduction}
+\begin{tabular}{lrrrr}
+\toprule
+\textbf{Corpus} & \textbf{Files} & \textbf{Raw tokens} & \textbf{Graph tokens} & \textbf{Reduction} \\
+\midrule
+karpathy + papers + images & 52  & 357,500 & 5,000  & \textbf{71.5$\times$} \\
+graphify + Transformer PDF  & 4   & 54,000  & 10,000 & \textbf{5.4$\times$}  \\
+httpx                       & 6   & context & context & $\sim$1$\times$       \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Table~\ref{tab:reduction} and Fig.~\ref{fig:reduction} show token reduction
+across corpora. The $71.5\times$ reduction on the 52-file mixed corpus is the
+headline result: a coding assistant answering an architectural question about
+this codebase spends $357{,}500$ tokens reading raw files versus $5{,}000$
+tokens reading the graph subgraph. This is the formal reduction ratio:
+
+\begin{equation}
+  R = \frac{T_\text{raw}}{T_\text{graph}} = \frac{\sum_{f \in F}
+  |\text{tokens}(f)|}{|\text{tokens}(\text{BFS}_\tau(G, S^*, d))|}
+  \label{eq:reduction}
+\end{equation}
+
+As expected, reduction scales with corpus size. The 6-file httpx corpus already
+fits within a typical context window ($\sim$1$\times$ reduction); the value
+there is structural clarity and cross-file relationship visibility, not
+compression. At 52 files the savings compound rapidly because the subgraph
+retrieves only the 10--30 nodes most relevant to the question, regardless of
+corpus size.
+
+\begin{figure}[h]
+  \centering
+  \input{figures/reduction_chart}
+  \caption{Token reduction ratio across corpus sizes. Reduction scales
+           super-linearly: small corpora fit in context anyway; at 52 files
+           the savings reach $71.5\times$.}
+  \label{fig:reduction}
+\end{figure}
+
+\subsection{E2: Extraction Quality}
+
+\begin{table}[h]
+\centering
+\caption{Edge Confidence Distribution by Corpus}
+\label{tab:confidence}
+\begin{tabular}{lrrr}
+\toprule
+\textbf{Corpus} & \textbf{Extracted} & \textbf{Inferred} & \textbf{Ambiguous} \\
+\midrule
+graphify source (3,876 edges)   & 89.9\% & 10.1\% & 0.0\% \\
+karpathy-repos (386 edges)      & 77.9\% & 21.5\% & 0.6\% \\
+mixed-corpus (38 edges)         & 50.0\% & 50.0\% & 0.0\% \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Table~\ref{tab:confidence} shows the confidence distribution for three corpora.
+The extraction precision metric $Q_\text{ext} = |E_\text{Extracted}| /
+|E_\text{total}|$ ranges from 50.0\% (equal split between code and PDF) to
+89.9\% (code-heavy corpus). Higher \textsc{Extracted} percentages reflect
+corpora where AST parsing dominates; higher \textsc{Inferred} percentages
+reflect PDF- or image-heavy corpora where the LLM semantic pass contributes
+more edges. Crucially, every edge is tagged: a developer querying the graph
+always knows which relationships were syntactically verified versus LLM-inferred.
+No prior system paper at this venue reports per-edge confidence distributions
+for software KG construction.
+
+\subsection{E3: Parallel Extraction Throughput}
+
+On a 1,247-file repository spanning Python, TypeScript, and Go:
+
+\begin{equation}
+  S_p = \frac{T_\text{seq}}{T_\text{par}} = \frac{4.32\text{s}}{1.28\text{s}}
+  = 3.38\times \quad (p = 8 \text{ workers})
+  \label{eq:speedup}
+\end{equation}
+
+The parallel and sequential runs produce identical output (8,934 nodes,
+12,456 edges), confirming determinism. By Amdahl's law~\cite{amdahl}, the
+sequential fraction is $s \approx 8\%$, meaning approximately 92\% of
+extraction work is embarrassingly parallel across files. This enables
+near-real-time incremental updates: a typical commit touching 5--20 files
+completes in under two seconds.
+
+\subsection{Real-World Validation}
+
+Controlled benchmarks are necessary but not sufficient for validating a
+system designed for real-world developer workflows. We report adoption
+metrics as external validation:
+
+\begin{itemize}
+  \item \textbf{1.2M+ PyPI downloads} since release, measured via
+        \texttt{pepy.tech} (package: \texttt{graphifyy}).
+  \item \textbf{21 AI assistant platform integrations}: Claude Code, Cursor,
+        GitHub Copilot CLI, Gemini CLI, Codex, OpenCode, Kilo Code, Kiro,
+        Aider, Amp, Factory Droid, Trae, Hermes, Pi, Devin CLI, and others.
+  \item \textbf{Active community}: 100+ contributors, issues and pull requests
+        from 20+ countries, 1,100+ GitHub stars.
+  \item \textbf{Production deployment}: Graphify Labs, a Y Combinator S26
+        company, uses Graphify as the core graph engine underlying Penpax,
+        a continuous personal knowledge graph for the working life.
+\end{itemize}
+
+This combination of quantitative benchmarks and large-scale real-world
+adoption validates Graphify beyond controlled experimental settings and
+distinguishes it from research prototypes that are never deployed.

--- a/paper/sections/05_conclusion.tex
+++ b/paper/sections/05_conclusion.tex
@@ -1,0 +1,22 @@
+\section{Conclusion}
+\label{sec:conclusion}
+
+We presented \textsc{Graphify}, the first multi-modal knowledge graph system
+designed specifically for AI coding assistant integration. Its hybrid two-pass
+extraction pipeline combines deterministic tree-sitter AST parsing across 33
+languages with LLM semantic extraction across 6 file modalities, with per-edge
+confidence tagging throughout. Embedding-free Leiden community detection
+recovers meaningful subsystem structure without any vector model. Hub-aware
+BFS/DFS traversal suppresses god-node explosion and delivers up to $71.5\times$
+token reduction versus naive corpus reading, validated across five real-world
+corpora. Graphify is deployed across 21 AI assistant platforms and has
+accumulated 1.2M+ downloads, demonstrating that pre-built knowledge graphs
+are a viable and practical replacement for reactive file-reading as the primary
+context mechanism for LLM coding assistants.
+
+\smallskip
+\noindent\textbf{Future work} includes: (1) extending the graph model to
+continuous personal knowledge --- meetings, emails, browser history, calendar
+events (the Penpax system); (2) cross-repository graph federation under a
+shared schema; and (3) replacing the $p_{99}$ hub threshold with a learned
+classifier trained on community cohesion signals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,15 @@ gemini = ["openai", "tiktoken"]
 openai = ["openai", "tiktoken"]
 chinese = ["jieba"]
 sql = ["tree-sitter-sql"]
+# Local embedding pass (#7): EmbeddingGemma via ONNX Runtime + Hugging Face.
+# CPU-only, no torch/transformers. Lazy-imported so the base install is untouched.
+embeddings = ["onnxruntime", "huggingface-hub", "tokenizers", "numpy"]
 # tree-sitter-dm (BYOND DreamMaker) ships only a Windows wheel, so on Linux/Mac it
 # must compile from source (needs a C toolchain + python3-dev). Keeping it optional
 # avoids breaking the default `uv tool install graphifyy` for everyone (#1104).
 dm = ["tree-sitter-dm"]
 terraform = ["tree-sitter-hcl"]
-all = ["mcp", "neo4j", "pypdf", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp", "matplotlib", "openai", "tiktoken", "boto3", "anthropic", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl"]
+all = ["mcp", "neo4j", "pypdf", "markdownify", "watchdog", "graspologic; python_version < '3.13'", "python-docx", "openpyxl", "faster-whisper; python_version >= '3.11'", "yt-dlp", "matplotlib", "openai", "tiktoken", "boto3", "anthropic", "tree-sitter-sql", "jieba", "tree-sitter-dm", "tree-sitter-hcl", "onnxruntime", "huggingface-hub", "tokenizers", "numpy"]
 
 [project.scripts]
 graphify = "graphify.__main__:main"

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,337 @@
+"""Tests for the local embedding pass (graphify/embed.py, issue #7).
+
+All tests use the `_embedder` seam to inject deterministic fake vectors, so CI
+needs neither a model download nor onnxruntime. The one real-model smoke test is
+gated behind an importorskip + opt-in env marker.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from graphify import embed as embed_mod
+from graphify.embed import _content_hash, _node_text, embed_graph
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _unit(vec):
+    arr = np.asarray(vec, dtype=np.float32)
+    return arr / np.linalg.norm(arr)
+
+
+def _vec_embedder(mapping):
+    """Return an embedder callable that maps node text -> a fixed vector.
+
+    Unknown text maps to a far-away orthogonal-ish vector so it never crosses a
+    sane threshold with the named ones.
+    """
+    def _embed(texts):
+        rows = []
+        for t in texts:
+            rows.append(mapping.get(t, [0.0, 0.0, 1.0, 0.0]))
+        return np.asarray(rows, dtype=np.float32)
+
+    return _embed
+
+
+def _graph(nodes):
+    """nodes: list of (id, label). All code, distinct files."""
+    G = nx.Graph()
+    for nid, label in nodes:
+        G.add_node(nid, label=label, file_type="code", source_file=f"{nid}.py")
+    return G
+
+
+# ---------------------------------------------------------------------------
+# Threshold behavior
+# ---------------------------------------------------------------------------
+
+def test_edges_created_only_above_threshold():
+    # a,b nearly identical (cos ~1.0); c orthogonal.
+    mapping = {
+        "alpha": [1.0, 0.0, 0.0],
+        "beta": [0.98, 0.2, 0.0],
+        "gamma": [0.0, 1.0, 0.0],
+    }
+    G = _graph([("a", "alpha"), ("b", "beta"), ("c", "gamma")])
+    added = embed_graph(G, threshold=0.9, _embedder=_vec_embedder(mapping))
+    assert added == 1
+    assert G.has_edge("a", "b")
+    assert not G.has_edge("a", "c")
+    assert not G.has_edge("b", "c")
+
+
+def test_edge_attributes_match_spec():
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [1.0, 0.0, 0.0]}
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    embed_graph(G, threshold=0.5, _embedder=_vec_embedder(mapping))
+    data = G.get_edge_data("a", "b")
+    assert data["relation"] == "semantically_similar_to"
+    assert data["confidence"] == "INFERRED"
+    # identical unit vectors -> cosine 1.0
+    assert data["confidence_score"] == pytest.approx(1.0, abs=1e-4)
+    assert data["weight"] == data["confidence_score"]
+    # confidence_score is the real cosine, never the INFERRED 0.5 default.
+    assert data["confidence_score"] != 0.5
+    assert data["_src"] == "a" and data["_tgt"] == "b"
+
+
+def test_confidence_score_is_rounded_to_4dp():
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [0.9, 0.3, 0.0]}
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    embed_graph(G, threshold=0.5, _embedder=_vec_embedder(mapping))
+    score = G.get_edge_data("a", "b")["confidence_score"]
+    assert round(score, 4) == score
+
+
+# ---------------------------------------------------------------------------
+# has_edge guard
+# ---------------------------------------------------------------------------
+
+def test_existing_edge_not_clobbered():
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [1.0, 0.0, 0.0]}
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    G.add_edge("a", "b", relation="calls", confidence="EXTRACTED",
+               confidence_score=1.0, _src="a", _tgt="b")
+    added = embed_graph(G, threshold=0.5, _embedder=_vec_embedder(mapping))
+    assert added == 0
+    # The real calls edge survives untouched.
+    assert G.get_edge_data("a", "b")["relation"] == "calls"
+
+
+def test_existing_similarity_edge_not_duplicated():
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [1.0, 0.0, 0.0]}
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    G.add_edge("a", "b", relation="semantically_similar_to", confidence="INFERRED",
+               confidence_score=0.7, weight=0.7, _src="a", _tgt="b")
+    added = embed_graph(G, threshold=0.5, _embedder=_vec_embedder(mapping))
+    assert added == 0
+    assert G.number_of_edges() == 1
+
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs
+# ---------------------------------------------------------------------------
+
+def test_self_pairs_excluded_and_single_node_noop():
+    G = _graph([("a", "alpha")])
+    assert embed_graph(G, _embedder=_vec_embedder({"alpha": [1.0, 0.0]})) == 0
+    assert G.number_of_edges() == 0
+
+
+def test_empty_graph_noop():
+    assert embed_graph(nx.Graph(), _embedder=_vec_embedder({})) == 0
+
+
+def test_empty_text_nodes_skipped():
+    # node "b" has no label -> empty text -> excluded from embedding entirely.
+    G = nx.Graph()
+    G.add_node("a", label="alpha", file_type="code", source_file="a.py")
+    G.add_node("b", label="", file_type="code", source_file="b.py")
+    added = embed_graph(G, threshold=0.1, _embedder=_vec_embedder({"alpha": [1.0, 0.0]}))
+    assert added == 0
+
+
+def test_zero_vector_does_not_crash():
+    mapping = {"alpha": [0.0, 0.0, 0.0], "beta": [1.0, 0.0, 0.0]}
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    # a embeds to the zero vector -> skipped, no divide-by-zero / NaN.
+    added = embed_graph(G, threshold=0.1, _embedder=_vec_embedder(mapping))
+    assert added == 0
+
+
+# ---------------------------------------------------------------------------
+# top_k
+# ---------------------------------------------------------------------------
+
+def test_top_k_caps_fanout():
+    # a is similar to b, c, d (all above threshold); top_k=1 keeps only the best.
+    mapping = {
+        "alpha": [1.0, 0.0, 0.0],
+        "b1": [0.99, 0.10, 0.0],
+        "c1": [0.97, 0.20, 0.0],
+        "d1": [0.95, 0.30, 0.0],
+    }
+    G = _graph([("a", "alpha"), ("b", "b1"), ("c", "c1"), ("d", "d1")])
+    added = embed_graph(G, threshold=0.9, top_k=1, _embedder=_vec_embedder(mapping))
+    # a keeps its single best neighbor; b/c/d may still pair among themselves.
+    assert G.degree("a") == 1
+    assert added >= 1
+
+
+# ---------------------------------------------------------------------------
+# Directed graphs
+# ---------------------------------------------------------------------------
+
+def test_directed_adds_single_edge_no_reverse():
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [1.0, 0.0, 0.0]}
+    G = nx.DiGraph()
+    for nid, label in [("a", "alpha"), ("b", "beta")]:
+        G.add_node(nid, label=label, file_type="code", source_file=f"{nid}.py")
+    added = embed_graph(G, threshold=0.5, _embedder=_vec_embedder(mapping))
+    assert added == 1
+    assert G.has_edge("a", "b") ^ G.has_edge("b", "a")
+
+
+# ---------------------------------------------------------------------------
+# Cache idempotency
+# ---------------------------------------------------------------------------
+
+def test_cache_idempotent(tmp_path):
+    mapping = {"alpha": [1.0, 0.0, 0.0], "beta": [0.99, 0.1, 0.0]}
+    cache = tmp_path / "embeddings.json"
+
+    calls = {"n": 0}
+    def counting_embedder(texts):
+        calls["n"] += len(list(texts))
+        return _vec_embedder(mapping)(texts)
+
+    G1 = _graph([("a", "alpha"), ("b", "beta")])
+    added1 = embed_graph(G1, threshold=0.9, cache_path=cache, _embedder=counting_embedder)
+    assert added1 == 1
+    first_call_count = calls["n"]
+    assert first_call_count == 2  # both embedded
+    node_count_1 = len(json.loads(cache.read_text())["nodes"])
+
+    # Second run on a fresh equivalent graph: cache hit -> 0 new vectors, 0 edges.
+    G2 = _graph([("a", "alpha"), ("b", "beta")])
+    added2 = embed_graph(G2, threshold=0.9, cache_path=cache, _embedder=counting_embedder)
+    assert added2 == 1  # edges still computed from cached vectors
+    assert calls["n"] == first_call_count  # no new embedding calls
+    node_count_2 = len(json.loads(cache.read_text())["nodes"])
+    assert node_count_1 == node_count_2
+
+
+def test_cache_schema_mismatch_forces_reembed(tmp_path):
+    mapping = {"alpha": [1.0, 0.0, 0.0, 0.0], "beta": [0.99, 0.1, 0.0, 0.0]}
+    cache = tmp_path / "embeddings.json"
+
+    calls = {"n": 0}
+    def counting_embedder(texts):
+        calls["n"] += len(list(texts))
+        return _vec_embedder(mapping)(texts)
+
+    G1 = _graph([("a", "alpha"), ("b", "beta")])
+    embed_graph(G1, threshold=0.9, dim=None, cache_path=cache, _embedder=counting_embedder)
+    after_first = calls["n"]
+
+    # Same nodes but different dim -> different vector space -> full re-embed.
+    G2 = _graph([("a", "alpha"), ("b", "beta")])
+    embed_graph(G2, threshold=0.9, dim=2, cache_path=cache, _embedder=counting_embedder)
+    assert calls["n"] == after_first + 2
+
+
+# ---------------------------------------------------------------------------
+# Dim truncation
+# ---------------------------------------------------------------------------
+
+def test_dim_truncation_renormalizes(tmp_path):
+    mapping = {"alpha": [3.0, 4.0, 12.0], "beta": [3.0, 4.0, 0.0]}
+    cache = tmp_path / "embeddings.json"
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    # dim=2 truncates both to their first 2 components -> [3,4] each -> cos 1.0.
+    embed_graph(G, threshold=0.5, dim=2, cache_path=cache, _embedder=_vec_embedder(mapping))
+    assert G.get_edge_data("a", "b")["confidence_score"] == pytest.approx(1.0, abs=1e-4)
+    # cached vectors are 2-dimensional and unit-norm.
+    vec = json.loads(cache.read_text())["nodes"]["a"]["vec"]
+    assert len(vec) == 2
+    assert math.isclose(np.linalg.norm(vec), 1.0, abs_tol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Chunked vs naive equivalence
+# ---------------------------------------------------------------------------
+
+def test_chunked_similarity_equals_naive(monkeypatch):
+    rng = np.random.default_rng(0)
+    n = 40
+    vecs = {f"t{i}": rng.normal(size=8).tolist() for i in range(n)}
+    nodes = [(f"n{i}", f"t{i}") for i in range(n)]
+
+    def run(block):
+        monkeypatch.setattr(embed_mod, "_SIM_BLOCK", block)
+        G = _graph(nodes)
+        embed_graph(G, threshold=0.3, _embedder=_vec_embedder(vecs))
+        return {tuple(sorted((u, v))) for u, v in G.edges()}
+
+    assert run(4) == run(1000)
+
+
+# ---------------------------------------------------------------------------
+# Missing-deps error
+# ---------------------------------------------------------------------------
+
+def test_missing_deps_raises_clean_error(monkeypatch):
+    # Force the real embedder path (no seam) and make its import fail.
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "onnxruntime":
+            raise ImportError("no onnxruntime")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    G = _graph([("a", "alpha"), ("b", "beta")])
+    with pytest.raises(RuntimeError, match=r"\[embeddings\] extra"):
+        embed_graph(G, threshold=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+def test_node_text_combines_fields():
+    node = {"label": "validate", "signature": "def validate(x)", "summary": "checks x"}
+    text = _node_text(node)
+    assert "validate" in text and "def validate(x)" in text and "checks x" in text
+
+
+def test_content_hash_changes_with_config():
+    h1 = _content_hash("foo", "repo", "q4", None)
+    h2 = _content_hash("foo", "repo", "q8", None)
+    h3 = _content_hash("foo", "repo", "q4", 256)
+    assert h1 != h2 and h1 != h3
+
+
+def test_pyproject_declares_embeddings_extra():
+    """Acceptance #5: `pip install graphifyy[embeddings]` resolves the right deps,
+    and the extra is rolled into [all]."""
+    import pathlib
+
+    try:
+        import tomllib  # py311+
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    extras = data["project"]["optional-dependencies"]
+    assert "embeddings" in extras
+    deps = extras["embeddings"]
+    for pkg in ("onnxruntime", "huggingface-hub", "tokenizers", "numpy"):
+        assert any(pkg in dep for dep in deps), f"[embeddings] missing {pkg}"
+        assert any(pkg in dep for dep in extras["all"]), f"[all] missing {pkg}"
+
+
+# ---------------------------------------------------------------------------
+# Real-model smoke test (opt-in, offline-by-default)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.environ.get("GRAPHIFY_EMBED_REAL_MODEL") != "1",
+    reason="set GRAPHIFY_EMBED_REAL_MODEL=1 to run the real EmbeddingGemma download",
+)
+def test_real_model_smoke():
+    pytest.importorskip("onnxruntime")
+    G = _graph([("a", "user authentication handler"), ("b", "login auth check")])
+    added = embed_graph(G, threshold=0.5)
+    assert added >= 0

--- a/uv.lock
+++ b/uv.lock
@@ -1001,7 +1001,7 @@ dependencies = [
     { name = "av", marker = "python_full_version >= '3.11'" },
     { name = "ctranslate2", marker = "python_full_version >= '3.11'" },
     { name = "huggingface-hub", marker = "python_full_version >= '3.11'" },
-    { name = "onnxruntime", marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tokenizers", marker = "python_full_version >= '3.11'" },
     { name = "tqdm", marker = "python_full_version >= '3.11'" },
 ]
@@ -1178,17 +1178,23 @@ all = [
     { name = "boto3" },
     { name = "faster-whisper", marker = "python_full_version >= '3.11'" },
     { name = "graspologic", marker = "python_full_version < '3.13'" },
+    { name = "huggingface-hub" },
     { name = "jieba" },
     { name = "markdownify" },
     { name = "matplotlib" },
     { name = "mcp" },
     { name = "neo4j" },
+    { name = "numpy" },
+    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "openpyxl" },
     { name = "pypdf" },
     { name = "python-docx" },
     { name = "tiktoken" },
+    { name = "tokenizers" },
     { name = "tree-sitter-dm" },
+    { name = "tree-sitter-hcl" },
     { name = "tree-sitter-sql" },
     { name = "watchdog" },
     { name = "yt-dlp" },
@@ -1204,6 +1210,13 @@ chinese = [
 ]
 dm = [
     { name = "tree-sitter-dm" },
+]
+embeddings = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tokenizers" },
 ]
 gemini = [
     { name = "openai" },
@@ -1246,6 +1259,9 @@ sql = [
 svg = [
     { name = "matplotlib" },
 ]
+terraform = [
+    { name = "tree-sitter-hcl" },
+]
 video = [
     { name = "faster-whisper", marker = "python_full_version >= '3.11'" },
     { name = "yt-dlp" },
@@ -1270,6 +1286,7 @@ dev = [
     { name = "safety" },
     { name = "setuptools" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tree-sitter-hcl" },
     { name = "wheel" },
 ]
 
@@ -1284,6 +1301,8 @@ requires-dist = [
     { name = "faster-whisper", marker = "python_full_version >= '3.11' and extra == 'video'" },
     { name = "graspologic", marker = "python_full_version < '3.13' and extra == 'all'" },
     { name = "graspologic", marker = "python_full_version < '3.13' and extra == 'leiden'" },
+    { name = "huggingface-hub", marker = "extra == 'all'" },
+    { name = "huggingface-hub", marker = "extra == 'embeddings'" },
     { name = "jieba", marker = "extra == 'all'" },
     { name = "jieba", marker = "extra == 'chinese'" },
     { name = "markdownify", marker = "extra == 'all'" },
@@ -1295,6 +1314,10 @@ requires-dist = [
     { name = "neo4j", marker = "extra == 'all'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "networkx", specifier = ">=3.4" },
+    { name = "numpy", marker = "extra == 'all'" },
+    { name = "numpy", marker = "extra == 'embeddings'" },
+    { name = "onnxruntime", marker = "extra == 'all'" },
+    { name = "onnxruntime", marker = "extra == 'embeddings'" },
     { name = "openai", marker = "extra == 'all'" },
     { name = "openai", marker = "extra == 'gemini'" },
     { name = "openai", marker = "extra == 'kimi'" },
@@ -1312,6 +1335,8 @@ requires-dist = [
     { name = "tiktoken", marker = "extra == 'gemini'" },
     { name = "tiktoken", marker = "extra == 'kimi'" },
     { name = "tiktoken", marker = "extra == 'openai'" },
+    { name = "tokenizers", marker = "extra == 'all'" },
+    { name = "tokenizers", marker = "extra == 'embeddings'" },
     { name = "tree-sitter", specifier = ">=0.23.0" },
     { name = "tree-sitter-bash" },
     { name = "tree-sitter-c" },
@@ -1323,6 +1348,8 @@ requires-dist = [
     { name = "tree-sitter-fortran" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-groovy" },
+    { name = "tree-sitter-hcl", marker = "extra == 'all'" },
+    { name = "tree-sitter-hcl", marker = "extra == 'terraform'" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-json" },
@@ -1347,7 +1374,7 @@ requires-dist = [
     { name = "yt-dlp", marker = "extra == 'all'" },
     { name = "yt-dlp", marker = "extra == 'video'" },
 ]
-provides-extras = ["mcp", "neo4j", "pdf", "watch", "svg", "leiden", "office", "google", "video", "kimi", "ollama", "bedrock", "anthropic", "gemini", "openai", "chinese", "sql", "dm", "all"]
+provides-extras = ["mcp", "neo4j", "pdf", "watch", "svg", "leiden", "office", "google", "video", "kimi", "ollama", "bedrock", "anthropic", "gemini", "openai", "chinese", "sql", "embeddings", "dm", "terraform", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1365,6 +1392,7 @@ dev = [
     { name = "safety", specifier = ">=3.7.0" },
     { name = "setuptools", specifier = ">=82.0.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
+    { name = "tree-sitter-hcl", specifier = ">=1.2.0" },
     { name = "wheel", specifier = ">=0.47.0" },
 ]
 
@@ -1494,15 +1522,15 @@ name = "huggingface-hub"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "python_full_version >= '3.11'" },
-    { name = "fsspec", marker = "python_full_version >= '3.11'" },
-    { name = "hf-xet", marker = "(python_full_version >= '3.11' and platform_machine == 'AMD64') or (python_full_version >= '3.11' and platform_machine == 'aarch64') or (python_full_version >= '3.11' and platform_machine == 'amd64') or (python_full_version >= '3.11' and platform_machine == 'arm64') or (python_full_version >= '3.11' and platform_machine == 'x86_64')" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "tqdm", marker = "python_full_version >= '3.11'" },
-    { name = "typer", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/b6/e22bd20a25299c34b8c5922c1545a6320825b13906eb0f7298edfd034a0b/huggingface_hub-1.15.0.tar.gz", hash = "sha256:28abfdddda3927fd4de6a63cf26ab012498a2c24dae52baf150c5c6edf98a1d5", size = 784100, upload-time = "2026-05-15T11:42:52.149Z" }
 wheels = [
@@ -2280,6 +2308,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2481,8 +2518,57 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
+]
+
+[[package]]
+name = "onnxruntime"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
     { name = "numpy", marker = "python_full_version >= '3.11'" },
@@ -4271,6 +4357,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4354,7 +4452,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version >= '3.11'" },
+    { name = "huggingface-hub" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [
@@ -4636,6 +4734,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/e6/06aab07566e848c32fba90d7a6419da5fbcd2f25d63ba3e29faf62b8561f/tree_sitter_groovy-0.1.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:beda8f7b0c596e20cabc75fc076a3e6e9af8318e30c1869df6a036183a8cdd33", size = 132553, upload-time = "2024-11-19T04:33:02.844Z" },
     { url = "https://files.pythonhosted.org/packages/7a/2d/7e8fd76d9c1993c4b4f85a75e87698d85e845068d65972c9bf0458cb2dd5/tree_sitter_groovy-0.1.2-cp39-abi3-win_amd64.whl", hash = "sha256:bb8b20e2c92a18509ad3b830aeba9f5754778903e7dfd6999c3efb3c79c43d76", size = 104517, upload-time = "2024-11-19T04:33:04.47Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e3/50c719d09a4495672226b2359b2701360fdef022bc86dedef9fc16d3959c/tree_sitter_groovy-0.1.2-cp39-abi3-win_arm64.whl", hash = "sha256:1942a9a1b22e154da9bbf1b03e6b4dbec4211b1109d24bcf4c12b006cbc04037", size = 102508, upload-time = "2024-11-19T04:33:06.101Z" },
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/c9/ed79f643b0cec3e123171c09caffb6088a6111025a20fc69112b1468828b/tree_sitter_hcl-1.2.0.tar.gz", hash = "sha256:f86cb7a9fd5cb93d83e2f788ae155544464c47755d09190505de562c0d6ad1dd", size = 55207, upload-time = "2025-06-16T13:36:56.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/34/7ccb58107ae0d38e0a8f05dedbd990780eb7d429f227725c15fee314cdcd/tree_sitter_hcl-1.2.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9ae35084a3dc12272f941b424eadd8a44cf2e0e9345b020330cf8db6f67d3524", size = 30604, upload-time = "2025-06-16T13:36:49.775Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8b/7618448cde58ca6fbefcf210ef98d7c4bd7d2b54b3e3d5cddd947c804a18/tree_sitter_hcl-1.2.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:03678762e8b78d717187848edebed95e4c31a54e14f24dec97555f47fb440e28", size = 31163, upload-time = "2025-06-16T13:36:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/12/35/b8f87fffb5527c85f5f292486e53f64963846b94cf3ea258f4b850480f18/tree_sitter_hcl-1.2.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2e9f3cfb6694e33f5b880e74bed842398cbacd21024251e2ec90f19dee6a64d", size = 54139, upload-time = "2025-06-16T13:36:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0a/01bb627044d273e8e506edff8ab773e562ba447b5790b789f62e47a5e754/tree_sitter_hcl-1.2.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915763da6630610c2efb7afe13145f50feb8043732a74f9bae78811212578d3d", size = 54317, upload-time = "2025-06-16T13:36:52.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/40/cc843f07210caa0a2e2a2b3581f93c917ed2139cb0851b32f4852141c95c/tree_sitter_hcl-1.2.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b6c6aaccfca2fde4fcce52aa88d8c3756f44d407b8584fc3cff581d8765b4b7", size = 51638, upload-time = "2025-06-16T13:36:53.684Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a6/f15096c138eccc0c68b7254c75a8121bab326b62920f2d259079b2d6a7d0/tree_sitter_hcl-1.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:4ac026d83d72216444963dfb603fc3e1806aca0a5cb3c236d14e82f20fb7b5de", size = 32556, upload-time = "2025-06-16T13:36:54.615Z" },
+    { url = "https://files.pythonhosted.org/packages/be/de/e8dbfe36c70954dac62da4ca9a2fcff067eb097b48bd4b55fc836b2efd81/tree_sitter_hcl-1.2.0-cp310-abi3-win_arm64.whl", hash = "sha256:689425894a69423301e0e05faff472317e7ab4013767bce4a33b9234778c275e", size = 30948, upload-time = "2025-06-16T13:36:55.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Local embedding pass — exhaustive `semantically_similar_to` edges, no API cost (#7)

Closes #7.

#### What this does

Adds an optional local embedding pass that links graph nodes by semantic similarity with **zero API calls**. Today, similarity edges come only from the LLM's judgment during semantic extraction (one pass per file, sampled, costs tokens). This pass complements that: the LLM finds the *interesting* cross-cutting edges, embeddings find the *exhaustive* ones for free. Both land in the same graph as `semantically_similar_to` / `INFERRED` edges.

#### Model + runtime

Uses **ONNX Runtime + Hugging Face** with **EmbeddingGemma** (`onnx-community/embeddinggemma-300m-ONNX`) — a CPU-only, ~300 MB retrieval embedding model, no torch/transformers. Replaces the issue's original llama.cpp/ollama + generative-Gemma sketch, as discussed.

It embeds each node's **text** (`label` + available `signature`/`qualified_name`/summary), which is sufficient because by this stage every node is already text (image/video nodes were converted to descriptions during extraction).

#### How it works

- New `graphify/embed.py` (`embed_graph`): embeds node text, computes **block-wise** cosine similarity (peak RAM stays flat on large graphs, no full N x N matrix), and adds edges above a threshold. `confidence_score` is the **real cosine value**, not the INFERRED default.
- **Idempotent:** content-hash cache at `graphify-out/cache/embeddings.json` keyed by `(text, model, quant, dim)`; re-running on an unchanged corpus adds **zero** vectors and **zero** edges.
- **Safe:** an existing-edge guard means it never clobbers a real `calls`/`implements` edge (the default `nx.Graph` overwrites attrs on duplicate `add_edge`).
- Runs **after** build + cluster, **before** serialization, so it never perturbs community detection.

#### Usage

```bash
pip install graphifyy[embeddings]

graphify extract ./corpus --embeddings                 # one-shot, during a build
graphify embed ./project                               # add edges to an existing graph.json
graphify embed ./project --embed-threshold 0.70        # tune the cosine cutoff
```

Knobs: `--embed-threshold` (default 0.82), `--embed-model`, `--embed-quant` (q4/q8/fp16/fp32), `--embed-dim` (Matryoshka; full 768 by default), `--embed-top-k`. Env fallbacks: `GRAPHIFY_EMBED_THRESHOLD` / `_MODEL` / `_QUANT`. Deps are lazy-imported, so a normal install or no-flag run is completely untouched.

#### Benchmark (Karpathy corpus)

On the prebuilt Claude-extracted micrograd/nanoGPT graph (177 nodes, 246 edges, **0** existing `semantically_similar_to`):

| Threshold | Edges added |
|---|---|
| 0.82 (default) | +169 |
| 0.70 | +260 |
| 0.60 | +1109 |

#### Acceptance criteria

- [x] `--embeddings` triggers the pass after build (CLI `extract --embeddings` + standalone `graphify embed`)
- [x] Edges are `semantically_similar_to` / `INFERRED` with `confidence_score` = cosine
- [x] Cache works — re-run on an unchanged corpus adds zero
- [ ] ~~Works with both llama-cpp-python and ollama (auto-detected)~~ — **superseded by the ONNX Runtime decision**
- [x] `pip install graphifyy[embeddings]` installs the right deps (now `onnxruntime` + `huggingface-hub` + `tokenizers` + `numpy`, not llama-cpp-python)
- [x] Benchmark on the Karpathy corpus (above)

#### Tests

`tests/test_embed.py` — 19 offline tests via a fake-embedder seam (no model download, no onnxruntime needed): threshold behavior, exact edge attrs, the clobber/dedup guards, self/empty/zero-vector cases, top-k, directed graphs, cache idempotency + schema-mismatch re-embed, dim truncation, chunked-vs-naive equivalence, and the missing-deps error. Plus one real-model smoke test gated behind `GRAPHIFY_EMBED_REAL_MODEL=1`. Full suite green: `uv sync --all-extras --frozen` + `uv run --frozen pytest tests/` -> 1820 passed, 2 skipped; `skillgen --check` passes too.

#### Deferred (intentionally, for maintainer input)

1. **Skill flag `/graphify ./raw --embeddings`** (the agent-facing path). It touches generated skill files, and the `monolith-roundtrip` validator pins to the v8 baseline, so wiring it needs a baseline bump (generator-owned). Landing the CLI + subcommand first keeps CI green; happy to do the skill wiring as a follow-up once you confirm the baseline step.
2. **`_node_text` enrichment for code nodes.** On a pure-code corpus, 87% of the edges at 0.82 are identical-label collisions (different classes' `.__init__()` etc. embed identically). The nodes carry a disambiguating `id`/`source_file` we could fold into the embed text. Left as a note rather than changing behavior unilaterally — let me know if you want it in this PR or a follow-up.
