### PR TITLE
perf(detect): memoize ignore-pattern checks across shared ancestor dirs

### DIFF
--- a/graphify/detect.py
+++ b/graphify/detect.py
@@ -757,7 +757,13 @@ def _load_graphifyignore(root: Path) -> list[tuple[Path, str]]:
     return patterns
 
 
-def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> bool:
+def _is_ignored(
+    path: Path,
+    root: Path,
+    patterns: list[tuple[Path, str]],
+    *,
+    _cache: dict[Path, bool] | None = None,
+) -> bool:
     """Return True if the path should be ignored per .graphifyignore patterns.
 
     Uses gitignore last-match-wins semantics: all patterns are evaluated in
@@ -766,12 +772,18 @@ def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> boo
 
     Enforces gitignore's parent-exclusion rule: a ! pattern cannot re-include
     a file whose ancestor directory is already excluded.
+
+    _cache: optional dict shared across calls within the same scan. Ancestor
+    directory results are memoised so files under the same subtree don't
+    re-evaluate the same patterns repeatedly.
     """
     if not patterns:
         return False
 
     def _eval(target: Path) -> bool:
         """Apply last-match-wins to a single target path."""
+        if _cache is not None and target in _cache:
+            return _cache[target]
         def _matches(rel: str, p: str, anchored: bool) -> bool:
             if anchored:
                 return fnmatch.fnmatch(rel, p)
@@ -818,6 +830,8 @@ def _is_ignored(path: Path, root: Path, patterns: list[tuple[Path, str]]) -> boo
 
             if matched:
                 result = not negated  # last match wins; ! flips to un-ignore
+        if _cache is not None:
+            _cache[target] = result
         return result
 
     # Gitignore parent-exclusion rule: a ! re-include cannot rescue a file
@@ -983,6 +997,7 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
 
     skipped_sensitive: list[str] = []
     ignore_patterns = _load_graphifyignore(root)
+    ignore_cache: dict[Path, bool] = {}  # shared across all _is_ignored calls in this scan
     # CLI --exclude patterns are anchored at the scan root and appended last
     # so they win over any .graphifyignore/.gitignore rules (#947).
     if extra_excludes:
@@ -1021,7 +1036,7 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
                 dirnames[:] = [
                     d for d in dirnames
                     if not _is_noise_dir(d, dp)
-                    and (has_negation or not _is_ignored(dp / d, root, ignore_patterns))
+                    and (has_negation or not _is_ignored(dp / d, root, ignore_patterns, _cache=ignore_cache))
                 ]
             for fname in filenames:
                 if fname in _SKIP_FILES:
@@ -1042,7 +1057,7 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
             # Skip files inside our own converted/ dir (avoid re-processing sidecars)
             if str(p).startswith(str(converted_dir)):
                 continue
-        if not in_memory and _is_ignored(p, root, ignore_patterns):
+        if not in_memory and _is_ignored(p, root, ignore_patterns, _cache=ignore_cache):
             continue
         if _is_sensitive(p):
             skipped_sensitive.append(str(p))
@@ -1063,7 +1078,7 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
                     skipped_sensitive.append(str(p) + f" [Google Workspace export failed: {exc}]")
                     continue
                 if md_path:
-                    if _is_ignored(md_path, root, ignore_patterns):
+                    if _is_ignored(md_path, root, ignore_patterns, _cache=ignore_cache):
                         continue
                     files[ftype].append(str(md_path))
                     total_words += count_words(md_path)
@@ -1074,7 +1089,7 @@ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace:
             if p.suffix.lower() in OFFICE_EXTENSIONS:
                 md_path = convert_office_file(p, converted_dir)
                 if md_path:
-                    if _is_ignored(md_path, root, ignore_patterns):
+                    if _is_ignored(md_path, root, ignore_patterns, _cache=ignore_cache):
                         continue
                     files[ftype].append(str(md_path))
                     total_words += count_words(md_path)


### PR DESCRIPTION
## Summary
Cuts `detect()` scan time by **34%** (442s → 291s) on a repo with ~200 active ignore patterns by memoizing ancestor directory ignore-check results instead of recomputing them for every file.

  - Adds an optional `_cache` dict (keyword-only, default `None`) to `_is_ignored` / `_eval`
  - `detect()` creates one shared dict for the entire scan — each unique directory path is evaluated at most once
  - Callers in `extract.py` and `watch.py` pass no cache and are unaffected

  **The problem:** `_is_ignored` enforces gitignore's parent-exclusion rule by walking every ancestor of a path and   calling `_eval` on each one. `_eval` runs up to `3×P` `Path.relative_to` + `fnmatch` calls (P = number of patterns). Ancestor directories are shared across many files, so the same result was recomputed once per file that passes through   that subtree — O(N×D×P) total evaluations. On a repo with a few hundred ignore patterns the cost adds up fast.

  **The fix:** memoize `_eval` results keyed by `Path`. The cache is scoped to a single `detect()` call so it can't leak across scans with different roots or patterns.

  ## Profiling
Tested against a repo with ~200 patterns in `.graphifyignore` / `.gitignore`.

**Before**
```
[graphify extract] scanning C:\repo-path
[graphify extract] found 2182 code, 0 docs, 0 papers, 0 images
[graphify extract] AST extraction on 2182 code files...
  AST extraction: 100/2182 uncached files (4%) [20 workers]
  AST extraction: 200/2182 uncached files (9%) [20 workers]
  AST extraction: 300/2182 uncached files (13%) [20 workers]
  AST extraction: 400/2182 uncached files (18%) [20 workers]
  AST extraction: 500/2182 uncached files (22%) [20 workers]
  AST extraction: 600/2182 uncached files (27%) [20 workers]
  AST extraction: 700/2182 uncached files (32%) [20 workers]
  AST extraction: 800/2182 uncached files (36%) [20 workers]
  AST extraction: 900/2182 uncached files (41%) [20 workers]
  AST extraction: 1000/2182 uncached files (45%) [20 workers]
  AST extraction: 1100/2182 uncached files (50%) [20 workers]
  AST extraction: 1200/2182 uncached files (54%) [20 workers]
  AST extraction: 1300/2182 uncached files (59%) [20 workers]
  AST extraction: 1400/2182 uncached files (64%) [20 workers]
  AST extraction: 1500/2182 uncached files (68%) [20 workers]
  AST extraction: 1600/2182 uncached files (73%) [20 workers]
  AST extraction: 1700/2182 uncached files (77%) [20 workers]
  AST extraction: 1800/2182 uncached files (82%) [20 workers]
  AST extraction: 1900/2182 uncached files (87%) [20 workers]
  AST extraction: 2000/2182 uncached files (91%) [20 workers]
  AST extraction: 2100/2182 uncached files (96%) [20 workers]
  AST extraction: 2182/2182 files (100%) [20 workers]
[graphify] Deduplicated 37143 node(s) (34785 exact, 1875 fuzzy).
[graphify extract] wrote C:\repo-path\graphify-out\graph.json: 49641 nodes, 103146 edges, 2096 communities
[graphify extract] wrote C:\repo-path\graphify-out\.graphify_analysis.json
[graphify extract] next: run `graphify cluster-only C:\repo-path` to generate GRAPH_REPORT.md and name communities

  _     ._   __/__   _ _  _  _ _/_   Recorded: 07:09:34  Samples:  330779
 /_//_/// /_\ / //_// / //_'/ //     Duration: 386.228   CPU time: 376.953
/   _/                      v5.1.2

Program: graphify .

386.230 <module>  ..\graphify\__main__.py:1
└─ 386.199 main  ..\graphify\__main__.py:2070
   └─ 386.168 main  ..\graphify\__main__.py:2070
      ├─ 187.712 detect  ..\graphify\detect.py:970
      │  └─ 185.541 _is_ignored  ..\graphify\detect.py:760
      │     └─ 183.976 _eval  ..\graphify\detect.py:773
      │        ├─ 90.729 WindowsPath.relative_to  pathlib\__init__.py:481
      │        │     [21 frames hidden]  <frozen _collections_abc>, pathlib
      │        ├─ 86.333 _matches  ..\graphify\detect.py:775
      │        │  ├─ 75.796 fnmatch  fnmatch.py:22
      │        │  │     [9 frames hidden]  <frozen ntpath>, <built-in>, fnmatch
      │        │  └─ 7.907 [self]  ..\graphify\detect.py
      │        └─ 4.015 [self]  ..\graphify\detect.py
      ├─ 111.468 extract  ..\graphify\extract.py:11290
      │  ├─ 56.027 _disambiguate_colliding_node_ids  ..\graphify\extract.py:6757
      │  │  └─ 54.204 _source_key  ..\graphify\extract.py:6747
      │  │     ├─ 32.910 WindowsPath.resolve  pathlib\__init__.py:937
      │  │     │     [2 frames hidden]  <frozen ntpath>, <built-in>
      │  │     └─ 20.255 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │           [5 frames hidden]  <frozen _collections_abc>, pathlib
      │  ├─ 26.028 _augment_symbol_resolution_edges  ..\graphify\extract.py:7824
      │  │  ├─ 14.755 _collect_js_symbol_resolution_facts  ..\graphify\extract.py:7484
      │  │  │  └─ 12.229 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │     └─ 11.603 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │        └─ 10.954 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │           └─ 10.276 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │              └─ 9.604 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                 └─ 8.942 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                    └─ 8.283 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                       └─ 7.622 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                          └─ 7.012 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                             └─ 6.398 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                └─ 5.826 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                   └─ 5.312 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                      └─ 4.831 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                         └─ 4.326 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  └─ 11.189 _apply_symbol_resolution_facts  ..\graphify\extract.py:6955
      │  │     └─ 8.489 _js_source_path  ..\graphify\extract.py:6879
      │  │        └─ 7.650 WindowsPath.resolve  pathlib\__init__.py:937
      │  │              [2 frames hidden]  <frozen ntpath>, <built-in>
      │  ├─ 17.691 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │     [5 frames hidden]  <frozen _collections_abc>, pathlib
      │  └─ 3.952 _extract_parallel  ..\graphify\extract.py:11170
      ├─ 63.123 build  ..\graphify\build.py:276
      │  └─ 59.898 deduplicate_entities  ..\graphify\dedup.py:131
      ├─ 13.681 cluster  ..\graphify\cluster.py:86
      │  ├─ 8.504 _partition  ..\graphify\cluster.py:22
      │  │  └─ 5.743 func  networkx\utils\decorators.py:783
      │  │     └─ 5.743 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │  │        └─ 5.743 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │  │           └─ 5.743 louvain_communities  networkx\algorithms\community\louvain.py:14
      │  │              └─ 5.735 louvain_partitions  networkx\algorithms\community\louvain.py:133
      │  └─ 4.556 _split_community  ..\graphify\cluster.py:191
      │     └─ 4.225 _partition  ..\graphify\cluster.py:22
      └─ 7.945 to_json  ..\graphify\export.py:484
         └─ 6.946 dump  json\__init__.py:120
               [2 frames hidden]  json

To view this report with different options, run:
    pyinstrument --load-prev 2026-06-10T07-09-34 [options]

Elapsed: 441.7s
```

After
```
[graphify extract] scanning C:\repo-path
[graphify extract] found 2182 code, 0 docs, 0 papers, 0 images
[graphify extract] AST extraction on 2182 code files...
  AST extraction: 100/2182 uncached files (4%) [20 workers]
  AST extraction: 200/2182 uncached files (9%) [20 workers]
  AST extraction: 300/2182 uncached files (13%) [20 workers]
  AST extraction: 400/2182 uncached files (18%) [20 workers]
  AST extraction: 500/2182 uncached files (22%) [20 workers]
  AST extraction: 600/2182 uncached files (27%) [20 workers]
  AST extraction: 700/2182 uncached files (32%) [20 workers]
  AST extraction: 800/2182 uncached files (36%) [20 workers]
  AST extraction: 900/2182 uncached files (41%) [20 workers]
  AST extraction: 1000/2182 uncached files (45%) [20 workers]
  AST extraction: 1100/2182 uncached files (50%) [20 workers]
  AST extraction: 1200/2182 uncached files (54%) [20 workers]
  AST extraction: 1300/2182 uncached files (59%) [20 workers]
  AST extraction: 1400/2182 uncached files (64%) [20 workers]
  AST extraction: 1500/2182 uncached files (68%) [20 workers]
  AST extraction: 1600/2182 uncached files (73%) [20 workers]
  AST extraction: 1700/2182 uncached files (77%) [20 workers]
  AST extraction: 1800/2182 uncached files (82%) [20 workers]
  AST extraction: 1900/2182 uncached files (87%) [20 workers]
  AST extraction: 2000/2182 uncached files (91%) [20 workers]
  AST extraction: 2100/2182 uncached files (96%) [20 workers]
  AST extraction: 2182/2182 files (100%) [20 workers]
[graphify] Deduplicated 37140 node(s) (34785 exact, 1875 fuzzy).
[graphify extract] wrote C:\repo-path\graphify-out\graph.json: 49644 nodes, 103148 edges, 2081 communities
[graphify extract] wrote C:\repo-path\graphify-out\.graphify_analysis.json
[graphify extract] next: run `graphify cluster-only C:\repo-path` to generate GRAPH_REPORT.md and name communities

  _     ._   __/__   _ _  _  _ _/_   Recorded: 07:21:18  Samples:  208580
 /_//_/// /_\ / //_// / //_'/ //     Duration: 271.127   CPU time: 264.000
/   _/                      v5.1.2

Program: graphify .

271.125 <module>  ..\graphify\__main__.py:1
└─ 271.082 main  ..\graphify\__main__.py:2070
   └─ 271.046 main  ..\graphify\__main__.py:2070
      ├─ 123.604 extract  ..\graphify\extract.py:11290
      │  ├─ 61.574 _disambiguate_colliding_node_ids  ..\graphify\extract.py:6757
      │  │  └─ 59.792 _source_key  ..\graphify\extract.py:6747
      │  │     ├─ 36.267 WindowsPath.resolve  pathlib\__init__.py:937
      │  │     │     [2 frames hidden]  <frozen ntpath>, <built-in>
      │  │     └─ 22.401 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │           [10 frames hidden]  <frozen _collections_abc>, pathlib
      │  ├─ 29.461 _augment_symbol_resolution_edges  ..\graphify\extract.py:7824
      │  │  ├─ 16.972 _collect_js_symbol_resolution_facts  ..\graphify\extract.py:7484
      │  │  │  └─ 14.158 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │     └─ 13.432 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │        └─ 12.647 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │           └─ 11.861 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │              └─ 11.066 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                 └─ 10.314 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                    └─ 9.448 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                       └─ 8.671 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                          └─ 7.937 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                             └─ 7.257 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                └─ 6.544 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                   └─ 5.919 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                      └─ 5.353 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                         └─ 4.753 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                            └─ 4.248 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                               └─ 3.769 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                                  └─ 3.294 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  │                                                     └─ 2.844 _walk_js_tree  ..\graphify\extract.py:7191
      │  │  └─ 12.402 _apply_symbol_resolution_facts  ..\graphify\extract.py:6955
      │  │     └─ 9.393 _js_source_path  ..\graphify\extract.py:6879
      │  │        └─ 8.555 WindowsPath.resolve  pathlib\__init__.py:937
      │  │              [2 frames hidden]  <frozen ntpath>, <built-in>
      │  ├─ 18.889 WindowsPath.relative_to  pathlib\__init__.py:481
      │  │     [8 frames hidden]  <frozen _collections_abc>, pathlib
      │  ├─ 4.658 _extract_parallel  ..\graphify\extract.py:11170
      │  │  └─ 3.699 as_completed  concurrent\futures\_base.py:193
      │  │        [3 frames hidden]  threading, <built-in>
      │  └─ 2.934 load_cached  ..\graphify\cache.py:226
      ├─ 71.327 build  ..\graphify\build.py:276
      │  ├─ 67.515 deduplicate_entities  ..\graphify\dedup.py:131
      │  │  ├─ 60.628 [self]  ..\graphify\dedup.py
      │  │  └─ 3.313 <genexpr>  ..\graphify\dedup.py:237
      │  └─ 3.569 build_from_json  ..\graphify\build.py:107
      ├─ 50.969 detect  ..\graphify\detect.py:984
      │  └─ 48.630 _is_ignored  ..\graphify\detect.py:760
      │     └─ 46.973 _eval  ..\graphify\detect.py:783
      │        ├─ 22.268 _matches  ..\graphify\detect.py:787
      │        │  └─ 19.618 fnmatch  fnmatch.py:22
      │        │        [5 frames hidden]  <frozen ntpath>, <built-in>, fnmatch
      │        └─ 22.148 WindowsPath.relative_to  pathlib\__init__.py:481
      │              [8 frames hidden]  <frozen _collections_abc>, pathlib
      ├─ 15.212 cluster  ..\graphify\cluster.py:86
      │  ├─ 9.701 _partition  ..\graphify\cluster.py:22
      │  │  └─ 6.615 func  networkx\utils\decorators.py:783
      │  │     └─ 6.615 argmap_louvain_communities_5  <class 'networkx.utils.decorators.argmap'> compilation 9:1
      │  │        └─ 6.615 _dispatchable._call_if_no_backends_installed  networkx\utils\backends.py:541
      │  │           └─ 6.615 louvain_communities  networkx\algorithms\community\louvain.py:14
      │  │              └─ 6.610 louvain_partitions  networkx\algorithms\community\louvain.py:133
      │  │                 └─ 4.212 _one_level  networkx\algorithms\community\louvain.py:227
      │  └─ 4.860 _split_community  ..\graphify\cluster.py:191
      │     └─ 4.512 _partition  ..\graphify\cluster.py:22
      └─ 7.727 to_json  ..\graphify\export.py:484
         └─ 6.870 dump  json\__init__.py:120
               [3 frames hidden]  json

To view this report with different options, run:
    pyinstrument --load-prev 2026-06-10T07-21-18 [options]

Elapsed: 291.2s
```

  Notes

  - Cache is unbounded but holds at most one bool per unique path visited — negligible memory next to the file lists detect() already builds
  - _cache uses a leading underscore to signal it is an internal threading parameter; external callers should not pass it