### PR TITLE
fix(build): skip ghost-merge when basename+label matches multiple AST nodes (#1257)

### DIFF
--- a/graphify/build.py
+++ b/graphify/build.py
@@ -163,7 +163,12 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
     # pairs that share (source_file basename, label) and collapse the semantic
     # copy into the AST copy so edges re-point to a single node.
     # Two passes: first collect all AST (located) nodes, then find ghosts.
+    # When 2+ located nodes share a key (same-named symbols in same-named
+    # files across directories, e.g. render in two index.ts), the key is
+    # ambiguous: merging the ghost would pick an arbitrary winner. Skip those
+    # keys entirely (same conservatism as _rewire_unique_stub_nodes).
     _loc_nodes: dict[tuple[str, str], str] = {}   # (basename, label) -> AST node id
+    _loc_collisions: set[tuple[str, str]] = set()  # keys shared by 2+ AST nodes
     _noloc_nodes: dict[tuple[str, str], str] = {}  # (basename, label) -> semantic node id
     for nid in node_set:
         attrs = G.nodes[nid]
@@ -173,7 +178,11 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
         if not label or not basename:
             continue
         if attrs.get("source_location"):
-            _loc_nodes[(basename, label)] = nid
+            key = (basename, label)
+            if key in _loc_nodes:
+                _loc_collisions.add(key)
+            else:
+                _loc_nodes[key] = nid
     for nid in node_set:
         attrs = G.nodes[nid]
         label = str(attrs.get("label", "")).strip()
@@ -182,6 +191,8 @@ def build_from_json(extraction: dict, *, directed: bool = False, root: str | Pat
         if not label or not basename or attrs.get("source_location"):
             continue
         key = (basename, label)
+        if key in _loc_collisions:
+            continue
         if key in _loc_nodes and _loc_nodes[key] != nid:
             _noloc_nodes[key] = nid
     # For every ghost that has an AST counterpart, record a remap.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -149,6 +149,56 @@ def test_file_type_synonym_mapping():
     assert G.nodes["n3"]["file_type"] == "concept"
 
 
+def test_ghost_merge_unique_located_node_still_merges():
+    """#1145 ghost-merge: a semantic ghost collapses into the single AST node
+    sharing its (basename, label), and edges re-point to the AST node."""
+    ext = {
+        "nodes": [
+            {"id": "ast_render", "label": "render", "file_type": "code",
+             "source_file": "src/app/index.ts", "source_location": "L10"},
+            {"id": "ghost_render", "label": "render", "file_type": "code",
+             "source_file": "src/app/index.ts"},
+            {"id": "caller", "label": "main", "file_type": "code",
+             "source_file": "src/main.ts", "source_location": "L1"},
+        ],
+        "edges": [{"source": "caller", "target": "ghost_render", "relation": "calls",
+                   "confidence": "EXTRACTED", "source_file": "src/main.ts", "weight": 1.0}],
+        "input_tokens": 0, "output_tokens": 0,
+    }
+    G = build_from_json(ext)
+    assert "ghost_render" not in G.nodes()
+    assert G.has_edge("caller", "ast_render")
+
+
+def test_ghost_merge_skipped_on_basename_collision():
+    """When two files with the same basename both define a symbol with the
+    same label, the (basename, label) key is ambiguous and the semantic ghost
+    must not be merged into an arbitrary one of them."""
+    ext = {
+        "nodes": [
+            {"id": "a_render", "label": "render", "file_type": "code",
+             "source_file": "src/a/index.ts", "source_location": "L10"},
+            {"id": "b_render", "label": "render", "file_type": "code",
+             "source_file": "src/b/index.ts", "source_location": "L20"},
+            {"id": "ghost_render", "label": "render", "file_type": "code",
+             "source_file": "src/a/index.ts"},
+            {"id": "caller", "label": "main", "file_type": "code",
+             "source_file": "src/main.ts", "source_location": "L1"},
+        ],
+        "edges": [{"source": "caller", "target": "ghost_render", "relation": "calls",
+                   "confidence": "EXTRACTED", "source_file": "src/main.ts", "weight": 1.0}],
+        "input_tokens": 0, "output_tokens": 0,
+    }
+    G = build_from_json(ext)
+    # The ghost survives: merging it into either a_render or b_render would
+    # pick an arbitrary winner (dict insertion order over a set iteration).
+    assert "ghost_render" in G.nodes()
+    assert G.number_of_nodes() == 4
+    assert G.has_edge("caller", "ghost_render")
+    assert not G.has_edge("caller", "a_render")
+    assert not G.has_edge("caller", "b_render")
+
+
 def test_build_merge_preserves_call_edge_direction(tmp_path):
     """Regression for #760.
 


### PR DESCRIPTION
Fixes #1257.

## Summary

- The #1145 ghost-merge pass in `build_from_json` keys located (AST) nodes by `(source_file basename, label)` in a last-writer-wins dict. When two files with the same basename in different directories both define a symbol with the same label (e.g. `render` in two `index.ts` files), the semantic ghost is merged into whichever located node was written last — and since iteration is over a `set`, the winner is arbitrary and can flip run-to-run, mis-pointing the ghost's edges and churning the serialized graph.
- Fix: track keys shared by 2+ located nodes and skip the ghost-merge for those keys. Ghosts only merge when the key identifies exactly one AST node — the same conservatism `_rewire_unique_stub_nodes` applies at the extractor level (`len(candidates) != 1: continue`).

Related but distinct from #952, which covers basename collisions at the extractor level; this pass mis-merges even with correct extractor output.

## Test

Regression tests in `tests/test_build.py`:

- `test_ghost_merge_skipped_on_basename_collision`: two `index.ts` files in different dirs, each with a located `render`, plus one ghost `render` — the ghost and its edge must survive untouched. Fails before the fix (ghost merged into an arbitrary node), passes after.
- `test_ghost_merge_unique_located_node_still_merges`: guards the existing happy path — a ghost with exactly one located counterpart still collapses and its edges re-point.

Full suite: 1985 passed, 27 skipped (`uv run --frozen pytest tests/ -q`).

Made with [Cursor](https://cursor.com)