### PR TITLE
fix(claude-cli): handle JSON-array envelope from Claude Code CLI ≥ 2.1

### DIFF
--- a/graphify/llm.py
+++ b/graphify/llm.py
@@ -1,4 +1,3 @@
-# Direct LLM backend for semantic extraction — supports Claude, Kimi K2.6,
 # Gemini, and OpenAI.
 # Used by `graphify extract . --backend gemini` and the benchmark scripts.
 # The default graphify pipeline uses Claude Code subagents via skill.md;
@@ -979,6 +978,38 @@ def _call_claude(api_key: str, model: str, user_message: str, max_tokens: int = 
     return result
 
 
+def _claude_cli_envelope(stdout: str) -> dict:
+    """Parse the JSON returned by `claude -p --output-format json`.
+
+    Older Claude Code CLI versions returned a single envelope object. Newer
+    versions (>= ~2.1) emit a JSON ARRAY of streamed event objects (a system
+    init event, assistant turns, an optional rate_limit_event, and a final
+    {"type":"result"} object). Normalize both shapes to the result dict that
+    carries `result`, `usage`, `modelUsage`, and `stop_reason`.
+    """
+    try:
+        envelope = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"claude -p produced unparseable JSON envelope: {exc}; "
+            f"first 500 chars of stdout: {stdout[:500]!r}"
+        ) from exc
+    if isinstance(envelope, list):
+        result_events = [
+            e for e in envelope
+            if isinstance(e, dict) and e.get("type") == "result"
+        ]
+        if result_events:
+            return result_events[-1]
+        if envelope and isinstance(envelope[-1], dict):
+            return envelope[-1]
+        raise RuntimeError(
+            "claude -p returned a JSON array with no result object; "
+            f"first 500 chars of stdout: {stdout[:500]!r}"
+        )
+    return envelope
+
+
 def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bool = False, images: list[_ImageRef] | None = None) -> dict:
     """Call Claude via the locally-installed Claude Code CLI (`claude -p`).
 
@@ -1065,13 +1096,7 @@ def _call_claude_cli(user_message: str, max_tokens: int = 8192, *, deep_mode: bo
             f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}"
         )
 
-    try:
-        envelope = json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"claude -p produced unparseable JSON envelope: {exc}; "
-            f"first 500 chars of stdout: {proc.stdout[:500]!r}"
-        ) from exc
+    envelope = _claude_cli_envelope(proc.stdout)
 
     raw_content = envelope.get("result", "")
     result = _parse_llm_json(raw_content or "{}")
@@ -1727,10 +1752,7 @@ def _call_llm(prompt: str, *, backend: str, max_tokens: int = 200) -> str:
         )
         if proc.returncode != 0:
             raise RuntimeError(f"claude -p exited {proc.returncode}: {proc.stderr.strip()[:500]}")
-        try:
-            envelope = json.loads(proc.stdout)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"claude -p produced unparseable JSON envelope: {exc}") from exc
+        envelope = _claude_cli_envelope(proc.stdout)
         return envelope.get("result", "")
 
 


### PR DESCRIPTION
## Summary

The `claude-cli` backend crashes on every chunk with `'list' object has no attribute 'get'` when run against a recent Claude Code CLI.

```
[graphify extract] semantic extraction on 76 files via claude-cli...
[graphify] chunk 1/5 failed: 'list' object has no attribute 'get'
[graphify] chunk 2/5 failed: 'list' object has no attribute 'get'
...
```

## Root cause

`claude -p --output-format json` used to return a single envelope **object**. Newer Claude Code CLI versions (observed on **2.1.172**) emit a JSON **array** of streamed event objects instead:

```json
[
  {"type":"system","subtype":"init", ...},
  {"type":"assistant","message":{...}},
  {"type":"rate_limit_event", ...},
  {"type":"result","subtype":"success","result":"...","usage":{...},"modelUsage":{...},"stop_reason":...}
]
```

So `json.loads(proc.stdout)` returns a `list`, and the next line — `envelope.get("result", "")` in `_call_claude_cli` (and the same pattern in the second `claude -p` call site) — raises `'list' object has no attribute 'get'`. The data graphify wants is the terminal `{"type":"result"}` element, which already carries the exact keys the code reads (`result`, `usage`, `modelUsage`, `stop_reason`).

## Fix

Add a small shared helper `_claude_cli_envelope(stdout)` that:

- parses the stdout JSON (preserving the existing unparseable-envelope error),
- when given a **list**, returns the last `{"type":"result"}` event (falling back to the last dict element, with a clear error if neither exists),
- when given a **dict**, returns it unchanged — so **older CLI versions keep working**.

Both `claude -p` call sites now route through this helper, removing the duplicated parse-and-`.get()` logic.

## Impact

Without this, the entire semantic-extraction layer is lost on current Claude Code — every LLM chunk fails and the graph is built from AST extraction only (no cross-file/semantic edges, no god-node summaries, no doc/concept extraction). For a doc-heavy corpus that is effectively no graph.

## Notes

- This change is backward-compatible with the single-object envelope shape.
- No cache entries were produced to attach (the crash happens before any cache write), since extraction dies on the first `.get()`.
- Verified with `ast.parse` that the patched module is syntactically valid.

Tested locally against Claude Code CLI 2.1.172 on Windows; extraction completes and chunks process normally with the helper in place.