### PR TITLE
chore: add Claude guidance and dev baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[mcp,pdf,watch,sql]"
-          pip install pytest
+          pip install -e ".[dev,mcp,pdf,watch,sql]"
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ docs/superpowers/
 .vscode/
 openspec/
 uv.lock
+.DS_Store
+.opencode/
 # Local benchmark scripts — never commit
 scripts/run_k2_*.py
 scripts/llm.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -4224,8 +4224,8 @@ def extract_objc(path: Path) -> dict:
     def _read(node) -> str:
         return source[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
 
-    def _get_name(node, field: str) -> str | None:
-        n = node.child_by_field_name(field)
+    def _get_name(node, field_name: str) -> str | None:
+        n = node.child_by_field_name(field_name)
         return _read(n) if n else None
 
     def walk(node, parent_nid: str | None = None) -> None:

--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -953,7 +953,8 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
         return resp.content[0].text if resp.content else ""
 
     if backend == "claude-cli":
-        import shutil, subprocess
+        import shutil
+        import subprocess
         if shutil.which("claude") is None:
             raise RuntimeError("Claude Code CLI not found on $PATH")
         proc = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Repository = "https://github.com/safishamsi/graphify"
 Issues = "https://github.com/safishamsi/graphify/issues"
 
 [project.optional-dependencies]
+dev = ["pytest", "ruff", "build"]
 mcp = ["mcp"]
 neo4j = ["neo4j"]
 pdf = ["pypdf", "markdownify"]
@@ -80,3 +81,14 @@ graphify = ["skill.md", "skill-codex.md", "skill-opencode.md", "skill-aider.md",
 
 [tool.bandit]
 skips = ["B404"]
+
+[tool.ruff]
+exclude = [
+    "build",
+    "worked",
+    "graphify-out",
+]
+
+[tool.ruff.lint]
+# Existing codebase debt to tackle incrementally; keep ruff available for new work.
+ignore = ["E402", "E702", "E713", "E741", "F401", "F541", "F841"]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -125,7 +125,8 @@ def test_print_benchmark_error_message(capsys):
 # stdout cannot encode the glyph.
 
 def test_safe_returns_unicode_when_encodable():
-    import io, sys
+    import io
+    import sys
     real_stdout = sys.stdout
     try:
         sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
@@ -135,7 +136,8 @@ def test_safe_returns_unicode_when_encodable():
         sys.stdout = real_stdout
 
 def test_safe_falls_back_when_unencodable():
-    import io, sys
+    import io
+    import sys
     real_stdout = sys.stdout
     try:
         sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
@@ -146,7 +148,8 @@ def test_safe_falls_back_when_unencodable():
 
 def test_print_benchmark_survives_cp1252_stdout(tmp_path, monkeypatch, capsys):
     """Regression: U+2500 / U+2192 used to crash with UnicodeEncodeError on cp1252."""
-    import io, sys
+    import io
+    import sys
     G = _make_graph()
     graph_file = tmp_path / "graph.json"
     _write_graph(G, graph_file)

--- a/tests/test_pascal.py
+++ b/tests/test_pascal.py
@@ -298,7 +298,8 @@ def test_dfm_no_dangling_edges():
 
 def test_dfm_binary_returns_empty_not_crash():
     from graphify.extract import extract_delphi_form
-    import tempfile, pathlib
+    import tempfile
+    import pathlib
     # Write a fake binary DFM (FF 0A magic header)
     with tempfile.NamedTemporaryFile(suffix=".dfm", delete=False) as f:
         f.write(b"\xff\x0a\x00\x00some binary data")


### PR DESCRIPTION
## Summary
- Add Claude Code guidance for the repo (CLAUDE.md)
- Add `dev` extra and ruff baseline configuration
- Improve CI to install with `.[dev,mcp,pdf,watch,sql]`
- Ignore `.DS_Store` and `.opencode/` in git
- Fix ruff-discovered extraction issues (real bug)
- Re-apply import style fixes after rebasing onto origin/v7

## Validation
- ruff: all checks passed
- pytest: 779 passed
- build: graphifyy-0.7.19 sdist + wheel built successfully
- graphify update: 189/189 files, 4623 nodes, 6778 edges, 315 communities

## Test plan
- [x] `ruff check` passes
- [x] `pytest` passes
- [x] `python -m build` passes
- [x] `graphify update .` runs cleanly