### PR TITLE
fix: guard label/text normalizers against None node labels (#1194)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -311,8 +311,10 @@ def build(
     return build_from_json(combined, directed=directed, root=root)
 
 
-def _norm_label(label: str) -> str:
+def _norm_label(label: str | None) -> str:
     """Canonical dedup key — Unicode-aware, preserves CJK/word characters."""
+    if not isinstance(label, str):
+        label = "" if label is None else str(label)
     label = unicodedata.normalize("NFKC", label)
     return re.sub(r"[\W_ ]+", " ", label.casefold(), flags=re.UNICODE).strip()
 

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -15,8 +15,10 @@ from rapidfuzz.distance import JaroWinkler
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-def _norm(label: str) -> str:
+def _norm(label: str | None) -> str:
     """Lowercase + collapse non-alphanumeric runs to space (Unicode-aware)."""
+    if not isinstance(label, str):
+        label = "" if label is None else str(label)
     label = unicodedata.normalize("NFKC", label)
     return re.sub(r"[\W_]+", " ", label.casefold(), flags=re.UNICODE).strip()
 

--- a/graphify/export.py
+++ b/graphify/export.py
@@ -102,8 +102,10 @@ def _obsidian_tag(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_\-/]", "", name.replace(" ", "_"))
 
 
-def _strip_diacritics(text: str) -> str:
+def _strip_diacritics(text: str | None) -> str:
     import unicodedata
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
     nfkd = unicodedata.normalize("NFKD", text)
     return "".join(c for c in nfkd if not unicodedata.combining(c))
 

--- a/graphify/serve.py
+++ b/graphify/serve.py
@@ -51,8 +51,10 @@ def _communities_from_graph(G: nx.Graph) -> dict[int, list[str]]:
     return communities
 
 
-def _strip_diacritics(text: str) -> str:
+def _strip_diacritics(text: str | None) -> str:
     import unicodedata
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
     nfkd = unicodedata.normalize("NFKD", text)
     return "".join(c for c in nfkd if not unicodedata.combining(c))
 


### PR DESCRIPTION
## What & why

Graph nodes can carry `label: None` — OpenAI-compatible LLM backends occasionally emit a null label during semantic extraction. The callers fetch the label with `node.get("label", node.get("id", ""))` / `node.get("label", "")`, but `dict.get(key, default)` returns the default **only when the key is absent**; for an explicit `"label": None` it returns `None`. That `None` flows into helpers that call `unicodedata.normalize(...)`, crashing the **entire** extract pipeline with:

```
TypeError: normalize() argument 2 must be str, not None
```

at whichever normalizer runs first (dedup → build → export). The four affected helpers:

- `dedup._norm`
- `build._norm_label`
- `export._strip_diacritics`
- `serve._strip_diacritics`

Because semantic extraction results are cached **before** the build step, the crash recurs on every subsequent `extract` until the cache is wiped, and there's no `--no-dedup` escape hatch. Same bug class as #454 (`sanitize_label` crashing on a `None` `source_file`).

The other `unicodedata.normalize` call sites (`extract._make_id`, `build._normalize_id`, `symbol_resolution._bash_make_id`, `mcp_ingest`) build their input via `"_".join(p for p in parts if p)`, so they're always `str` — not affected.

## Fix

Coerce non-`str` input to `""` at each chokepoint (and widen the type hint to `str | None`). A null/empty label then normalizes to `""`, which the surrounding `if key:` guards already skip — so the offending node simply isn't considered for merging (it stays in the graph) instead of aborting the run.

## Verification

Reproduced on a 6,253-file Markdown corpus via a vLLM / `gpt-oss-120b` OpenAI-compatible backend: every `extract` crashed — first at `dedup._norm`, then (after guarding that) at `export._strip_diacritics`. With all four guarded, the same corpus builds cleanly:

```
[graphify extract] wrote /data/graphify-out/graph.json: 16715 nodes, 16136 edges, 4272 communities
[graphify] Done
```

`py_compile` clean. Unit check: `_norm(None) == ""`, `_norm_label(None) == ""`, both `_strip_diacritics(None) == ""`; normal strings unchanged.

Fixes #1194
