### PR TITLE
docs: add troubleshooting table for common install issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ for example `graphify claude install --project` or `graphify codex install --pro
 
 > **Git hooks and uv tool / pipx:** `graphify hook install` embeds the current interpreter path directly into the hook scripts at install time, so the post-commit hook fires correctly even in GUI git clients and CI runners where `~/.local/bin` is not on PATH. If you reinstall or upgrade graphify, re-run `graphify hook install` to refresh the embedded path.
 
+### Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ModuleNotFoundError: No module named 'graphify'` | You installed with plain `pip`. Reinstall with `uv tool install graphifyy` or `pipx install graphifyy` |
+| `graphify: command not found` | Add `~/.local/bin` (Linux) or `~/Library/Python/3.x/bin` (Mac) to your PATH, or use `python -m graphify` |
+| PowerShell: `/graphify` gives path error | Use `graphify .` without the leading slash |
+| `PreToolUse hook failed` in Codex | Run `graphify codex install` to regenerate the hook |
+| `graphify update` leaves temp files in project root | These should be inside `graphify-out/` — run `graphify hook install` to refresh |
+
 ### Pick your platform
 
 | Platform | Install command |

--- a/README.md
+++ b/README.md
@@ -121,16 +121,6 @@ for example `graphify claude install --project` or `graphify codex install --pro
 
 > **Git hooks and uv tool / pipx:** `graphify hook install` embeds the current interpreter path directly into the hook scripts at install time, so the post-commit hook fires correctly even in GUI git clients and CI runners where `~/.local/bin` is not on PATH. If you reinstall or upgrade graphify, re-run `graphify hook install` to refresh the embedded path.
 
-### Troubleshooting
-
-| Symptom | Fix |
-|---------|-----|
-| `ModuleNotFoundError: No module named 'graphify'` | You installed with plain `pip`. Reinstall with `uv tool install graphifyy` or `pipx install graphifyy` |
-| `graphify: command not found` | Add `~/.local/bin` (Linux) or `~/Library/Python/3.x/bin` (Mac) to your PATH, or use `python -m graphify` |
-| PowerShell: `/graphify` gives path error | Use `graphify .` without the leading slash |
-| `PreToolUse hook failed` in Codex | Run `graphify codex install` to regenerate the hook |
-| `graphify update` leaves temp files in project root | These should be inside `graphify-out/` — run `graphify hook install` to refresh |
-
 ### Pick your platform
 
 | Platform | Install command |
@@ -411,6 +401,9 @@ Your shell's PATH doesn't include the Python scripts directory. Use `uv` or `pip
 
 **`/graphify .` causes "path not recognized" in PowerShell**
 PowerShell treats a leading `/` as a path separator. Use `graphify .` (no slash) on Windows.
+
+**`PreToolUse hook failed` in Codex**
+Run `graphify codex install` to regenerate the hook. On v0.6.5+ the hook uses a cross-platform `graphify hook-check` command instead of inline Python, so this should not recur.
 
 **Graph has fewer nodes after `--update` or rebuild**
 If a refactor deleted files, the old nodes linger. Pass `--force` (or set `GRAPHIFY_FORCE=1`) to overwrite even when the rebuild has fewer nodes.


### PR DESCRIPTION
## Summary
- Add a compact troubleshooting table to the README Install section
- Covers the most common issues reported in issues: wrong pip path, missing PATH, PowerShell slash syntax, Codex PreToolUse hook failure

## Changes
- Added `### Troubleshooting` section after the existing install notes in README.md
- 5 rows covering the top recurring symptoms and their fixes

## Motivation
New users frequently hit the same issues and file duplicate issues. This adds a self-service troubleshooting section so they can resolve common problems without waiting for maintainer response.

Addresses recurring issues: #39, #178, #356, #374, #533, #651, #831