### PR TITLE
fix(hooks): detach background rebuild via Python instead of nohup (#1161)

### DIFF
--- a/graphify/hooks.py
+++ b/graphify/hooks.py
@@ -74,6 +74,110 @@ if [ -z "$GRAPHIFY_PYTHON" ]; then
 fi
 """
 
+# The Python that the rebuild runs, shared by both hooks. Embedded verbatim into
+# the launcher below and re-executed in the detached child. Must not contain the
+# double-quote, $, backtick or backslash characters: it is carried inside a
+# shell double-quoted `-c "..."` argument (see _detached_launch).
+_REBUILD_BODY_COMMIT = """\
+import os, signal, sys
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0 and hasattr(signal, 'SIGALRM'):
+        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+        signal.alarm(_timeout)
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _rebuild_code(Path('.'), changed_paths=changed, force=_force)
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+"""
+
+_REBUILD_BODY_CHECKOUT = """\
+from graphify.watch import _rebuild_code, _apply_resource_limits
+from pathlib import Path
+import os, signal, sys
+try:
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0 and hasattr(signal, 'SIGALRM'):
+        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+        signal.alarm(_timeout)
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    # post-checkout: branch switch can touch arbitrary files; full rebuild path
+    # (no changed_paths) is correct here. The flock inside _rebuild_code still
+    # prevents pile-ups when commit + checkout fire back-to-back.
+    _rebuild_code(Path('.'), force=_force)
+except TimeoutError as exc:
+    print(f'[graphify] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify] Rebuild failed: {exc}')
+    sys.exit(1)
+"""
+
+# Cross-platform detached-launch shim (#1161). The hooks used to background the
+# rebuild with `nohup "$GRAPHIFY_PYTHON" -c "..." &`, but Git for Windows' bundled
+# MSYS shell ships no nohup (nor setsid), so that line died with
+# 'nohup: command not found' and the rebuild silently never ran — git commit/pull
+# still returned 0, so the graph just went stale with no signal. graphify already
+# requires Python, so we let Python do the detaching: a tiny outer process spawns
+# the real rebuild fully detached and returns immediately, so the hook never
+# blocks. POSIX uses start_new_session (the setsid equivalent); Windows uses
+# DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP, breaking away from any job object
+# when allowed. This payload is carried inside a shell double-quoted -c argument,
+# so it deliberately uses only single-quoted Python strings (no ", $, ` or \\).
+_LAUNCHER_TEMPLATE = """\
+import os, subprocess, sys
+_src = '''
+__REBUILD_BODY__
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x00000008 | 0x00000200  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"""
+
+
+def _detached_launch(rebuild_body: str) -> str:
+    """Return a POSIX-sh line that runs ``rebuild_body`` as a detached background
+    Python process via ``$GRAPHIFY_PYTHON``.
+
+    Replaces the old ``nohup ... &`` form, which failed on Git for Windows'
+    shell (no nohup/setsid) and let the rebuild silently never run (#1161).
+    The launcher writes the child's output to ``$GRAPHIFY_REBUILD_LOG`` and
+    returns the instant the child is spawned, so the git hook never blocks.
+    """
+    launcher = _LAUNCHER_TEMPLATE.replace("__REBUILD_BODY__", rebuild_body)
+    return '"$GRAPHIFY_PYTHON" -c "' + launcher + '"\n'
+
+
 _HOOK_SCRIPT = """\
 # graphify-hook-start
 # Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
@@ -107,41 +211,15 @@ fi
 """ + _PYTHON_DETECT + """
 export GRAPHIFY_CHANGED="$CHANGED"
 
-# Run rebuild detached so git commit returns immediately.
-# Full repo rebuilds can take hours; blocking the post-commit hook stalls the shell.
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
 _GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
 mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
 echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
-nohup "$GRAPHIFY_PYTHON" -c "
-import os, signal, sys
-from pathlib import Path
-
-changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
-changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
-
-if not changed:
-    sys.exit(0)
-
-print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
-
-try:
-    from graphify.watch import _rebuild_code, _apply_resource_limits
-    _apply_resource_limits()
-    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
-    if _timeout > 0 and hasattr(signal, 'SIGALRM'):
-        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
-        signal.alarm(_timeout)
-    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
-    _rebuild_code(Path('.'), changed_paths=changed, force=_force)
-except TimeoutError as exc:
-    print(f'[graphify hook] {exc}')
-    sys.exit(1)
-except Exception as exc:
-    print(f'[graphify hook] Rebuild failed: {exc}')
-    sys.exit(1)
-" >> "$_GRAPHIFY_LOG" 2>&1 < /dev/null &
-disown 2>/dev/null || true
-# graphify-hook-end
+""" + _detached_launch(_REBUILD_BODY_COMMIT) + """# graphify-hook-end
 """
 
 
@@ -179,31 +257,9 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 """ + _PYTHON_DETECT + """
 _GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
 mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
 echo "[graphify] Branch switched - launching background rebuild (log: $_GRAPHIFY_LOG)"
-nohup "$GRAPHIFY_PYTHON" -c "
-from graphify.watch import _rebuild_code, _apply_resource_limits
-from pathlib import Path
-import os, signal, sys
-try:
-    _apply_resource_limits()
-    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
-    if _timeout > 0 and hasattr(signal, 'SIGALRM'):
-        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
-        signal.alarm(_timeout)
-    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
-    # post-checkout: branch switch can touch arbitrary files; full rebuild path
-    # (no changed_paths) is correct here. The flock inside _rebuild_code still
-    # prevents pile-ups when commit + checkout fire back-to-back.
-    _rebuild_code(Path('.'), force=_force)
-except TimeoutError as exc:
-    print(f'[graphify] {exc}')
-    sys.exit(1)
-except Exception as exc:
-    print(f'[graphify] Rebuild failed: {exc}')
-    sys.exit(1)
-" >> "$_GRAPHIFY_LOG" 2>&1 < /dev/null &
-disown 2>/dev/null || true
-# graphify-checkout-hook-end
+""" + _detached_launch(_REBUILD_BODY_CHECKOUT) + """# graphify-checkout-hook-end
 """
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -216,3 +216,98 @@ def test_hook_check_no_additionalContext(tmp_path):
     assert result.returncode == 0
     assert result.stdout == ""
     assert result.stderr == ""
+
+
+# ── #1161: background rebuild must not rely on nohup (missing on Git for Windows) ──
+
+import ast  # noqa: E402
+import re  # noqa: E402
+
+from graphify.hooks import (  # noqa: E402
+    _HOOK_SCRIPT,
+    _CHECKOUT_SCRIPT,
+    _REBUILD_BODY_COMMIT,
+    _REBUILD_BODY_CHECKOUT,
+    _detached_launch,
+)
+
+_HOOK_SCRIPTS = [("post-commit", _HOOK_SCRIPT), ("post-checkout", _CHECKOUT_SCRIPT)]
+
+
+@pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
+def test_hooks_do_not_use_nohup(name, script):
+    """Git for Windows' bundled shell ships no `nohup`/`setsid`, so the old
+    `nohup ... &` launch died with 'nohup: command not found' and the rebuild
+    silently never ran (#1161). The generated hooks must not reference either."""
+    assert "nohup" not in script, f"{name} still references nohup (#1161)"
+    assert "setsid" not in script, f"{name} still references setsid (#1161)"
+    assert "disown" not in script, f"{name} still uses disown (#1161)"
+
+
+@pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
+def test_hooks_use_cross_platform_detach(name, script):
+    """The replacement detaches via Python: start_new_session on POSIX and
+    DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP on Windows (#1161)."""
+    assert "subprocess.Popen" in script
+    assert "start_new_session=True" in script, f"{name} missing POSIX detach"
+    assert "0x00000008" in script, f"{name} missing Windows DETACHED_PROCESS flag"
+    assert "0x00000200" in script, f"{name} missing CREATE_NEW_PROCESS_GROUP flag"
+
+
+def _launcher_payload(script: str) -> str:
+    """Extract the `python -c "<payload>"` the hook hands to GRAPHIFY_PYTHON.
+
+    The launcher is the only `-c` invocation whose body begins with
+    `import os, subprocess, sys` (the interpreter-detection probes in
+    _PYTHON_DETECT use `-c "import graphify"`)."""
+    m = re.search(r'-c "(import os, subprocess, sys.*?)"\n', script, re.DOTALL)
+    assert m, "launcher payload not found"
+    return m.group(1)
+
+
+@pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
+def test_launcher_payload_is_shell_quote_safe(name, script):
+    """The launcher is carried inside a shell double-quoted `-c "..."` argument,
+    so it must contain no characters the shell would interpret there: an
+    unescaped double-quote, $, backtick or backslash would corrupt the hook."""
+    payload = _launcher_payload(script)
+    for bad in ('"', "$", "`", "\\"):
+        assert bad not in payload, f"{name} launcher payload contains unsafe {bad!r}"
+
+
+@pytest.mark.parametrize("name,script", _HOOK_SCRIPTS)
+def test_launcher_and_rebuild_body_are_valid_python(name, script):
+    """Both the launcher and the rebuild body it re-executes must parse, so a
+    quoting slip can't ship a hook that crashes the moment git fires it."""
+    payload = _launcher_payload(script)
+    ast.parse(payload)  # launcher itself
+    inner = re.search(r"_src = '''(.*?)'''", payload, re.DOTALL)
+    assert inner, f"{name}: embedded rebuild body not found"
+    ast.parse(inner.group(1))  # the detached child's source
+
+
+def test_rebuild_bodies_are_shell_quote_safe():
+    """The shared rebuild bodies are embedded verbatim into the launcher, so they
+    too must avoid characters unsafe inside a shell double-quoted argument."""
+    for body in (_REBUILD_BODY_COMMIT, _REBUILD_BODY_CHECKOUT):
+        for bad in ('"', "$", "`", "\\"):
+            assert bad not in body
+        assert "'''" not in body  # would terminate the launcher's _src literal
+
+
+def test_detached_launch_targets_graphify_python():
+    """The launcher must run via the resolved $GRAPHIFY_PYTHON, not a bare
+    `python`, so it uses the same interpreter the detection block selected."""
+    snippet = _detached_launch(_REBUILD_BODY_COMMIT)
+    assert snippet.startswith('"$GRAPHIFY_PYTHON" -c "')
+    assert "nohup" not in snippet
+
+
+def test_installed_hooks_contain_no_nohup(tmp_path):
+    """End-to-end: the files written to .git/hooks must be nohup-free (#1161)."""
+    repo = _make_git_repo(tmp_path)
+    install(repo)
+    for name in ("post-commit", "post-checkout"):
+        text = (repo / ".git" / "hooks" / name).read_text(encoding="utf-8")
+        assert "nohup" not in text, f"installed {name} still references nohup"
+        assert "start_new_session=True" in text


### PR DESCRIPTION
## Summary

Fixes #1161.

The git hooks installed by `graphify hook install` background the graph rebuild with `nohup "$GRAPHIFY_PYTHON" -c "..." &`. **Git for Windows' bundled MSYS/MINGW shell ships no `nohup`** (nor `setsid`), so that line dies with `nohup: command not found` and the rebuild never runs. Worse, it fails **silently** — `git commit` / `git pull` still return `0`, so the knowledge graph quietly goes stale with no signal to the user. Both `post-commit` and `post-checkout` were affected.

## Fix

graphify already requires Python, so let Python do the detaching — portable and dependency-free. A small launcher spawns the real rebuild as a fully detached child and returns immediately, so the hook never blocks the commit/checkout:

- **POSIX:** `subprocess.Popen(..., start_new_session=True)` (the `setsid` equivalent)
- **Windows:** `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`, adding `CREATE_BREAKAWAY_FROM_JOB` when the job object allows it (falls back gracefully if not)

This follows the approach suggested in the issue.

### Implementation notes

- The two rebuild bodies are factored into shared constants (`_REBUILD_BODY_COMMIT`, `_REBUILD_BODY_CHECKOUT`) and embedded verbatim into a single `_LAUNCHER_TEMPLATE` via `_detached_launch()`, so the detach logic lives in one place.
- The launcher + body are carried inside a shell double-quoted `-c "..."` argument, so they deliberately use **only single-quoted Python strings** — no `"`, `$`, backtick or backslash that the shell would interpret. There are regression tests guarding exactly this.
- Child output still streams to `~/.cache/graphify-rebuild.log`. The log path is now exported as `GRAPHIFY_REBUILD_LOG` so the path the hook echoes matches where the detached child actually writes.

## Testing

- **End-to-end on Git for Windows' shell** (the exact environment from the issue): the parent returns instantly with **no `nohup: command not found`**, and the detached child runs independently and writes its progress to the log.
- `sh -n` validates both fully-rendered hook scripts as syntactically correct POSIX sh.
- Added 8 regression tests in `tests/test_hooks.py`:
  - generated hooks contain no `nohup` / `setsid` / `disown`
  - both hooks use the cross-platform detach (`start_new_session` + Windows creation flags)
  - the embedded `-c` payload is shell-quote-safe
  - both the launcher and the rebuild body it re-executes parse as valid Python
  - end-to-end: the files written to `.git/hooks` are nohup-free
- `tests/test_hooks.py` is fully green (31 passed) under the CI matrix interpreter (Python 3.12, `uv run --frozen --all-extras`).

### Test plan
- [x] `uv run --frozen --all-extras pytest tests/test_hooks.py -q` → 31 passed
- [x] `ruff check graphify/hooks.py --select E9,F63,F7,F82` → clean
- [x] `sh -n` on both rendered hooks → OK
- [x] Manual end-to-end launch through Git for Windows `sh`
