### PR TITLE
build: add version floors to networkx, datasketch, rapidfuzz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ license = { file = "LICENSE" }
 keywords = ["claude", "claude-code", "codex", "opencode", "kilo", "cursor", "gemini", "aider", "kiro", "pi", "devin", "knowledge-graph", "rag", "graphrag", "obsidian", "community-detection", "tree-sitter", "leiden", "llm"]
 requires-python = ">=3.10"
 dependencies = [
-    "networkx",
-    "datasketch",
-    "rapidfuzz",
+    "networkx>=3.4",
+    "datasketch>=1.6",
+    "rapidfuzz>=3.0",
     "tree-sitter>=0.23.0",
     "tree-sitter-python",
     "tree-sitter-javascript",

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.8.30"
+version = "0.8.31"
 source = { editable = "." }
 dependencies = [
     { name = "datasketch" },
@@ -1279,7 +1279,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'" },
     { name = "boto3", marker = "extra == 'all'" },
     { name = "boto3", marker = "extra == 'bedrock'" },
-    { name = "datasketch" },
+    { name = "datasketch", specifier = ">=1.6" },
     { name = "faster-whisper", marker = "python_full_version >= '3.11' and extra == 'all'" },
     { name = "faster-whisper", marker = "python_full_version >= '3.11' and extra == 'video'" },
     { name = "graspologic", marker = "python_full_version < '3.13' and extra == 'all'" },
@@ -1294,7 +1294,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'" },
     { name = "neo4j", marker = "extra == 'all'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
-    { name = "networkx" },
+    { name = "networkx", specifier = ">=3.4" },
     { name = "openai", marker = "extra == 'all'" },
     { name = "openai", marker = "extra == 'gemini'" },
     { name = "openai", marker = "extra == 'kimi'" },
@@ -1307,7 +1307,7 @@ requires-dist = [
     { name = "pypdf", marker = "extra == 'pdf'" },
     { name = "python-docx", marker = "extra == 'all'" },
     { name = "python-docx", marker = "extra == 'office'" },
-    { name = "rapidfuzz" },
+    { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "tiktoken", marker = "extra == 'all'" },
     { name = "tiktoken", marker = "extra == 'gemini'" },
     { name = "tiktoken", marker = "extra == 'kimi'" },


### PR DESCRIPTION
## What

Three core runtime dependencies are declared with no version constraint:

```toml
dependencies = [
    "networkx",
    "datasketch",
    "rapidfuzz",
    "tree-sitter>=0.23.0",
    ...
]
```

This PR adds lower bounds matching the versions already resolved and tested in `uv.lock`:

| Dependency | Floor added | Resolved in `uv.lock` |
|---|---|---|
| `networkx`   | `>=3.4` | 3.4.2 (py<3.11) / 3.6.1 (py≥3.11) |
| `datasketch` | `>=1.6` | 1.10.0 |
| `rapidfuzz`  | `>=3.0` | 3.14.5 |

## Why

The committed `uv.lock` protects users who install via `uv tool` / `uvx` / `pipx`. But the README also documents `pip install graphifyy`, and a plain `pip` resolve **ignores the lockfile** — it can pull a major with breaking API changes:

- `rapidfuzz` changed its API between the 2.x and 3.x lines
- `networkx` has had breaking changes across majors

With no floor, such an install can fail at import/call time on a user's machine while CI (which uses `--frozen`) stays green. Floors cost nothing for lockfile users and close the gap for the documented `pip install` path.

## Notes

- All floors are **at or below** the currently locked versions and preserve `requires-python = ">=3.10"` (networkx 3.4.2 is already the version used on Python 3.10).
- `uv lock` updated **only** `graphifyy`'s own `requires-dist` metadata. **No resolved dependency versions changed.** It also synced the lock's `graphifyy` version field, which was stale at `0.8.30` vs `pyproject.toml`'s `0.8.31`.

## Test plan

- [x] `uv lock --check` passes — lockfile is consistent with `pyproject.toml`, no resolution drift
- [ ] CI green (`uv sync --all-extras --frozen` + `pytest` on Python 3.10 & 3.12)
