### PR TITLE
fix: resolve claude.cmd path in _call_llm claude-cli backend on Windows

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1579,10 +1579,13 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
 
     if backend == "claude-cli":
         import shutil, subprocess
-        if shutil.which("claude") is None:
+        # Prefer claude.cmd on Windows: CreateProcess cannot execute the bare
+        # name when shutil.which resolves to claude.ps1 (same as issue #1072).
+        _claude = shutil.which("claude.cmd") or shutil.which("claude")
+        if _claude is None:
             raise RuntimeError("Claude Code CLI not found on $PATH")
         proc = subprocess.run(
-            ["claude", "-p", "--output-format", "json", "--no-session-persistence"],
+            [_claude, "-p", "--output-format", "json", "--no-session-persistence"],
             input=prompt,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Bug

On Windows, `graphify label . --backend=claude-cli` fails silently: every batch dies with `[WinError 2] The system cannot find the file specified` and the `Community N` placeholders are kept.

Root cause: in `graphify/llm.py`, `_call_llm` (the `claude-cli` branch, ~line 1580) spawns the CLI with the bare name:

```python
subprocess.run(["claude", "-p", ...])
```

The npm-installed Claude Code CLI on Windows is `claude.cmd` / `claude.ps1` — there is no `claude.exe` — and `CreateProcess` cannot execute a bare name without an `.exe` extension.

This is the exact same bug that was already fixed in `_call_claude_cli` for issue #1072 (~line 868, which resolves via `shutil.which("claude.cmd")` first), but the fix was never applied to `_call_llm`, which has its own independent subprocess call (used by community labeling).

## Fix

Same resolution as #1072, applied to `_call_llm`:

```python
_claude = shutil.which("claude.cmd") or shutil.which("claude")
if _claude is None:
    raise RuntimeError("Claude Code CLI not found on $PATH")
proc = subprocess.run([_claude, "-p", ...])
```

On non-Windows platforms, `shutil.which("claude.cmd")` returns `None`, so behavior is unchanged.

## Verification

Patch applied locally on Windows 11 against an installed copy and verified functional: `graphify label . --backend=claude-cli` then named **227 communities successfully** (previously 0, all batches failing with WinError 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
