### PR TITLE
Fix two latent bugs: merge-chunks output and manifest data loss

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -4520,7 +4520,7 @@ def main() -> None:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(merged, ensure_ascii=False), encoding="utf-8")
         print(
-            f"Merged {len(chunk_files)} chunks: {merged['nodes']} nodes, {len(merged['edges'])} edges, "
+            f"Merged {len(chunk_files)} chunks: {len(merged['nodes'])} nodes, {len(merged['edges'])} edges, "
             f"{merged['input_tokens']:,} in / {merged['output_tokens']:,} out tokens"
         )
 

--- a/graphify/global_graph.py
+++ b/graphify/global_graph.py
@@ -16,8 +16,27 @@ def _load_manifest() -> dict:
     if _GLOBAL_MANIFEST.exists():
         try:
             return json.loads(_GLOBAL_MANIFEST.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as exc:
+            # Don't silently wipe the user's manifest on a parse error: that
+            # deletes every tracked repo. Back the bad file up and surface the
+            # error so the user can recover or report it.
+            backup = _GLOBAL_MANIFEST.with_suffix(
+                _GLOBAL_MANIFEST.suffix + f".corrupt.{int(datetime.now(timezone.utc).timestamp())}"
+            )
+            try:
+                _GLOBAL_MANIFEST.rename(backup)
+                print(
+                    f"[graphify global] manifest at {_GLOBAL_MANIFEST} failed to parse ({exc}); "
+                    f"moved to {backup} and starting fresh. Restore from the backup if this was "
+                    f"unexpected.",
+                    file=sys.stderr,
+                )
+            except Exception as rename_exc:
+                print(
+                    f"[graphify global] manifest at {_GLOBAL_MANIFEST} failed to parse ({exc}) "
+                    f"and could not be backed up ({rename_exc}). Starting fresh.",
+                    file=sys.stderr,
+                )
     return {"version": 1, "repos": {}}
 
 


### PR DESCRIPTION
Two small, independent bug fixes spotted during a review pass. Both have the same shape: a defensive coding mistake whose worst case is reachable through normal use.

## 1. `graphify merge-chunks` dumps the full node list to the terminal

`__main__.py:4523` concatenates `merged['nodes']` (a list of dicts) into an f-string where it clearly intends the node count -- the other two values in the same line use `len()` correctly:

```python
f\"Merged {len(chunk_files)} chunks: {merged['nodes']} nodes, {len(merged['edges'])} edges, \"
```

Fix: `len(merged['nodes'])`.

## 2. `global_graph._load_manifest` silently wipes `~/.graphify/global-manifest.json` on any parse error

```python
def _load_manifest() -> dict:
    if _GLOBAL_MANIFEST.exists():
        try:
            return json.loads(_GLOBAL_MANIFEST.read_text(encoding=\"utf-8\"))
        except Exception:
            pass
    return {\"version\": 1, \"repos\": {}}
```

The manifest is rewritten in full on every `global_add` / `global_remove` with no atomic rename or fsync, so a partial-write from an interrupted command or a disk-full event is enough to corrupt it. On the next `global *` invocation the parse fails, the empty default is returned, and `_save_manifest` overwrites the corrupt file with `{}` -- every tracked repo gone, silently.

Fix: on parse failure, rename the corrupt file to `<path>.corrupt.<unix_ts>`, print a message to stderr explaining what happened, and then fall through to the empty default. The user keeps a recoverable backup and the failure is visible.

## Test plan
- [ ] Run `graphify merge-chunks` against any chunked output; confirm the summary line shows a count, not a JSON blob.
- [ ] Corrupt `~/.graphify/global-manifest.json` (truncate to `{` or similar); confirm next `graphify global list` prints the backup notice, creates a `.corrupt.<ts>` file, and starts from an empty manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)