### PR TITLE
fix: resolve path/query endpoints by full-label match in _score_nodes

### DIFF
--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -136,11 +136,38 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
     scored = []
     norm_terms = [tok for t in terms for tok in _search_tokens(t)]
     idf = _compute_idf(G, norm_terms)
+    # Whole-query string for full-label matching (mirrors _find_node's `term`).
+    joined = " ".join(norm_terms)
+    # Weight the full-query bonus by the rarest constituent term so a specific
+    # multi-word label still outweighs common-token noise; floor at 1.0.
+    joined_w = max((idf.get(t, 1.0) for t in norm_terms), default=1.0)
     for nid, data in G.nodes(data=True):
         norm_label = data.get("norm_label") or _strip_diacritics(data.get("label") or "").lower()
         bare_label = norm_label.rstrip("()")
+        # Tokenized form of the label (punctuation stripped, same transform as the
+        # query). norm_label may still carry punctuation like ':' or '-', which a
+        # tokenized query can never equal; comparing token-joined forms on both
+        # sides makes "uoce: dehumidifier driver" match query "uoce dehumidifier
+        # driver".
+        label_tokens = " ".join(_search_tokens(data.get("label") or ""))
         source = (data.get("source_file") or "").lower()
         score = 0.0
+        # Full-query tier: a multi-word query that equals (or prefixes) the whole
+        # label must dominate the per-token bag-of-words sums below, so `path`/
+        # `query` resolve the same node `explain` does (via _find_node). Without
+        # this, no single token equals a multi-word label, the per-token exact
+        # tier never fires, and every node sharing the token set ties -> arbitrary
+        # node-id sort -> wrong/disconnected endpoint -> false "No path found".
+        if joined:
+            nid_lower = nid.lower()
+            if joined in (norm_label, bare_label, label_tokens, nid_lower):
+                score += _EXACT_MATCH_BONUS * 10 * joined_w
+            elif (
+                norm_label.startswith(joined)
+                or bare_label.startswith(joined)
+                or label_tokens.startswith(joined)
+            ):
+                score += _PREFIX_MATCH_BONUS * 10 * joined_w
         for t in norm_terms:
             w = idf.get(t, 1.0)
             # Three-tier precedence: exact > prefix > substring (take the
@@ -155,7 +182,10 @@ def _score_nodes(G: nx.Graph, terms: list[str]) -> list[tuple[float, str]]:
                 score += _SOURCE_MATCH_BONUS * w
         if score > 0:
             scored.append((score, nid))
-    return sorted(scored, reverse=True)
+    # Sort by score desc; break ties toward the shorter label so a concise exact
+    # match beats a longer superset that happens to share the same score.
+    scored.sort(key=lambda s: (-s[0], len(G.nodes[s[1]].get("label") or s[1]), s[1]))
+    return scored
 
 
 def _pick_seeds(scored: list[tuple[float, str]], max_k: int = 3, gap_ratio: float = 0.2) -> list[str]:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -87,6 +87,37 @@ def test_score_nodes_ignores_trailing_punctuation():
     assert scored[0][1] == "n1"
 
 
+def test_score_nodes_multiword_exact_label_outranks_superset():
+    """A multi-word query equal to a whole label must resolve uniquely.
+
+    Regression for the `graphify path` "No path found" bug: every node sharing
+    the query's token set scored identically (no single token equals a
+    multi-word label, so the per-token exact tier never fired), the tie broke by
+    arbitrary node-id sort, and a wrong/disconnected endpoint was chosen. The
+    full-query tier in _score_nodes must make the exact label win strictly.
+    """
+    G = nx.Graph()
+    # Reproduce the real graph: norm_label keeps punctuation (strip_diacritics +
+    # lower, NOT tokenized), so the ':' survives. A tokenized query can never
+    # equal that, which is exactly why the first-cut fix was a no-op for
+    # punctuated labels. The exact node must still win via the label's tokenized
+    # form.
+    def _add(nid, label, src):
+        G.add_node(nid, label=label, norm_label=label.lower(),
+                   source_file=src, community=0)
+
+    _add("exact", "UOCE: Dehumidifier Driver", "uoce_dehumidifier.yaml")
+    _add("super", "UOCE: Dehumidifier Driver State Machine", "uoce_dehumidifier.yaml")
+    _add("decoy", "Dehumidifier Driver Helper", "uoce_dehumidifier.yaml")
+
+    # CLI resolves endpoints as [t.lower() for t in label.split()].
+    scored = _score_nodes(G, [t.lower() for t in "UOCE: Dehumidifier Driver".split()])
+
+    # Resolves uniquely to the exact label, strictly ahead of the superset.
+    assert scored[0][1] == "exact"
+    assert scored[0][0] > scored[1][0], "exact label must strictly outrank superset/token-bag matches"
+
+
 def test_find_node_ignores_trailing_punctuation():
     G = _make_graph()
     assert _find_node(G, "extract?") == ["n1"]


### PR DESCRIPTION
## Problem

`graphify path "A" "B"` (and the MCP `shortest_path` tool) resolve each endpoint with `_score_nodes` in `graphify/serve.py`. Its exact-match tier compares a **single query token** to the **whole node label**:

```python
for t in norm_terms:
    if t == norm_label or t == bare_label:   # one token vs the entire label
        score += _EXACT_MATCH_BONUS * w
```

For a multi-word query no single token ever equals the full label, so the exact bonus never fires. Every node sharing the query's token set scores identically; the tie breaks by arbitrary node-id sort, so `path` picks a wrong or disconnected endpoint and reports `No path found` (or returns a path to the wrong node) even when the two labels are one hop apart.

`explain` is unaffected because it uses `_find_node`, which joins the query into one string and matches the whole label (exact → prefix → substring). `_score_nodes` had no equivalent full-query tier.

### Repro

Against a real graph with the unique labels `MC Delta Stress — air EMC below wood filtered MC` and `UOCE: Dehumidifier Driver` (one `references` edge apart):

```
$ graphify path "MC Delta Stress — air EMC below wood filtered MC" "UOCE: Dehumidifier Driver"
No path found
```

`explain "MC Delta"` resolves the same node and shows the edge — so the graph is fine; the resolver is at fault.

## Fix

Add a full-query tier to `_score_nodes` that compares the joined query string to the whole label, complementing (not replacing) the existing per-token tiers:

- A query equal to the label gets a dominant bonus (`_EXACT_MATCH_BONUS * 10 * idf`) so a full-label exact match outranks any token-bag sum; an equal-prefix gets the scaled prefix bonus.
- The comparison is done against the label's **tokenized** form (`_search_tokens(label)`), not only the stored `norm_label`. A node's `norm_label` can still carry punctuation (`:`, `—`) that a `\w+`-tokenized query never equals, so comparing against the raw `norm_label` alone is a silent no-op for punctuated labels like `UOCE: Dehumidifier Driver`. The joined query is also matched against `norm_label`, `bare_label`, and the node id, so all existing forms still hit.
- The final sort gains a length tiebreak so a concise exact label beats a longer superset on equal score.

Net effect: `path`/`query` now resolve the same node `explain` already does.

```
$ graphify path "MC Delta Stress — air EMC below wood filtered MC" "UOCE: Dehumidifier Driver"
Shortest path (1 hops):
  MC Delta Stress — air EMC below wood filtered MC <--references [EXTRACTED]-- UOCE: Dehumidifier Driver
```

No new dependencies; `uv.lock` unchanged.

## Test

Adds `test_score_nodes_multiword_exact_label_outranks_superset` to `tests/test_serve.py`. It reproduces the real condition (a node whose `norm_label` retains punctuation) and asserts a multi-word exact label scores strictly above a longer superset and a decoy, resolving uniquely. `tests/test_serve.py` is green (53 passed).

## Notes

- **Not a duplicate of #879.** That PR adds a per-token exact bonus (`any(t == label for t in terms)`), which fixes only single-word labels and targets `main`; this targets `v8` and addresses the multi-word / full-query gap, which `v8`'s existing per-token exact tier still has. Adjacent context: #569 (scoped resolution).
- The `label_tokens` comparison adds one `_search_tokens` regex call per node per `_score_nodes` query — O(nodes), negligible at these graph sizes. A maintainer who wants it lazier could hoist it behind the cheaper `norm_label`/`bare_label` checks; happy to adjust.
