### PR TITLE
Wire bandit and pip-audit into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,30 @@ jobs:
         run: |
           uv run --frozen graphify --help
           uv run --frozen graphify install
+
+  security-scan:
+    # The dev deps already include bandit, pip-audit, and safety. Run them in
+    # CI so a new HIGH-severity finding or vulnerable dependency is caught on
+    # the PR that introduces it, rather than at the next manual audit.
+    # Non-blocking for now (continue-on-error) to avoid breaking CI on
+    # pre-existing findings; remove continue-on-error after the initial
+    # cleanup pass.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: bandit (static security analysis)
+        continue-on-error: true
+        run: uv run --frozen bandit -r graphify -ll
+
+      - name: pip-audit (dependency vulnerabilities)
+        continue-on-error: true
+        run: uv run --frozen pip-audit --strict


### PR DESCRIPTION
`bandit`, `pip-audit`, and `safety` are already declared in the `[dependency-groups].dev` table but nothing in `.github/workflows/ci.yml` invokes them. So a new HIGH-severity bandit finding or a freshly-disclosed CVE in a pinned dep can land without anyone noticing until the next manual audit.

Adds a `security-scan` job that runs on every push and PR:

- `bandit -r graphify -ll` (HIGH-severity only -- LOW/MEDIUM is noisy without a tuned config)
- `pip-audit --strict` (against the committed lock via `uv sync`)

Marked `continue-on-error: true` for now so this doesn't block PRs on pre-existing findings. A follow-up should do the cleanup pass and flip the flag to blocking.

`safety` intentionally omitted -- it now requires a free-tier API key for its commercial backend, which is a setup burden for forks and CI. `pip-audit` covers the same ground via the PyPI JSON advisory feed and OSV.

## Test plan
- [ ] CI runs the new job and posts results.
- [ ] Confirm existing pyproject `[tool.bandit]` skip (`B404`) is honored.
- [ ] No churn to `uv.lock` from the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)