### PR TITLE
fix: graphify hangs in corporate windows environments w/ EDR

### DIFF
--- a/graphify/_minhash.py
+++ b/graphify/_minhash.py
@@ -1,0 +1,107 @@
+"""MinHash + band-LSH — datasketch-compatible drop-in (no scipy).
+
+datasketch.lsh has `from scipy.integrate import quad` at module level.
+scipy's array_api_compat layer then lazily loads numpy.testing, which calls
+platform.machine() at import time to set test-skip decorator constants — and
+that in turn spawns cmd.exe via subprocess, hanging for minutes under EDR
+software in corporate Windows environments.
+
+Covers the exact MinHash/MinHashLSH API surface used by dedup.py.
+Hash family (Mersenne-prime permutations) and LSH band structure are
+equivalent to datasketch so dedup quality is unchanged.
+"""
+from __future__ import annotations
+import hashlib
+import struct
+
+import numpy as np
+
+
+_MP = np.uint64((1 << 61) - 1)  # Mersenne prime for the hash family
+_MH = np.uint64(0xFFFF_FFFF)    # mask to 32-bit values
+
+# One (a, b) coefficient array per num_perm, shared across all instances.
+_MH_COEFFS: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+
+
+def _mh_coeffs(num_perm: int) -> tuple[np.ndarray, np.ndarray]:
+    if num_perm not in _MH_COEFFS:
+        rng = np.random.RandomState(1)
+        a = rng.randint(1, int(_MP), num_perm, dtype=np.uint64)
+        b = rng.randint(0, int(_MP), num_perm, dtype=np.uint64)
+        _MH_COEFFS[num_perm] = (a, b)
+    return _MH_COEFFS[num_perm]
+
+
+class MinHash:
+    """MinHash sketch — same API as datasketch.MinHash for the subset used here."""
+
+    __slots__ = ("num_perm", "hashvalues", "_a", "_b")
+
+    def __init__(self, num_perm: int = 128) -> None:
+        self.num_perm = num_perm
+        self.hashvalues = np.full(num_perm, int(_MH), dtype=np.uint64)
+        self._a, self._b = _mh_coeffs(num_perm)
+
+    def update(self, v: bytes) -> None:
+        hv = np.uint64(struct.unpack("<I", hashlib.sha1(v).digest()[:4])[0])
+        phv = np.bitwise_and((self._a * hv + self._b) % _MP, _MH)
+        self.hashvalues = np.minimum(self.hashvalues, phv)
+
+
+def _lsh_integrate(f, lo: float, hi: float, n: int = 128) -> float:
+    """Numerical integration — replaces scipy.integrate.quad for LSH param search."""
+    h = (hi - lo) / n
+    return h * sum(f(lo + i * h) for i in range(n))
+
+
+_LSH_PARAMS_CACHE: dict[tuple[float, int], tuple[int, int]] = {}
+
+
+def _optimal_lsh_params(threshold: float, num_perm: int) -> tuple[int, int]:
+    """Find (bands, rows) that minimise weighted FP+FN error, without scipy."""
+    key = (threshold, num_perm)
+    if key in _LSH_PARAMS_CACHE:
+        return _LSH_PARAMS_CACHE[key]
+    best_err, best = float("inf"), (1, 1)
+    for b in range(1, num_perm + 1):
+        for r in range(1, num_perm // b + 1):
+            fp = _lsh_integrate(
+                lambda s, _b=float(b), _r=float(r): 1 - (1 - s ** _r) ** _b,
+                0.0, threshold,
+            )
+            fn = _lsh_integrate(
+                lambda s, _b=float(b), _r=float(r): 1 - (1 - (1 - s ** _r) ** _b),
+                threshold, 1.0,
+            )
+            err = 0.5 * fp + 0.5 * fn
+            if err < best_err:
+                best_err, best = err, (b, r)
+    _LSH_PARAMS_CACHE[key] = best
+    return best
+
+
+class MinHashLSH:
+    """Band-hashing LSH — same API as datasketch.MinHashLSH for the subset used here."""
+
+    def __init__(self, threshold: float = 0.5, num_perm: int = 128) -> None:
+        self.b, self.r = _optimal_lsh_params(threshold, num_perm)
+        self._tables: list[dict[bytes, list[str]]] = [{} for _ in range(self.b)]
+        self._keys: set[str] = set()
+
+    def insert(self, key: str, minhash: MinHash) -> None:
+        if key in self._keys:
+            raise ValueError(f"Key {key!r} already exists in MinHashLSH")
+        self._keys.add(key)
+        hv = minhash.hashvalues
+        for i, table in enumerate(self._tables):
+            band = hv[i * self.r : (i + 1) * self.r].tobytes()
+            table.setdefault(band, []).append(key)
+
+    def query(self, minhash: MinHash) -> list[str]:
+        hv = minhash.hashvalues
+        candidates: set[str] = set()
+        for i, table in enumerate(self._tables):
+            band = hv[i * self.r : (i + 1) * self.r].tobytes()
+            candidates.update(table.get(band, []))
+        return list(candidates)

--- a/graphify/dedup.py
+++ b/graphify/dedup.py
@@ -9,7 +9,7 @@ import re
 import unicodedata
 from collections import defaultdict
 
-from datasketch import MinHash, MinHashLSH
+from graphify._minhash import MinHash, MinHashLSH
 from rapidfuzz.distance import JaroWinkler
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["claude", "claude-code", "codex", "opencode", "kilo", "cursor", "gem
 requires-python = ">=3.10"
 dependencies = [
     "networkx>=3.4",
-    "datasketch>=1.6",
+    "numpy>=1.21",
     "rapidfuzz>=3.0",
     "tree-sitter>=0.23.0",
     "tree-sitter-python",

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -1,0 +1,90 @@
+"""Tests for graphify/_minhash.py — MinHash sketch and band-LSH."""
+from __future__ import annotations
+import numpy as np
+import pytest
+from graphify._minhash import MinHash, MinHashLSH, _optimal_lsh_params
+
+
+def _minhash_for(text: str, num_perm: int = 128) -> MinHash:
+    m = MinHash(num_perm=num_perm)
+    for i in range(0, len(text) - 2):
+        m.update(text[i:i + 3].encode())
+    return m
+
+
+# ── MinHash ───────────────────────────────────────────────────────────────────
+
+def test_identical_texts_produce_identical_hashvalues():
+    a = _minhash_for("graphextractor")
+    b = _minhash_for("graphextractor")
+    assert np.array_equal(a.hashvalues, b.hashvalues)
+
+
+def test_similar_texts_share_most_hashvalues():
+    a = _minhash_for("authentication manager")
+    b = _minhash_for("authentication managers")
+    overlap = np.sum(a.hashvalues == b.hashvalues) / len(a.hashvalues)
+    assert overlap > 0.5
+
+
+def test_unrelated_texts_share_few_hashvalues():
+    a = _minhash_for("authentication manager")
+    b = _minhash_for("file system watcher")
+    overlap = np.sum(a.hashvalues == b.hashvalues) / len(a.hashvalues)
+    assert overlap < 0.3
+
+
+def test_update_mutates_hashvalues():
+    m = MinHash(num_perm=64)
+    before = m.hashvalues.copy()
+    m.update(b"hello")
+    assert not np.array_equal(m.hashvalues, before)
+
+
+# ── MinHashLSH ────────────────────────────────────────────────────────────────
+
+def test_near_duplicates_are_candidates():
+    lsh = MinHashLSH(threshold=0.5, num_perm=128)
+    a = _minhash_for("authentication manager")
+    b = _minhash_for("authentication managers")
+    lsh.insert("a", a)
+    lsh.insert("b", b)
+    assert "b" in lsh.query(a)
+
+
+def test_unrelated_strings_not_candidates():
+    lsh = MinHashLSH(threshold=0.5, num_perm=128)
+    a = _minhash_for("authentication manager")
+    b = _minhash_for("file system watcher")
+    lsh.insert("a", a)
+    lsh.insert("b", b)
+    assert "b" not in lsh.query(a)
+
+
+def test_query_always_returns_self():
+    lsh = MinHashLSH(threshold=0.5, num_perm=128)
+    m = _minhash_for("graphextractor")
+    lsh.insert("x", m)
+    assert "x" in lsh.query(m)
+
+
+def test_duplicate_insert_raises():
+    lsh = MinHashLSH(threshold=0.5, num_perm=128)
+    m = _minhash_for("foo")
+    lsh.insert("key", m)
+    with pytest.raises(ValueError, match="already exists"):
+        lsh.insert("key", m)
+
+
+# ── _optimal_lsh_params ───────────────────────────────────────────────────────
+
+def test_optimal_params_within_budget():
+    b, r = _optimal_lsh_params(0.5, 128)
+    assert b >= 1 and r >= 1
+    assert b * r <= 128
+
+
+def test_optimal_params_cached():
+    result1 = _optimal_lsh_params(0.7, 128)
+    result2 = _optimal_lsh_params(0.7, 128)
+    assert result1 is result2

--- a/uv.lock
+++ b/uv.lock
@@ -918,21 +918,6 @@ wheels = [
 ]
 
 [[package]]
-name = "datasketch"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/73/8e9014887f9fca2d785777a0a6186813e4fc7faa24f05fc88c6420624891/datasketch-1.10.0.tar.gz", hash = "sha256:d23aea80ce4c40790ca7a40795659848be92ecc43db80942be26f21e81d24714", size = 91699, upload-time = "2026-04-17T23:06:56.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/e7/a94668082e078099eb0161635649510aa887690767b779fffe4bdc479913/datasketch-1.10.0-py3-none-any.whl", hash = "sha256:303dd90cda0948a21abba3aaefc9f8528fa12b8204edc5e1ae8b1d7b750234e7", size = 99914, upload-time = "2026-04-17T23:06:54.39Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1146,12 +1131,13 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.8.35"
+version = "0.8.36"
 source = { editable = "." }
 dependencies = [
-    { name = "datasketch" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "rapidfuzz" },
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
@@ -1298,7 +1284,6 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'" },
     { name = "boto3", marker = "extra == 'all'" },
     { name = "boto3", marker = "extra == 'bedrock'" },
-    { name = "datasketch", specifier = ">=1.6" },
     { name = "faster-whisper", marker = "python_full_version >= '3.11' and extra == 'all'" },
     { name = "faster-whisper", marker = "python_full_version >= '3.11' and extra == 'video'" },
     { name = "graspologic", marker = "python_full_version < '3.13' and extra == 'all'" },
@@ -1314,6 +1299,7 @@ requires-dist = [
     { name = "neo4j", marker = "extra == 'all'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "networkx", specifier = ">=3.4" },
+    { name = "numpy", specifier = ">=1.21" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=2.0" },
     { name = "numpy", marker = "python_full_version >= '3.13' and extra == 'svg'", specifier = ">=2.0" },
     { name = "openai", marker = "extra == 'all'" },
@@ -4236,19 +4222,12 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
I was trying to use graphify on my corporate windows machine and graphify would consistently hang for up to 20 minutes. TLDR is that datasketch downstream calls platform._syscmd_ver() which spawns cmd.exe which Windows Defender can delay up to 20 minutes before it either completes the analysis or times out. The fix was to replace datasketch with a local implementation that did not need to spawn cmd.exe.

More details are in the commit message.

example log:
```
  [graphify extract] scanning C:\gits\app
  [graphify extract] found 2182 code, 0 docs, 0 papers, 0 images
  [graphify extract] AST extraction on 2182 code files...
    AST extraction: 100/2182 uncached files (4%) [20 workers]
    AST extraction: 200/2182 uncached files (9%) [20 workers]
    AST extraction: 300/2182 uncached files (13%) [20 workers]
    AST extraction: 400/2182 uncached files (18%) [20 workers]
    AST extraction: 500/2182 uncached files (22%) [20 workers]
    AST extraction: 600/2182 uncached files (27%) [20 workers]
    AST extraction: 700/2182 uncached files (32%) [20 workers]
    AST extraction: 800/2182 uncached files (36%) [20 workers]
    AST extraction: 900/2182 uncached files (41%) [20 workers]
    AST extraction: 1000/2182 uncached files (45%) [20 workers]
    AST extraction: 1100/2182 uncached files (50%) [20 workers]
    AST extraction: 1200/2182 uncached files (54%) [20 workers]
    AST extraction: 1300/2182 uncached files (59%) [20 workers]
    AST extraction: 1400/2182 uncached files (64%) [20 workers]
    AST extraction: 1500/2182 uncached files (68%) [20 workers]
    AST extraction: 1600/2182 uncached files (73%) [20 workers]
    AST extraction: 1700/2182 uncached files (77%) [20 workers]
    AST extraction: 1800/2182 uncached files (82%) [20 workers]
    AST extraction: 1900/2182 uncached files (87%) [20 workers]
    AST extraction: 2000/2182 uncached files (91%) [20 workers]
    AST extraction: 2100/2182 uncached files (96%) [20 workers]
    AST extraction: 2182/2182 files (100%) [20 workers]
  [graphify] Deduplicated 37131 node(s) (34785 exact, 1870 fuzzy).
  [graphify extract] wrote C:\gits\app\graphify-out\graph.json: 49653 nodes, 103256 edges, 2079 communities
  [graphify extract] wrote C:\gits\app\graphify-out\.graphify_analysis.json
  [graphify extract] next: run `graphify cluster-only C:\gits\app` to generate GRAPH_REPORT.md and name communities

    _     ._   __/__   _ _  _  _ _/_   Recorded: 17:56:39  Samples:  349874
   /_//_/// /_\ / //_// / //_'/ //     Duration: 1687.099  CPU time: 400.359
  /   _/                      v5.1.2

  Program: graphify .

  1687.153 <module>  ..\graphify\__main__.py:1
  └─ 1687.125 main  ..\graphify\__main__.py:2070
     └─ 1687.090 main  ..\graphify\__main__.py:2070
        ├─ 1353.451 build  ..\graphify\build.py:276
        │  ├─ 1279.138 <module>  ..\graphify\dedup.py:1
        │  │  └─ 1279.092 <module>  datasketch\__init__.py:1
        │  │     └─ 1279.076 <module>  datasketch\aio\__init__.py:1
        │  │        └─ 1279.075 <module>  datasketch\aio\lsh.py:1
        │  │           └─ 1279.040 <module>  datasketch\lsh.py:1
        │  │              └─ 1278.928 <module>  scipy\integrate\__init__.py:1
        │  │                 └─ 1278.399 <module>  scipy\integrate\_quadrature.py:1
        │  │                    └─ 1278.391 <module>  scipy\special\__init__.py:1
        │  │                       └─ 1278.348 <module>  scipy\special\_support_alternative_backends.py:1
        │  │                          └─ 1278.280 <module>  scipy\_lib\_array_api.py:1
        │  │                             └─ 1278.160 <module>  scipy\_lib\array_api_compat\numpy\__init__.py:1
        │  │                                └─ 1278.131 clone_module  scipy\_lib\array_api_compat\_internal.py:56
        │  │                                   └─ 1278.130 <module>  <string>:1
        │  │                                      └─ 1278.130 __getattr__  numpy\__init__.py:717
        │  │                                         └─ 1277.953 <module>  numpy\testing\__init__.py:1
        │  │                                            └─ 1277.940 <module>  numpy\testing\_private\utils.py:1
        │  │                                               └─ 1277.940 machine  platform.py:1120
        │  │                                                     [4 frames hidden]  platform
        │  │                                                        1277.925 exec_query  <built-in>
        │  └─ 71.070 deduplicate_entities  ..\graphify\dedup.py:131
        ├─ 194.421 detect  ..\graphify\detect.py:970
        │  └─ 191.997 _is_ignored  ..\graphify\detect.py:760
        │     └─ 190.318 _eval  ..\graphify\detect.py:773
        │        ├─ 93.762 WindowsPath.relative_to  pathlib\__init__.py:481
        │        │     [7 frames hidden]  <frozen _collections_abc>, pathlib
        │        └─ 89.191 _matches  ..\graphify\detect.py:775
        │           └─ 78.324 fnmatch  fnmatch.py:22
        │              └─ 49.520 normcase  <frozen ntpath>:50
        └─ 113.348 extract  ..\graphify\extract.py:11290
           ├─ 57.885 _disambiguate_colliding_node_ids  ..\graphify\extract.py:6757
           │  └─ 56.087 _source_key  ..\graphify\extract.py:6747
           │     ├─ 33.872 WindowsPath.resolve  pathlib\__init__.py:937
           │     │     [2 frames hidden]  <frozen ntpath>, <built-in>
           │     └─ 21.102 WindowsPath.relative_to  pathlib\__init__.py:481
           ├─ 25.836 _augment_symbol_resolution_edges  ..\graphify\extract.py:7824
           └─ 17.707 WindowsPath.relative_to  pathlib\__init__.py:481

  To view this report with different options, run:
      pyinstrument --load-prev 2026-06-09T17-56-39 [options]

  Elapsed: 1743.1s
```