### PR TITLE
feat: extract JS/TS this.X=, exports.X=, prototype, class arrow fields, and function expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Full release notes with details on each version: [GitHub Releases](https://githu
 
 ## Unreleased
 
+- Feat: JS/TS AST now extracts function symbols defined via `this.X = () => {}` / `this.X = function(){}` (constructor-assigned methods), `exports.X = fn` / `module.exports.X = fn`, `Foo.prototype.X = fn`, class arrow/function fields (`class C { onClick = (e) => {} }`), and `const f = function(){}` function expressions. Previously only top-level `function` declarations, top-level `const x = () =>` arrows, classes, and method shorthand were captured, so the majority of callable symbols in constructor-style and CommonJS codebases (DAOs, route handlers, services) never became nodes and could not be call-edge endpoints. Arbitrary `obj.x = fn` is deliberately not captured, preserving the #1077 phantom-god-node guard (#1322).
 - Fix: `graphify query`, `graphify explain`, and MCP `query_graph`/`get_node` now show the human-readable community name (e.g. "FlashAttention Paper") instead of a blank or numeric ID after running `cluster-only`. `to_json` now accepts `community_labels` and embeds `community_name` on each node; read paths fall back to the numeric `community` field for backward compatibility with old graphs (#1305).
 - Fix: `graphify-mcp` and `python -m graphify.serve` now accept `--graph <path>` as an alias for the positional argument, consistent with every other graphify subcommand. Previously `--graph` raised "unrecognized arguments" (#1304).
 

--- a/graphify/extract.py
+++ b/graphify/extract.py
@@ -1726,10 +1726,117 @@ def _require_imports_js(node, source: bytes, file_nid: str, stem: str, edges: li
     return found
 
 
+# Node types whose value is a callable, for the JS/TS assignment / class-field
+# / function-expression forms below. Older tree-sitter-javascript grammars
+# label a function expression `function`; current ones use `function_expression`.
+_JS_FUNCTION_VALUE_TYPES = frozenset({"arrow_function", "function_expression", "function"})
+
+
+def _js_member_assignment_target(left, source: bytes):
+    """Classify the symbol an `assignment_expression` LHS defines when its RHS
+    is a function. Returns (kind, owner_name, member_name) or None.
+
+      this.foo = fn            → ("this",      None,  "foo")
+      exports.foo = fn         → ("exports",   None,  "foo")
+      module.exports.foo = fn  → ("exports",   None,  "foo")
+      Foo.prototype.bar = fn   → ("prototype", "Foo", "bar")
+
+    Any other shape (an arbitrary `obj.x = fn`) returns None and is skipped —
+    capturing those would reintroduce the bare-named / phantom-god-node class
+    of bug the module-level scope guard (#1077) exists to prevent.
+    """
+    if left is None or left.type != "member_expression":
+        return None
+    prop = left.child_by_field_name("property")
+    if prop is None:
+        return None
+    member_name = _read_text(prop, source)
+    if not member_name:
+        return None
+    obj = left.child_by_field_name("object")
+    if obj is None:
+        return None
+    if obj.type == "this":
+        return ("this", None, member_name)
+    if obj.type == "identifier":
+        if _read_text(obj, source) == "exports":
+            return ("exports", None, member_name)
+        return None
+    if obj.type == "member_expression":
+        # module.exports.X  or  Foo.prototype.X
+        inner_obj = obj.child_by_field_name("object")
+        inner_prop = obj.child_by_field_name("property")
+        if inner_obj is None or inner_prop is None:
+            return None
+        inner_prop_name = _read_text(inner_prop, source)
+        if inner_obj.type == "identifier":
+            inner_obj_name = _read_text(inner_obj, source)
+            if inner_obj_name == "module" and inner_prop_name == "exports":
+                return ("exports", None, member_name)
+            if inner_prop_name == "prototype":
+                return ("prototype", inner_obj_name, member_name)
+    return None
+
+
 def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
                    nodes: list, edges: list, seen_ids: set, function_bodies: list,
                    parent_class_nid: str | None, add_node_fn, add_edge_fn) -> bool:
     """Handle lexical_declaration (arrow functions, CJS requires, module-level const literals) for JS/TS. Returns True if handled."""
+    # CommonJS / prototype member assignments whose value is a function:
+    #   exports.X = () => {}     → file-contained function  X()
+    #   module.exports.X = fn    → file-contained function  X()
+    #   Foo.prototype.bar = fn   → method bar() owned by Foo
+    # (`this.X = fn` lives inside a function body, which is not recursed here;
+    #  it is captured at the enclosing function — see the function branch.)
+    if node.type == "expression_statement":
+        assign = next((c for c in node.children
+                       if c.type == "assignment_expression"), None)
+        if assign is not None:
+            value = assign.child_by_field_name("right")
+            if value is not None and value.type in _JS_FUNCTION_VALUE_TYPES:
+                target = _js_member_assignment_target(
+                    assign.child_by_field_name("left"), source)
+                if target is not None:
+                    kind, owner_name, member_name = target
+                    line = node.start_point[0] + 1
+                    handled = False
+                    if kind == "exports":
+                        nid = _make_id(stem, member_name)
+                        add_node_fn(nid, f"{member_name}()", line)
+                        add_edge_fn(file_nid, nid, "contains", line)
+                        handled = True
+                    elif kind == "prototype":
+                        owner_nid = _make_id(stem, owner_name)
+                        nid = _make_id(owner_nid, member_name)
+                        add_node_fn(nid, f".{member_name}()", line)
+                        add_edge_fn(owner_nid, nid, "method", line)
+                        handled = True
+                    if handled:
+                        body = value.child_by_field_name("body")
+                        if body:
+                            function_bodies.append((nid, body))
+                        return True
+
+    # Class fields whose value is a function:
+    #   class C { handler = () => {} }   → method handler() owned by C
+    # Reaches here with parent_class_nid set because class bodies are recursed
+    # with the class nid as parent.
+    if parent_class_nid and node.type in ("field_definition", "public_field_definition"):
+        prop = node.child_by_field_name("property") or node.child_by_field_name("name")
+        value = node.child_by_field_name("value")
+        if (prop is not None and value is not None
+                and value.type in _JS_FUNCTION_VALUE_TYPES):
+            field_name = _read_text(prop, source)
+            if field_name:
+                line = node.start_point[0] + 1
+                nid = _make_id(parent_class_nid, field_name)
+                add_node_fn(nid, f".{field_name}()", line)
+                add_edge_fn(parent_class_nid, nid, "method", line)
+                body = value.child_by_field_name("body")
+                if body:
+                    function_bodies.append((nid, body))
+                return True
+
     if node.type in ("lexical_declaration", "variable_declaration"):
         # CJS require imports — emit edges, do not block other lexical_declaration handling
         require_found = _require_imports_js(node, source, file_nid, stem, edges, str_path)
@@ -1755,7 +1862,8 @@ def _js_extra_walk(node, source: bytes, file_nid: str, stem: str, str_path: str,
             for child in node.children:
                 if child.type == "variable_declarator":
                     value = child.child_by_field_name("value")
-                    if value and value.type == "arrow_function":
+                    if value and value.type in _JS_FUNCTION_VALUE_TYPES:
+                        # `const f = () => {}` and `const f = function(){}`
                         name_node = child.child_by_field_name("name")
                         if name_node:
                             func_name = _read_text(name_node, source)
@@ -3103,6 +3211,39 @@ def _extract_generic(path: Path, config: LanguageConfig) -> dict:
                                      line, context=ctx)
 
             body = _find_body(node, config)
+            # JS/TS: capture `this.X = () => {}` / `this.X = function(){}`
+            # assigned directly in this function/constructor body. They live
+            # inside the body (otherwise only walked for calls), so without this
+            # they are never emitted — the dominant miss on constructor-style
+            # ("function Foo(){ this.bar = () => {} }") and many CommonJS repos.
+            # Owner is the enclosing class when present (a constructor's methods
+            # belong to the class), else the function itself.
+            if body is not None and config.ts_module in (
+                "tree_sitter_javascript", "tree_sitter_typescript"
+            ):
+                this_owner_nid = parent_class_nid if parent_class_nid else func_nid
+                for stmt in body.children:
+                    if stmt.type != "expression_statement":
+                        continue
+                    assign = next((c for c in stmt.children
+                                   if c.type == "assignment_expression"), None)
+                    if assign is None:
+                        continue
+                    val = assign.child_by_field_name("right")
+                    if val is None or val.type not in _JS_FUNCTION_VALUE_TYPES:
+                        continue
+                    tgt = _js_member_assignment_target(
+                        assign.child_by_field_name("left"), source)
+                    if tgt is None or tgt[0] != "this":
+                        continue
+                    m_name = tgt[2]
+                    m_line = stmt.start_point[0] + 1
+                    m_nid = _make_id(this_owner_nid, m_name)
+                    add_node(m_nid, f".{m_name}()", m_line)
+                    add_edge(this_owner_nid, m_nid, "method", m_line)
+                    m_body = val.child_by_field_name("body")
+                    if m_body:
+                        function_bodies.append((m_nid, m_body))
             if body:
                 function_bodies.append((func_nid, body))
             return

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -513,6 +513,112 @@ def test_extract_js_arrow_function_still_extracted():
         arrow_fixture.unlink()
 
 
+def test_extract_js_this_assigned_methods(tmp_path):
+    """`this.X = () => {}` / `this.X = function(){}` in a constructor-style
+    function body must be captured as methods owned by that function.
+
+    This is the dominant pattern in pre-class JS (DAOs, route handlers): the
+    methods live in the function body, which is otherwise only walked for
+    calls, so before this they were entirely invisible as symbols.
+    """
+    from graphify.extract import extract_js
+    f = tmp_path / "dao.js"
+    f.write_text(
+        "function UserDAO(db) {\n"
+        "  this.addUser = (name) => { return name; };\n"
+        "  this.getUser = function(id) { return id; };\n"
+        "}\n"
+    )
+    result = extract_js(f)
+    by_label = {n["label"]: n for n in result["nodes"]}
+    assert "UserDAO()" in by_label
+    assert ".addUser()" in by_label
+    assert ".getUser()" in by_label
+    # The methods are owned by UserDAO via a `method` edge.
+    owner = by_label["UserDAO()"]["id"]
+    method_edges = {
+        (e["source"], by_label_by_id(result, e["target"]))
+        for e in result["edges"]
+        if e["relation"] == "method"
+    }
+    assert (owner, ".addUser()") in method_edges
+    assert (owner, ".getUser()") in method_edges
+
+
+def test_extract_js_commonjs_exports_assignment(tmp_path):
+    """`exports.X = fn` and `module.exports.X = fn` must produce function nodes."""
+    from graphify.extract import extract_js
+    f = tmp_path / "mod.js"
+    f.write_text(
+        "exports.alpha = (x) => x;\n"
+        "module.exports.beta = function(y) { return y; };\n"
+    )
+    labels = [n["label"] for n in extract_js(f)["nodes"]]
+    assert "alpha()" in labels
+    assert "beta()" in labels
+
+
+def test_extract_js_prototype_method_assignment(tmp_path):
+    """`Foo.prototype.bar = fn` must be captured as a method owned by Foo."""
+    from graphify.extract import extract_js
+    f = tmp_path / "proto.js"
+    f.write_text(
+        "function Foo() {}\n"
+        "Foo.prototype.bar = function() { return 1; };\n"
+    )
+    by_label = {n["label"]: n for n in extract_js(f)["nodes"]}
+    assert "Foo()" in by_label
+    assert ".bar()" in by_label
+
+
+def test_extract_js_const_function_expression(tmp_path):
+    """`const f = function(){}` (function expression, not arrow) must be captured."""
+    from graphify.extract import extract_js
+    f = tmp_path / "fnexpr.js"
+    f.write_text("const handler = function(req, res) { return res; };\n")
+    labels = [n["label"] for n in extract_js(f)["nodes"]]
+    assert "handler()" in labels
+
+
+def test_extract_ts_class_arrow_field(tmp_path):
+    """A class field initialised with an arrow function (`x = () => {}`) must be
+    captured as a method of the class — common in React/TS component classes."""
+    from graphify.extract import extract_js
+    f = tmp_path / "comp.ts"
+    f.write_text(
+        "class Widget {\n"
+        "  onClick = (e) => { return e; };\n"
+        "  render() { return null; }\n"
+        "}\n"
+    )
+    by_label = {n["label"]: n for n in extract_js(f)["nodes"]}
+    assert "Widget" in by_label
+    assert ".onClick()" in by_label   # arrow field
+    assert ".render()" in by_label    # plain method (regression guard)
+
+
+def test_extract_js_arbitrary_member_assignment_not_captured(tmp_path):
+    """Guard against the phantom-god-node class (#1077): an arbitrary
+    `obj.x = fn` (obj is neither this/exports/module.exports/<X>.prototype)
+    must NOT produce a node."""
+    from graphify.extract import extract_js
+    f = tmp_path / "noise.js"
+    f.write_text(
+        "const obj = {};\n"
+        "obj.whatever = () => 1;\n"
+    )
+    labels = [n["label"] for n in extract_js(f)["nodes"]]
+    assert "whatever()" not in labels
+    assert ".whatever()" not in labels
+
+
+def by_label_by_id(result, node_id):
+    for n in result["nodes"]:
+        if n["id"] == node_id:
+            return n["label"]
+    return None
+
+
 def test_cross_file_call_promoted_to_extracted_with_import_evidence(tmp_path):
     """A cross-file `calls` edge must be EXTRACTED when the caller's file has
     an `imports` or `imports_from` edge linking it to the callee."""


### PR DESCRIPTION
Closes #1322.

## Problem

The JS/TS extractor captured top-level `function` declarations, top-level `const x = () => …` arrows, classes, and method shorthand — but silently dropped several common ways of defining a named function. On expression-style and CommonJS codebases the majority of callable symbols never became nodes (and could not be call-edge endpoints):

```js
function UserDAO(db){ this.addUser = () => {} }   // constructor-assigned method — missed
this.handler = function(){}                        // this.X function expression — missed
exports.foo = () => {}                             // CommonJS export — missed
module.exports.bar = fn                             // missed
Foo.prototype.baz = function(){}                   // prototype method — missed
class C { onClick = (e) => {} }                    // class arrow field — missed
const f = function(){}                             // function expression — missed
```

The constructor-function-with-`this.method = () => {}` pattern is pervasive in pre-class JS (DAOs, route handlers, services); such a file emitted only the outer `function` node and none of its methods.

## Fix

- `_js_member_assignment_target()` classifies an assignment LHS into `this` / `exports` / `module.exports` / `<Name>.prototype`. Anything else (an arbitrary `obj.x = fn`) returns `None` and is skipped — this preserves the module-level scope guard from #1077 (no phantom god-nodes from bare-named locals).
- `_js_extra_walk` now also handles module-level `exports.X` / `module.exports.X` / `Foo.prototype.X` assignments and class function-valued fields, and accepts `function_expression` alongside `arrow_function` in `lexical_declaration`.
- The function-emission branch scans the function/constructor body for `this.X = fn` direct assignments and emits them as methods owned by the enclosing class (if present) else the function. Recovered function bodies are appended to `function_bodies` so the call pass sees them.

Ownership / labels follow the existing conventions: file-contained functions get `name()` + a `contains` edge; methods get `.name()` + a `method` edge from their owner.

## Tests

6 new tests in `tests/test_extract.py` — one per recovered form plus a negative guard asserting arbitrary `obj.x = fn` is **not** captured. The existing arrow / TSX / require regression tests still pass.

Full suite: no regressions. (The 18 failures in `test_terraform` / `test_skillgen` / `test_install_references` reproduce on a clean checkout of this branch's base — missing tree-sitter grammar and unbuilt skill payload in the dev environment, unrelated to this change.)

## Repro before/after

```python
from graphify.extract import extract_js
from pathlib import Path
print(sorted(n["label"] for n in extract_js(Path("probe.js"))["nodes"]))
# before: ['.methodInClass()', 'Foo', 'Outer()', 'arrowTop()', 'declTop()', 'probe.js']
# after:  [+ '.arrowField()', '.thisFnExpr()', '.thisMethod()', 'exportedArrow()', 'fnExprTop()', 'modArrow()', ...]
```