### PR TITLE
feat(terraform): add Terraform/HCL support (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full release notes with details on each version: [GitHub Releases](https://github.com/safishamsi/graphify/releases)
 
+## Unreleased
+
+- Feat: Terraform/HCL support (#187). `.tf`, `.tfvars`, and `.hcl` files are now AST-extracted via tree-sitter-hcl into a real infrastructure dependency graph: resources, data sources, modules, variables, outputs, providers, and locals become nodes, and interpolation references (`aws_instance.web -> var.region`, `-> data.aws_ami.ubuntu`, ...) plus explicit `depends_on` become edges. Node IDs are scoped by directory rather than file, so cross-file references (a resource defined in `main.tf` and used in `network.tf`) resolve when per-file extractions are merged.
+
 ## 0.8.30 (2026-06-03)
 
 - Fix: `graphify install --project --platform antigravity` now writes Antigravity's always-on layer (`.agents/rules/graphify.md` + `.agents/workflows/graphify.md`), not just the skill. The project-scoped path went through the skill-only branch and skipped them, even though the project uninstall removes them.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ To remove graphify from all platforms at once: `graphify uninstall` (add `--purg
 
 | Type | Extensions |
 |------|-----------|
-| Code (33 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .svh .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json .dm .dme .dmi .dmm .dmf .sln .csproj .fsproj .vbproj .razor .cshtml` (`.dm`/`.dme` AST extraction requires `uv tool install graphifyy[dm]`) |
+| Code (34 languages) | `.py .ts .js .jsx .tsx .mjs .go .rs .java .c .cpp .h .hpp .rb .cs .kt .scala .php .swift .lua .luau .zig .ps1 .ex .exs .m .mm .jl .vue .svelte .astro .groovy .gradle .dart .v .sv .svh .sql .f .f90 .f95 .f03 .f08 .pas .pp .dpr .dpk .lpr .inc .dfm .lfm .lpk .sh .bash .json .tf .tfvars .hcl .dm .dme .dmi .dmm .dmf .sln .csproj .fsproj .vbproj .razor .cshtml` (`.dm`/`.dme` AST extraction requires `uv tool install graphifyy[dm]`) |
 | MCP configs | `.mcp.json` `mcp.json` `mcp_servers.json` `claude_desktop_config.json` — extracts server nodes, package refs, env var requirements |
 | Docs | `.md .mdx .qmd .html .txt .rst .yaml .yml` |
 | Office | `.docx .xlsx` (requires `uv tool install graphifyy[office]`) |

--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -25,7 +25,7 @@ class FileType(str, Enum):
 
 _MANIFEST_PATH = "graphify-out/manifest.json"
 
-CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml'}
+CODE_EXTENSIONS = {'.py', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.ejs', '.ets', '.go', '.rs', '.java', '.groovy', '.gradle', '.cpp', '.cc', '.cxx', '.c', '.h', '.hpp', '.rb', '.swift', '.kt', '.kts', '.cs', '.scala', '.php', '.lua', '.luau', '.toc', '.zig', '.ps1', '.ex', '.exs', '.m', '.mm', '.jl', '.vue', '.svelte', '.astro', '.dart', '.v', '.sv', '.svh', '.sql', '.r', '.f', '.F', '.f90', '.F90', '.f95', '.F95', '.f03', '.F03', '.f08', '.F08', '.pas', '.pp', '.dpr', '.dpk', '.lpr', '.inc', '.dfm', '.lfm', '.lpk', '.sh', '.bash', '.json', '.tf', '.tfvars', '.hcl', '.dm', '.dme', '.dmi', '.dmm', '.dmf', '.sln', '.csproj', '.fsproj', '.vbproj', '.razor', '.cshtml'}
 DOC_EXTENSIONS = {'.md', '.mdx', '.qmd', '.txt', '.rst', '.html', '.yaml', '.yml'}
 PAPER_EXTENSIONS = {'.pdf'}
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -10526,6 +10526,198 @@ def extract_dmf(path: Path) -> dict:
     return {"nodes": nodes, "edges": edges}
 
 
+# Head tokens in an HCL traversal that are meta/builtins, not references to a
+# block defined in the corpus (count.index, each.key, self.*, path.module, ...).
+_TF_META_HEADS = frozenset({"count", "each", "self", "path", "terraform"})
+
+
+def extract_terraform(path: Path) -> dict:
+    """Extract Terraform/HCL blocks and the references between them via tree-sitter.
+
+    Nodes: resources, data sources, modules, variables, outputs, providers, and
+    locals. Edges: `contains` (file -> block), `references` (block -> the blocks
+    it interpolates, e.g. `aws_instance.web` -> `var.region`), and `depends_on`
+    (explicit dependency edges).
+
+    Node IDs are scoped by the parent directory, not the file stem, because
+    Terraform resources are module(directory)-scoped: a resource defined in
+    main.tf is referenced from other .tf files in the same directory. Directory
+    scoping lets those cross-file references resolve when per-file extractions
+    are merged (stem scoping would split a definition from its references).
+    """
+    try:
+        import tree_sitter_hcl as tshcl
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return {"nodes": [], "edges": [], "error": "tree_sitter_hcl not installed. Run: pip install tree-sitter-hcl"}
+
+    try:
+        language = Language(tshcl.language())
+        parser = Parser(language)
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        root = tree.root_node
+    except Exception as e:
+        return {"nodes": [], "edges": [], "error": str(e)}
+
+    str_path = str(path)
+    file_nid = _make_id(str_path)
+    scope = path.parent.name or "tf"
+
+    nodes: list[dict] = [{"id": file_nid, "label": path.name, "file_type": "code",
+                          "source_file": str_path, "source_location": None}]
+    edges: list[dict] = []
+    seen_ids: set[str] = {file_nid}
+    seen_edges: set[tuple[str, str, str]] = set()
+
+    def _read(n) -> str:
+        return source[n.start_byte:n.end_byte].decode("utf-8", errors="replace")
+
+    def _label_text(n) -> str:
+        """Text of a block label, stripping surrounding quotes from string_lit."""
+        return _read(n).strip().strip('"')
+
+    def _add_node(address: str, label: str, line: int) -> str:
+        nid = _make_id(scope, address)
+        if nid not in seen_ids:
+            seen_ids.add(nid)
+            nodes.append({"id": nid, "label": label, "file_type": "code",
+                          "source_file": str_path, "source_location": f"L{line}"})
+            edges.append({"source": file_nid, "target": nid, "relation": "contains",
+                          "confidence": "EXTRACTED", "source_file": str_path,
+                          "source_location": f"L{line}", "weight": 1.0})
+        return nid
+
+    def _add_edge(src: str, address: str, relation: str, line: int) -> None:
+        tgt = _make_id(scope, address)
+        if src == tgt:
+            return
+        key = (src, tgt, relation)
+        if key in seen_edges:
+            return
+        seen_edges.add(key)
+        edges.append({"source": src, "target": tgt, "relation": relation,
+                      "confidence": "EXTRACTED", "source_file": str_path,
+                      "source_location": f"L{line}", "weight": 1.0})
+
+    def _block_parts(block) -> tuple[str | None, list[str]]:
+        """Return (block_type, [labels]) for an HCL block."""
+        btype: str | None = None
+        labels: list[str] = []
+        for c in block.children:
+            if c.type in ("block_start", "body", "block_end"):
+                break
+            if c.type == "identifier" and btype is None:
+                btype = _read(c)
+            elif c.type in ("string_lit", "identifier"):
+                labels.append(_label_text(c))
+        return btype, labels
+
+    def _ref_address(expr) -> str | None:
+        """Resolve a `variable_expr` (+ following get_attr siblings) to a Terraform
+        address, or None if it is a meta/builtin head."""
+        head = _read(expr)
+        # get_attr siblings live on the parent expression, after the variable_expr.
+        # Compare by node id, not `is`: tree-sitter hands out a fresh Python
+        # wrapper per traversal, so identity comparison never matches.
+        parent = expr.parent
+        attrs: list[str] = []
+        if parent is not None:
+            seen_self = False
+            for c in parent.children:
+                if c.id == expr.id:
+                    seen_self = True
+                    continue
+                if seen_self and c.type == "get_attr":
+                    name = None
+                    for gc in c.children:
+                        if gc.type == "identifier":
+                            name = _read(gc)
+                            break
+                    if name is None:
+                        break
+                    attrs.append(name)
+                elif seen_self and c.type not in ("get_attr",):
+                    break
+        if head in _TF_META_HEADS or not head:
+            return None
+        if head == "var":
+            return f"var.{attrs[0]}" if attrs else None
+        if head == "local":
+            return f"local.{attrs[0]}" if attrs else None
+        if head == "module":
+            return f"module.{attrs[0]}" if attrs else None
+        if head == "data":
+            return f"data.{attrs[0]}.{attrs[1]}" if len(attrs) >= 2 else None
+        # bare resource reference: TYPE.NAME
+        return f"{head}.{attrs[0]}" if attrs else None
+
+    def _collect_refs(node, owner_nid: str, relation: str) -> None:
+        """Walk a subtree, adding reference edges from owner_nid to every
+        traversal target. `relation` is overridden to depends_on under a
+        depends_on attribute."""
+        rel = relation
+        if node.type == "attribute":
+            key_node = node.child_by_field_name("key") or (
+                node.children[0] if node.children else None
+            )
+            if key_node is not None and _read(key_node) == "depends_on":
+                rel = "depends_on"
+        if node.type == "variable_expr":
+            addr = _ref_address(node)
+            if addr:
+                _add_edge(owner_nid, addr, rel, node.start_point[0] + 1)
+        for c in node.children:
+            if c.is_named:
+                _collect_refs(c, owner_nid, rel)
+
+    def _body_of(block):
+        for c in block.children:
+            if c.type == "body":
+                return c
+        return None
+
+    # The top-level body is wrapped in `config_file`, but a leading comment can
+    # push it past children[0], so find it by type rather than position.
+    body = next((c for c in root.children if c.type == "body"), root)
+    for block in body.children:
+        if block.type != "block":
+            continue
+        btype, labels = _block_parts(block)
+        line = block.start_point[0] + 1
+        blk_body = _body_of(block)
+        if btype == "resource" and len(labels) >= 2:
+            owner = _add_node(f"{labels[0]}.{labels[1]}", f"{labels[0]}.{labels[1]}", line)
+        elif btype == "data" and len(labels) >= 2:
+            owner = _add_node(f"data.{labels[0]}.{labels[1]}", f"data.{labels[0]}.{labels[1]}", line)
+        elif btype == "module" and labels:
+            owner = _add_node(f"module.{labels[0]}", f"module.{labels[0]}", line)
+        elif btype == "variable" and labels:
+            owner = _add_node(f"var.{labels[0]}", f"var.{labels[0]}", line)
+        elif btype == "output" and labels:
+            owner = _add_node(f"output.{labels[0]}", f"output.{labels[0]}", line)
+        elif btype == "provider" and labels:
+            owner = _add_node(f"provider.{labels[0]}", f"provider.{labels[0]}", line)
+        elif btype == "locals" and blk_body is not None:
+            # One node per local value so `local.x` references resolve precisely.
+            for attr in blk_body.children:
+                if attr.type != "attribute":
+                    continue
+                key_node = attr.children[0] if attr.children else None
+                if key_node is None:
+                    continue
+                key = _read(key_node)
+                lnid = _add_node(f"local.{key}", f"local.{key}", attr.start_point[0] + 1)
+                _collect_refs(attr, lnid, "references")
+            continue
+        else:
+            continue  # terraform{} settings and unknown blocks: no node
+        if blk_body is not None:
+            _collect_refs(blk_body, owner, "references")
+
+    return {"nodes": nodes, "edges": edges}
+
+
 _DISPATCH: dict[str, Any] = {
     ".py": extract_python,
     ".js": extract_js,
@@ -10594,6 +10786,9 @@ _DISPATCH: dict[str, Any] = {
     ".sh": extract_bash,
     ".bash": extract_bash,
     ".json": extract_json,
+    ".tf": extract_terraform,
+    ".tfvars": extract_terraform,
+    ".hcl": extract_terraform,
     ".dm": extract_dm,
     ".dme": extract_dm,
     ".dmi": extract_dmi,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "tree-sitter-fortran",
     "tree-sitter-bash",
     "tree-sitter-json",
+    "tree-sitter-hcl",
 ]
 
 [project.urls]

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -1,0 +1,149 @@
+"""Tests for the Terraform/HCL extractor (graphify/extract.py, issue #187)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify.build import build_from_json
+from graphify.extract import extract_terraform
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _labels(r) -> list[str]:
+    return [n["label"] for n in r["nodes"]]
+
+
+def _rel_pairs(r, relation: str) -> set[tuple[str, str]]:
+    lab = {n["id"]: n["label"] for n in r["nodes"]}
+    return {
+        (lab.get(e["source"], e["source"]), lab.get(e["target"], e["target"]))
+        for e in r["edges"]
+        if e["relation"] == relation
+    }
+
+
+SAMPLE = """\
+# leading comment so the body is not children[0]
+terraform {
+  required_providers { azurerm = { source = "hashicorp/azurerm" } }
+}
+
+variable "region" { default = "us-east-1" }
+
+provider "aws" { region = var.region }
+
+data "aws_ami" "ubuntu" { most_recent = true }
+
+resource "aws_instance" "web" {
+  ami       = data.aws_ami.ubuntu.id
+  subnet_id = var.region
+  depends_on = [aws_security_group.sg]
+}
+
+resource "aws_security_group" "sg" { name = "sg" }
+
+module "vpc" {
+  source = "./modules/vpc"
+  cidr   = local.cidr
+}
+
+locals { cidr = "10.0.0.0/16" }
+
+output "ip" { value = aws_instance.web.private_ip }
+"""
+
+
+def test_no_error_and_all_block_types_become_nodes(tmp_path):
+    r = extract_terraform(_write(tmp_path, "main.tf", SAMPLE))
+    assert r.get("error") is None
+    labels = set(_labels(r))
+    # one node per block type (the terraform{} settings block is intentionally skipped)
+    for expected in (
+        "var.region",
+        "provider.aws",
+        "data.aws_ami.ubuntu",
+        "aws_instance.web",
+        "aws_security_group.sg",
+        "module.vpc",
+        "local.cidr",
+        "output.ip",
+    ):
+        assert expected in labels, f"missing node {expected!r}"
+
+
+def test_reference_edges(tmp_path):
+    r = extract_terraform(_write(tmp_path, "main.tf", SAMPLE))
+    refs = _rel_pairs(r, "references")
+    assert ("provider.aws", "var.region") in refs
+    assert ("aws_instance.web", "data.aws_ami.ubuntu") in refs
+    assert ("aws_instance.web", "var.region") in refs
+    assert ("module.vpc", "local.cidr") in refs
+    assert ("output.ip", "aws_instance.web") in refs
+
+
+def test_depends_on_edge(tmp_path):
+    r = extract_terraform(_write(tmp_path, "main.tf", SAMPLE))
+    assert ("aws_instance.web", "aws_security_group.sg") in _rel_pairs(r, "depends_on")
+
+
+def test_file_contains_blocks(tmp_path):
+    r = extract_terraform(_write(tmp_path, "main.tf", SAMPLE))
+    contains = _rel_pairs(r, "contains")
+    assert ("main.tf", "aws_instance.web") in contains
+    assert ("main.tf", "var.region") in contains
+
+
+def test_meta_heads_not_emitted(tmp_path):
+    # count.index / each.key / self.* / path.module are builtins, not references.
+    body = """\
+resource "aws_instance" "web" {
+  count = 2
+  name  = "web-${count.index}"
+  tags  = each.value
+  dir   = path.module
+}
+"""
+    r = extract_terraform(_write(tmp_path, "main.tf", body))
+    targets = {t for _, t in _rel_pairs(r, "references")}
+    assert not any(t.startswith(("count", "each", "path")) for t in targets)
+
+
+def test_cross_file_references_resolve_after_merge(tmp_path):
+    # A resource defined in one file is referenced from another in the same
+    # directory; directory-scoped IDs must let the edge resolve at build time.
+    defn = """\
+resource "azurerm_resource_group" "main" { name = "rg" }
+"""
+    user = """\
+resource "azurerm_network_interface" "nic" {
+  resource_group_name = azurerm_resource_group.main.name
+}
+"""
+    r_defn = extract_terraform(_write(tmp_path, "main.tf", defn))
+    r_user = extract_terraform(_write(tmp_path, "nic.tf", user))
+
+    # The cross-file edge target id equals the definition's node id.
+    rg_id = next(n["id"] for n in r_defn["nodes"] if n["label"] == "azurerm_resource_group.main")
+    nic_ref_targets = {e["target"] for e in r_user["edges"] if e["relation"] == "references"}
+    assert rg_id in nic_ref_targets
+
+    # And it survives a real merge: the edge is present (not dropped as dangling).
+    G = build_from_json(
+        {
+            "nodes": r_defn["nodes"] + r_user["nodes"],
+            "edges": r_defn["edges"] + r_user["edges"],
+        }
+    )
+    nic_id = next(n["id"] for n in r_user["nodes"] if n["label"] == "azurerm_network_interface.nic")
+    assert G.has_edge(nic_id, rg_id)
+
+
+def test_empty_and_commentonly_files_are_safe(tmp_path):
+    assert extract_terraform(_write(tmp_path, "a.tf", "")).get("error") is None
+    r = extract_terraform(_write(tmp_path, "b.tf", "# just a comment\n"))
+    # only the file node, no crash
+    assert len(r["nodes"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1153,6 +1153,7 @@ dependencies = [
     { name = "tree-sitter-fortran" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-groovy" },
+    { name = "tree-sitter-hcl" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-json" },
@@ -1323,6 +1324,7 @@ requires-dist = [
     { name = "tree-sitter-fortran" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-groovy" },
+    { name = "tree-sitter-hcl" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-json" },
@@ -4636,6 +4638,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/e6/06aab07566e848c32fba90d7a6419da5fbcd2f25d63ba3e29faf62b8561f/tree_sitter_groovy-0.1.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:beda8f7b0c596e20cabc75fc076a3e6e9af8318e30c1869df6a036183a8cdd33", size = 132553, upload-time = "2024-11-19T04:33:02.844Z" },
     { url = "https://files.pythonhosted.org/packages/7a/2d/7e8fd76d9c1993c4b4f85a75e87698d85e845068d65972c9bf0458cb2dd5/tree_sitter_groovy-0.1.2-cp39-abi3-win_amd64.whl", hash = "sha256:bb8b20e2c92a18509ad3b830aeba9f5754778903e7dfd6999c3efb3c79c43d76", size = 104517, upload-time = "2024-11-19T04:33:04.47Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e3/50c719d09a4495672226b2359b2701360fdef022bc86dedef9fc16d3959c/tree_sitter_groovy-0.1.2-cp39-abi3-win_arm64.whl", hash = "sha256:1942a9a1b22e154da9bbf1b03e6b4dbec4211b1109d24bcf4c12b006cbc04037", size = 102508, upload-time = "2024-11-19T04:33:06.101Z" },
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/c9/ed79f643b0cec3e123171c09caffb6088a6111025a20fc69112b1468828b/tree_sitter_hcl-1.2.0.tar.gz", hash = "sha256:f86cb7a9fd5cb93d83e2f788ae155544464c47755d09190505de562c0d6ad1dd", size = 55207, upload-time = "2025-06-16T13:36:56.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/34/7ccb58107ae0d38e0a8f05dedbd990780eb7d429f227725c15fee314cdcd/tree_sitter_hcl-1.2.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9ae35084a3dc12272f941b424eadd8a44cf2e0e9345b020330cf8db6f67d3524", size = 30604, upload-time = "2025-06-16T13:36:49.775Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8b/7618448cde58ca6fbefcf210ef98d7c4bd7d2b54b3e3d5cddd947c804a18/tree_sitter_hcl-1.2.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:03678762e8b78d717187848edebed95e4c31a54e14f24dec97555f47fb440e28", size = 31163, upload-time = "2025-06-16T13:36:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/12/35/b8f87fffb5527c85f5f292486e53f64963846b94cf3ea258f4b850480f18/tree_sitter_hcl-1.2.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2e9f3cfb6694e33f5b880e74bed842398cbacd21024251e2ec90f19dee6a64d", size = 54139, upload-time = "2025-06-16T13:36:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0a/01bb627044d273e8e506edff8ab773e562ba447b5790b789f62e47a5e754/tree_sitter_hcl-1.2.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915763da6630610c2efb7afe13145f50feb8043732a74f9bae78811212578d3d", size = 54317, upload-time = "2025-06-16T13:36:52.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/40/cc843f07210caa0a2e2a2b3581f93c917ed2139cb0851b32f4852141c95c/tree_sitter_hcl-1.2.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b6c6aaccfca2fde4fcce52aa88d8c3756f44d407b8584fc3cff581d8765b4b7", size = 51638, upload-time = "2025-06-16T13:36:53.684Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a6/f15096c138eccc0c68b7254c75a8121bab326b62920f2d259079b2d6a7d0/tree_sitter_hcl-1.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:4ac026d83d72216444963dfb603fc3e1806aca0a5cb3c236d14e82f20fb7b5de", size = 32556, upload-time = "2025-06-16T13:36:54.615Z" },
+    { url = "https://files.pythonhosted.org/packages/be/de/e8dbfe36c70954dac62da4ca9a2fcff067eb097b48bd4b55fc836b2efd81/tree_sitter_hcl-1.2.0-cp310-abi3-win_arm64.whl", hash = "sha256:689425894a69423301e0e05faff472317e7ab4013767bce4a33b9234778c275e", size = 30948, upload-time = "2025-06-16T13:36:55.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

Closes #187.

#### What this does

Adds AST extraction for **Terraform / HCL** files (`.tf`, `.tfvars`, `.hcl`) via `tree-sitter-hcl`, turning an infrastructure repo into a real dependency graph. Before this, `.tf` files matched no extension set in `detect.py`, so they classified as `None` and were **skipped entirely** — graphify produced zero nodes/edges for Terraform. Now they become a structured graph.

#### Graph model

- **Nodes:** `resource`, `data` source, `module`, `variable`, `output`, `provider`, and per-key `locals`. (The `terraform {}` settings block is intentionally not a node.)
- **Edges:**
  - `contains` — file -> each block it defines
  - `references` — interpolation references, e.g. `aws_instance.web -> var.region`, `-> data.aws_ami.ubuntu`, `module.vpc -> local.cidr`, `output.ip -> aws_instance.web`
  - `depends_on` — explicit dependency edges

Labels use canonical Terraform addresses (`aws_instance.web`, `data.aws_ami.ubuntu`, `var.region`, `module.vpc`, `local.cidr`, `output.ip`).

#### Key design decision: directory-scoped node IDs

Terraform resources are **module (directory)-scoped**, not file-scoped — a resource defined in `main.tf` is referenced from sibling `.tf` files. Node IDs are therefore scoped by the parent directory rather than the file stem, so a definition in one file and a reference in another resolve to the same node when per-file extractions are merged. (Stem scoping, used by most language extractors, would split a definition from its references.)

#### Why AST (deterministic, free) is the right engine here

Extraction is byte-identical across runs, costs no tokens/API key, resolves references exactly from the HCL grammar (not guessed), and covers every resource/reference — all properties an LLM pass can't match for IaC.

#### Verified

- **Real repo** (a 9-file Terraform module): **25 nodes, 51 edges** (27 `contains`, 24 `references`), with cross-file resolution confirmed (`azurerm_network_interface.*` in one file -> `azurerm_resource_group.main` in another). Extraction is deterministic (two runs identical).
- **Tests** (`tests/test_terraform.py`, 7): block/edge model, `references`, `depends_on`, meta-head filtering (`count.index`/`each.key`/`path.module` are not emitted as refs), leading-comment handling, empty/comment-only files, and cross-file resolution through a real `build_from_json` merge.
- Full suite **1810 passed, 1 skipped** (no regressions); `ruff` clean; `uv sync --all-extras --frozen` consistent; `skillgen --check` unaffected.