### PR TITLE
fix: affected/benchmark crash on native "edges" graphs (KeyError: links)

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -148,7 +148,11 @@ def load_graph(path: Path) -> nx.Graph:
     # Force directed so stored caller→callee direction survives the round-trip;
     # mirrors serve.py and __main__.py (#1174).
     raw = {**raw, "directed": True}
+    # Merged/cross-repo graphs serialise edges under "links" (node_link_data
+    # default); native extractor graphs use "edges". Try "links" first and fall
+    # back to the networkx default ("edges") — the KeyError raised on a native
+    # graph must be caught here, otherwise load fails on every real graph.json.
     try:
         return json_graph.node_link_graph(raw, edges="links")
-    except TypeError:
+    except (TypeError, KeyError):
         return json_graph.node_link_graph(raw)

--- a/graphify/benchmark.py
+++ b/graphify/benchmark.py
@@ -101,9 +101,12 @@ def run_benchmark(
     from graphify.security import check_graph_file_size_cap
     check_graph_file_size_cap(Path(graph_path))
     data = json.loads(Path(graph_path).read_text(encoding="utf-8"))
+    # Native extractor graphs store edges under "edges"; merged graphs use
+    # "links". Catch the KeyError from the "links" attempt so native graphs
+    # fall back to the networkx default instead of crashing.
     try:
         G = json_graph.node_link_graph(data, edges="links")
-    except TypeError:
+    except (TypeError, KeyError):
         G = json_graph.node_link_graph(data)
 
     if corpus_words is None:

--- a/tests/test_affected_cli.py
+++ b/tests/test_affected_cli.py
@@ -60,6 +60,43 @@ def test_affected_cli_relation_filter_limits_reverse_traversal(monkeypatch, tmp_
     assert "__init__.py" not in out
 
 
+def test_affected_cli_loads_native_edges_key_graph(monkeypatch, tmp_path, capsys):
+    """The extractor writes graph.json with edges under the "edges" key (not the
+    node_link_data "links" key). load_graph attempts edges="links" first, which
+    raises KeyError on a native graph; that must be caught so the load falls back
+    to the networkx default. Regression for affected/benchmark crashing with
+    "could not load graph: 'links'" on every real graphify-out/graph.json.
+    """
+    # Hand-rolled native format — NOT node_link_data — to mirror real output.
+    data = {
+        "directed": True,
+        "nodes": [
+            {"id": "target", "label": "Foo", "source_file": "pkg/foo.py", "source_location": "L1"},
+            {"id": "caller", "label": "X()", "source_file": "app.py", "source_location": "L4"},
+        ],
+        "edges": [
+            {"source": "caller", "target": "target", "relation": "calls",
+             "context": "call", "confidence": "EXTRACTED"},
+        ],
+    }
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "affected", "Foo", "--graph", str(graph_path)],
+    )
+
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    assert "Affected nodes for Foo" in out
+    assert "X()" in out
+    assert "calls" in out
+
+
 def test_affected_cli_forces_directed_on_undirected_graph(monkeypatch, tmp_path, capsys):
     """A graph persisted with directed=false must still recover caller->callee
     direction (#1174): affected on the callee returns the caller, not the callee


### PR DESCRIPTION
## Problem

`graphify affected <node>` and `graphify benchmark` crash with:

```
error: could not load graph: 'links'
```

on every real `graphify-out/graph.json`. Reproduce on any extracted graph:

```bash
graphify extract ./some-repo --backend claude-cli --out /tmp/g
graphify affected "SomeSymbol" --graph /tmp/g/graphify-out/graph.json
# -> error: could not load graph: 'links'
graphify benchmark /tmp/g/graphify-out/graph.json
# -> KeyError: 'links'
```

## Root cause

`affected.py:load_graph` and `benchmark.py:run_benchmark` call:

```python
try:
    json_graph.node_link_graph(raw, edges="links")
except TypeError:
    json_graph.node_link_graph(raw)
```

The extractor serialises edges under the **`"edges"`** key. Only merged /
cross-repo graphs use `"links"` (written via `node_link_data`, whose default
edges key is `"links"`). On a native graph, the `edges="links"` attempt raises
**`KeyError`**, which the `except TypeError` clause does not catch — so the load
aborts instead of falling through to the working default.

## Fix

Widen the fallback to `except (TypeError, KeyError)`. Native `"edges"` graphs
now fall through to the networkx default; merged `"links"` graphs still load via
the fast path. Both formats verified.

## Why CI didn't catch it

`tests/test_affected_cli.py` builds its fixture with
`json_graph.node_link_data(graph, edges="links")`, producing a `"links"`-keyed
graph that happens to match the buggy reader — so the tests pass while every
real graph crashes.

Added `test_affected_cli_loads_native_edges_key_graph`, which writes the native
`"edges"` format the extractor actually emits. It **fails without this fix** with
the exact production error (`could not load graph: 'links'`) and passes with it.

```
$ pytest tests/test_affected_cli.py -q
....                                                                     [100%]
4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)