### PR TITLE
fix(affected): handle "edges"-keyed graph.json in load_graph (KeyError: 'links')

### DIFF
--- a/graphify/affected.py
+++ b/graphify/affected.py
@@ -165,6 +165,12 @@ def load_graph(path: Path) -> nx.Graph:
     # Force directed so stored caller→callee direction survives the round-trip;
     # mirrors serve.py and __main__.py (#1174).
     raw = {**raw, "directed": True}
+    # Normalize the edge key: graphify's `extract` output uses "edges" while
+    # networkx's node_link_data default is "links". Without this, an edges-keyed
+    # graph.json raises an uncaught KeyError: 'links' here — every other loader
+    # (__main__.py) already normalizes this (#738; same class as #1198).
+    if "links" not in raw and "edges" in raw:
+        raw = dict(raw, links=raw["edges"])
     try:
         return json_graph.node_link_graph(raw, edges="links")
     except TypeError:

--- a/tests/test_affected_cli.py
+++ b/tests/test_affected_cli.py
@@ -94,6 +94,36 @@ def test_affected_cli_forces_directed_on_undirected_graph(monkeypatch, tmp_path,
     assert "No affected nodes found." not in out
 
 
+def test_affected_cli_loads_edges_keyed_graph(monkeypatch, tmp_path, capsys):
+    """graphify's `extract` writes graph.json with an "edges" key (not networkx's
+    default "links"). affected.load_graph must handle it; before the edges/links
+    normalization it raised an uncaught KeyError: 'links' (same class as #1198)."""
+    graph = nx.DiGraph()
+    graph.add_node("target", label="Foo", source_file="pkg/foo.py", source_location="L1")
+    graph.add_node("caller", label="X()", source_file="app.py", source_location="L4")
+    graph.add_edge("caller", "target", relation="calls", context="call", confidence="EXTRACTED")
+
+    # Emulate graphify extract output: top-level "edges" key instead of "links".
+    data = json_graph.node_link_data(graph, edges="links")
+    data["edges"] = data.pop("links")
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setattr(mainmod, "_check_skill_version", lambda _: None)
+    monkeypatch.setattr(
+        mainmod.sys,
+        "argv",
+        ["graphify", "affected", "Foo", "--graph", str(graph_path)],
+    )
+
+    mainmod.main()
+
+    out = capsys.readouterr().out
+    assert "Affected nodes for Foo" in out
+    assert "X()" in out
+    assert "calls" in out
+
+
 def test_resolve_seed_bare_name_matches_callable_label():
     from graphify.affected import resolve_seed
 


### PR DESCRIPTION
## Summary

`graphify affected` fails to load graphs produced by `graphify extract`,
exiting with `error: could not load graph: 'links'`. Every other reader works.

## Root cause

`graphify/affected.py::load_graph` calls
`json_graph.node_link_graph(raw, edges="links")`, but `extract` writes
`graph.json` with an **`"edges"`** key. networkx then raises `KeyError: 'links'`,
which the surrounding `except TypeError` does not catch.

`__main__.py` already normalizes this everywhere it loads a graph:

```python
if "links" not in raw and "edges" in raw:
    raw = dict(raw, links=raw["edges"])
```

`affected.load_graph` is the only loader missing that normalization. Same class
of bug as #1198 (benchmark `KeyError: 'links'`).

## Fix

Mirror the existing normalization in `affected.load_graph` before calling
`node_link_graph`. `links`-keyed graphs and older networkx fall through unchanged.

## Repro

```
$ graphify extract . --no-cluster      # writes an "edges"-keyed graph.json
$ graphify affected "SomeSymbol" --depth 1
error: could not load graph: 'links'   # before; after: reverse-traversal output
```

## Tests

Added `test_affected_cli_loads_edges_keyed_graph` — writes an `"edges"`-keyed
graph (as `extract` does) and asserts `affected` reverse-traverses it. The
existing `_write_graph` helper only ever emitted the `"links"` key, so this path
was untested. Fails before the fix (`KeyError: 'links'`), passes after.

---

Found this while running graphify against a ~8,200-file monorepo (52k nodes /
186k edges) — after the fix, `affected` correctly reverse-traverses 621 nodes
from a core DB accessor. Happy to adjust if you'd rather hoist the
normalization into a shared helper instead of mirroring it per-loader.
