### PR TITLE
fix: resolve_seed matches bare names against ()-decorated callable labels

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -43,6 +43,12 @@ def _format_location(data: dict) -> str:
     return str(source_file)
 
 
+def _bare_name(label: str) -> str:
+    """Lowercased label with the callable decoration (trailing "()") removed."""
+    label = label.lower()
+    return label[:-2] if label.endswith("()") else label
+
+
 def resolve_seed(graph: nx.Graph, query: str) -> str | None:
     if query in graph:
         return query
@@ -54,6 +60,17 @@ def resolve_seed(graph: nx.Graph, query: str) -> str | None:
     ]
     if len(exact_label_matches) == 1:
         return exact_label_matches[0]
+    # Callable labels are decorated ("name()"), so a bare "name" query falls
+    # through exact matching and then ties with any "name*" sibling in the
+    # contains pass. Match on the undecorated name before giving up.
+    query_bare = _bare_name(query_lower)
+    bare_name_matches = [
+        str(node_id)
+        for node_id, data in graph.nodes(data=True)
+        if _bare_name(str(data.get("label", ""))) == query_bare
+    ]
+    if len(bare_name_matches) == 1:
+        return bare_name_matches[0]
     exact_source_matches = [
         str(node_id)
         for node_id, data in graph.nodes(data=True)

--- a/tests/test_affected_cli.py
+++ b/tests/test_affected_cli.py
@@ -92,3 +92,34 @@ def test_affected_cli_forces_directed_on_undirected_graph(monkeypatch, tmp_path,
     assert "calls" in out
     # B is the query node, not an affected node, and the result is not empty.
     assert "No affected nodes found." not in out
+
+
+def test_resolve_seed_bare_name_matches_callable_label():
+    from graphify.affected import resolve_seed
+
+    graph = nx.DiGraph()
+    graph.add_node("a", label="classifyProperty()", source_file="pkg/entity.py")
+    graph.add_node("b", label="classifyPropertySafe()", source_file="app/context.py")
+
+    assert resolve_seed(graph, "classifyProperty") == "a"
+    assert resolve_seed(graph, "classifyPropertySafe") == "b"
+
+
+def test_resolve_seed_decorated_query_matches_bare_label():
+    from graphify.affected import resolve_seed
+
+    graph = nx.DiGraph()
+    graph.add_node("a", label="Foo", source_file="pkg/foo.py")
+    graph.add_node("b", label="FooBar", source_file="pkg/foobar.py")
+
+    assert resolve_seed(graph, "Foo()") == "a"
+
+
+def test_resolve_seed_bare_name_tie_still_returns_none():
+    from graphify.affected import resolve_seed
+
+    graph = nx.DiGraph()
+    graph.add_node("a", label="dup()", source_file="pkg/one.py")
+    graph.add_node("b", label="dup()", source_file="pkg/two.py")
+
+    assert resolve_seed(graph, "dup") is None


### PR DESCRIPTION
## Problem

`graphify affected "classifyProperty"` returns **No unique node match** even when exactly one callable named `classifyProperty` exists in the graph.

Callable nodes are labeled with a trailing `()` decoration (`classifyProperty()`), so a bare-name query:
1. misses the exact-label pass (`classifyproperty` ≠ `classifyproperty()`), then
2. ties with any prefix sibling (e.g. `classifyPropertySafe()`) in the contains pass → `None`.

Users hit this on any codebase where one symbol name is a prefix of another — common with `foo` / `fooSafe` / `fooImpl` naming. The workaround (quoting the decorated label `"classifyProperty()"`) is not discoverable from the error message.

## Fix

Add a bare-name pass in `resolve_seed` between exact-label and exact-source matching: compare query and label with the trailing `()` stripped from each side. Bare queries now resolve decorated labels (and decorated queries resolve undecorated labels); genuine duplicates still return `None`.

## Testing

- 3 new tests in `tests/test_affected_cli.py` (bare→decorated, decorated→bare, true-duplicate still ambiguous); red before the fix, green after.
- Full suite run on Windows: failure set identical to a clean checkout (pre-existing platform failures only).
- Verified end-to-end on a 21.8k-node graph of a production TypeScript monorepo: `affected "classifyProperty"` went from "No unique node match" to the complete caller/importer set.

Proposed changelog line:
> Fix: `resolve_seed` (used by `affected`) now matches bare symbol names against `()`-decorated callable labels, instead of returning "No unique node match" whenever a prefix sibling exists (`foo` vs `fooSafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)