### PR TITLE
feat: add graphify-mcp console script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ all = ["mcp", "neo4j", "pypdf", "markdownify", "watchdog", "graspologic; python_
 
 [project.scripts]
 graphify = "graphify.__main__:main"
+graphify-mcp = "graphify.serve:_main"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

This PR adds a `graphify-mcp` console script entry point, making the MCP stdio server directly invocable as a first-class CLI command.

## Motivation

When `graphifyy` is installed via isolated package managers such as `uv tool install` or `pipx`, the module `graphify.serve` is not available to the user's default `python` interpreter. The current recommended invocation `python -m graphify.serve graphify-out/graph.json` therefore fails in these environments because `python` cannot find the `graphify` module.

By exposing `graphify.serve:_main` as a dedicated `graphify-mcp` script:

- `uv tool install graphifyy[mcp]` or `pipx install graphifyy[mcp]` can directly expose `graphify-mcp` on `$PATH`
- MCP server configurations (e.g. Claude Code, VS Code Copilot) can reference `graphify-mcp` as a stable command rather than relying on `python -m graphify.serve`
- Users do not need to know the internal module path to start the server

## Change

```toml
[project.scripts]
graphify = "graphify.__main__:main"
graphify-mcp = "graphify.serve:_main"
```

The new `graphify-mcp` command accepts the same arguments as `python -m graphify.serve` (e.g. `graphify-mcp graphify-out/graph.json`).

## Checklist

- [x] Single-line change to `[project.scripts]` in `pyproject.toml`
- [x] Uses existing `_main()` entry point already defined in `graphify.serve`
- [x] No new runtime dependencies or breaking changes