### PR TITLE
fix: ignore unreadable skill version probes

### DIFF
--- a/graphify/__main__.py
+++ b/graphify/__main__.py
@@ -94,9 +94,16 @@ def _enforce_graph_size_cap_or_exit(gp: Path) -> None:
 def _check_skill_version(skill_dst: Path) -> None:
     """Warn if the installed skill is from an older graphify version."""
     version_file = skill_dst.parent / ".graphify_version"
-    if not version_file.exists():
+    try:
+        if not version_file.exists():
+            return
+    except OSError:
         return
-    if not skill_dst.exists():
+    try:
+        skill_exists = skill_dst.exists()
+    except OSError:
+        return
+    if not skill_exists:
         print("  warning: skill dir exists but SKILL.md is missing. Run 'graphify install' to repair.")
         return
     # A progressive SKILL.md links to its references/ sidecar. If the body points
@@ -108,7 +115,10 @@ def _check_skill_version(skill_dst: Path) -> None:
         body = ""
     if "references/" in body and not (skill_dst.parent / "references").exists():
         print("  warning: skill references/ sidecar is missing. Run 'graphify install' to repair.", file=sys.stderr)
-    installed = version_file.read_text(encoding="utf-8").strip()
+    try:
+        installed = version_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return
     if installed != __version__:
         print(f"  warning: skill is from graphify {installed}, package is {__version__}. Run 'graphify install' to update.", file=sys.stderr)
 

--- a/tests/test_install_references.py
+++ b/tests/test_install_references.py
@@ -150,6 +150,29 @@ def test_check_skill_version_warns_on_missing_references(tmp_path, fake_bundle, 
     assert "references/ sidecar is missing" in err
 
 
+def test_check_skill_version_ignores_permission_error(tmp_path, fake_bundle, monkeypatch, capsys):
+    """Unreadable version probes should not crash startup."""
+    platform = fake_bundle
+    _install(tmp_path, platform)
+    skill_dir = tmp_path / ".claude" / "skills" / "graphify"
+    skill = skill_dir / "SKILL.md"
+
+    original_exists = Path.exists
+
+    def guarded_exists(self):
+        if self.name == ".graphify_version":
+            raise PermissionError("denied")
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", guarded_exists)
+
+    mainmod._check_skill_version(skill)
+
+    out = capsys.readouterr()
+    assert out.out == ""
+    assert out.err == ""
+
+
 def test_hard_fail_when_bundle_dir_present_but_references_missing(tmp_path, monkeypatch):
     """A bundle dir that exists but has no references/ subdir is a malformed
     package: exit 1 rather than silently shipping an empty sidecar.


### PR DESCRIPTION
## Summary

Treat unreadable skill-version probe files as non-fatal during startup.

## Change

- Skip or ignore unreadable `.graphify_version` paths
- Preserve the warning when the file is readable and the version is stale
- Add a regression test for the permission-failure case

## Notes

This keeps the compatibility warning behavior without making normal commands fail in sandboxed or restricted environments.
